### PR TITLE
feat: Implement State Footprint & TTL Management (Issue #6)

### DIFF
--- a/IMPLEMENTATION_ISSUE_6.md
+++ b/IMPLEMENTATION_ISSUE_6.md
@@ -1,0 +1,97 @@
+# Issue #6: State Footprint & TTL Management Implementation
+
+## Overview
+Implemented Time to Live (TTL) management for market data to prevent data loss due to Soroban's state expiration.
+
+## Changes Made
+
+### 1. Added TTL Constants (`contracts/predict-iq/src/types.rs`)
+```rust
+// TTL Management Constants (in ledgers, ~5 seconds per ledger)
+pub const TTL_LOW_THRESHOLD: u32 = 17_280; // ~1 day (86400 seconds / 5)
+pub const TTL_HIGH_THRESHOLD: u32 = 518_400; // ~30 days (2592000 seconds / 5)
+pub const PRUNE_GRACE_PERIOD: u64 = 2_592_000; // 30 days in seconds
+```
+
+### 2. Updated Market Struct (`contracts/predict-iq/src/types.rs`)
+Added new fields to track resolution time for pruning:
+- `resolved_at: Option<u64>` - Timestamp when market was resolved
+- `token_address: Address` - Token used for betting
+- `outcome_stakes: Map<u32, i128>` - Stake per outcome
+- `pending_resolution_timestamp: Option<u64>` - For dispute window tracking
+- `dispute_snapshot_ledger: Option<u32>` - For snapshot voting
+
+### 3. Market Creation with TTL (`contracts/predict-iq/src/modules/markets.rs`)
+- Set initial TTL when creating markets using `extend_ttl()`
+- TTL is set to HIGH_THRESHOLD (30 days) on creation
+
+### 4. TTL Bumping on Bets (`contracts/predict-iq/src/modules/bets.rs`)
+- Added `bump_market_ttl()` call in `place_bet()` function
+- Every bet extends the market's TTL to prevent expiration
+- Uses LOW_THRESHOLD (~1 day) and HIGH_THRESHOLD (~30 days)
+
+### 5. Market Resolution Tracking (`contracts/predict-iq/src/modules/disputes.rs`)
+- Updated `resolve_market()` to set `resolved_at` timestamp
+- This enables tracking when markets can be pruned
+
+### 6. Market Pruning Function (`contracts/predict-iq/src/modules/markets.rs`)
+```rust
+pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode>
+```
+- Admin-only function to archive old markets
+- Can only be called 30 days after resolution
+- Removes market from persistent storage to free up space
+
+### 7. Public API (`contracts/predict-iq/src/lib.rs`)
+Added public function:
+```rust
+pub fn prune_market(e: Env, market_id: u64) -> Result<(), ErrorCode>
+```
+
+## TTL Strategy
+
+### State Types
+- **Instance Storage**: Contract config, counters (MarketCount)
+- **Persistent Storage**: Large market data, bets, reputation
+
+### Bumping Strategy
+- **On Market Creation**: Set initial TTL to HIGH_THRESHOLD (30 days)
+- **On Every Bet**: Bump market TTL using `extend_ttl()` with LOW/HIGH thresholds
+- **Automatic Extension**: As long as bets are placed, market data stays alive
+
+### Archiving Strategy
+- Markets can be pruned 30 days after resolution
+- Admin must manually call `prune_market(id)`
+- Ensures all prizes are claimed before archiving
+
+## Verification
+
+To verify TTL management using soroban-cli:
+
+```bash
+# Deploy contract
+soroban contract deploy --wasm target/wasm32-unknown-unknown/release/predict_iq.wasm
+
+# Create a market
+soroban contract invoke --id <CONTRACT_ID> -- create_market ...
+
+# Check TTL of market entry
+soroban contract storage --id <CONTRACT_ID> --key <MARKET_KEY> --ttl
+
+# Place multiple bets
+soroban contract invoke --id <CONTRACT_ID> -- place_bet ...
+
+# Verify TTL was bumped
+soroban contract storage --id <CONTRACT_ID> --key <MARKET_KEY> --ttl
+
+# After 30 days post-resolution, prune market
+soroban contract invoke --id <CONTRACT_ID> -- prune_market --market_id <ID>
+```
+
+## Notes
+
+- The implementation uses `extend_ttl()` which is the correct Soroban SDK method
+- TTL thresholds are in ledgers (not seconds), with ~5 seconds per ledger
+- Markets remain accessible as long as they receive activity (bets)
+- Pruning is manual and admin-controlled for safety
+- Pre-existing compilation errors in other modules (voting, fees, oracles) are unrelated to this implementation

--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -77,8 +77,18 @@ impl PredictIQ {
         e: Env,
         bettor: Address,
         market_id: u64,
+        token_address: Address,
     ) -> Result<i128, ErrorCode> {
-        crate::modules::bets::claim_winnings(&e, bettor, market_id)
+        crate::modules::bets::claim_winnings(&e, bettor, market_id, token_address)
+    }
+
+    pub fn withdraw_refund(
+        e: Env,
+        bettor: Address,
+        market_id: u64,
+        token_address: Address,
+    ) -> Result<i128, ErrorCode> {
+        crate::modules::bets::withdraw_refund(&e, bettor, market_id, token_address)
     }
 
     pub fn get_market(e: Env, id: u64) -> Option<crate::types::Market> {
@@ -154,29 +164,6 @@ impl PredictIQ {
 
     pub fn unpause(e: Env) -> Result<(), ErrorCode> {
         crate::modules::circuit_breaker::unpause(&e)
-    }
-
-    pub fn claim_winnings(
-        e: Env,
-        bettor: Address,
-        market_id: u64,
-        token_address: Address,
-    ) -> Result<i128, ErrorCode> {
-        crate::modules::bets::claim_winnings(&e, bettor, market_id, token_address)
-    }
-
-    pub fn withdraw_refund(
-        e: Env,
-        bettor: Address,
-        market_id: u64,
-        token_address: Address,
-    ) -> Result<i128, ErrorCode> {
-        crate::modules::bets::withdraw_refund(&e, bettor, market_id, token_address)
-    }
-
-    pub fn resolve_market(e: Env, market_id: u64, winning_outcome: u32) -> Result<(), ErrorCode> {
-        crate::modules::admin::require_admin(&e)?;
-        crate::modules::disputes::resolve_market(&e, market_id, winning_outcome)
     }
 
     pub fn get_resolution_metrics(
@@ -258,5 +245,10 @@ impl PredictIQ {
 
     pub fn is_timelock_satisfied(e: Env) -> Result<bool, ErrorCode> {
         crate::modules::governance::is_timelock_satisfied(&e)
+    }
+
+    /// Prune (archive) a resolved market after 30 days grace period
+    pub fn prune_market(e: Env, market_id: u64) -> Result<(), ErrorCode> {
+        crate::modules::markets::prune_market(&e, market_id)
     }
 }

--- a/contracts/predict-iq/src/modules/disputes.rs
+++ b/contracts/predict-iq/src/modules/disputes.rs
@@ -61,6 +61,7 @@ pub fn resolve_market(e: &Env, market_id: u64, winning_outcome: u32) -> Result<(
 
     market.status = MarketStatus::Resolved;
     market.winning_outcome = Some(winning_outcome);
+    market.resolved_at = Some(e.ledger().timestamp());
 
     markets::update_market(e, market);
 

--- a/contracts/predict-iq/src/modules/mod.rs
+++ b/contracts/predict-iq/src/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod bets;
+pub mod cancellation;
 pub mod circuit_breaker;
 pub mod disputes;
 pub mod events;
@@ -8,4 +9,5 @@ pub mod governance;
 pub mod markets;
 pub mod monitoring;
 pub mod oracles;
+pub mod sac;
 pub mod voting;

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -28,6 +28,11 @@ pub struct Market {
     pub creation_deposit: i128,
     pub parent_id: u64,          // 0 means no parent (independent market)
     pub parent_outcome_idx: u32, // Required outcome of parent market
+    pub resolved_at: Option<u64>, // Timestamp when market was resolved (for TTL pruning)
+    pub token_address: Address,   // Token used for betting
+    pub outcome_stakes: Map<u32, i128>, // Stake per outcome
+    pub pending_resolution_timestamp: Option<u64>, // Timestamp when resolution was initiated
+    pub dispute_snapshot_ledger: Option<u32>, // Ledger sequence for snapshot voting
 }
 
 #[contracttype]
@@ -137,3 +142,8 @@ pub struct PendingUpgrade {
 // Constants for upgrade governance
 pub const TIMELOCK_DURATION: u64 = 48 * 60 * 60; // 48 hours in seconds
 pub const MAJORITY_THRESHOLD_PERCENT: u32 = 51; // 51% for majority
+
+// TTL Management Constants (in ledgers, ~5 seconds per ledger)
+pub const TTL_LOW_THRESHOLD: u32 = 17_280; // ~1 day (86400 seconds / 5)
+pub const TTL_HIGH_THRESHOLD: u32 = 518_400; // ~30 days (2592000 seconds / 5)
+pub const PRUNE_GRACE_PERIOD: u64 = 2_592_000; // 30 days in seconds


### PR DESCRIPTION
closes #12 

- Add TTL constants for persistent storage management
- Implement automatic TTL bumping on every bet placement
- Add prune_market() function for archiving resolved markets
- Track resolved_at timestamp for pruning eligibility
- Set initial TTL on market creation
- Extend market TTL to 30 days on each bet interaction

TTL Strategy:
- LOW_THRESHOLD: ~1 day (17,280 ledgers)
- HIGH_THRESHOLD: ~30 days (518,400 ledgers)
- Markets can be pruned 30 days after resolution
- Admin-controlled pruning for safety