### PR TITLE
feat: Implement Waitlist/Early Access API (Issue #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "futures",
  "handlebars",
  "prometheus",
+ "rand 0.8.5",
  "redis",
  "reqwest",
  "serde",

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 handlebars = "5.1"
 prometheus = "0.13"
+rand = "0.8"
 redis = { version = "0.25", features = ["tokio-comp", "connection-manager", "streams"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/services/api/database/migrations/009_enhance_waitlist_entries.sql
+++ b/services/api/database/migrations/009_enhance_waitlist_entries.sql
@@ -1,0 +1,32 @@
+-- Add additional fields to waitlist_entries table for enhanced functionality
+ALTER TABLE waitlist_entries
+ADD COLUMN IF NOT EXISTS name VARCHAR(255),
+ADD COLUMN IF NOT EXISTS role VARCHAR(50),
+ADD COLUMN IF NOT EXISTS referral_code VARCHAR(50) UNIQUE,
+ADD COLUMN IF NOT EXISTS referred_by_code VARCHAR(50),
+ADD COLUMN IF NOT EXISTS position INTEGER,
+ADD COLUMN IF NOT EXISTS invited_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS invitation_accepted_at TIMESTAMPTZ;
+
+-- Create index for referral tracking
+CREATE INDEX IF NOT EXISTS idx_waitlist_entries_referral_code
+ON waitlist_entries (referral_code);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_entries_referred_by
+ON waitlist_entries (referred_by_code);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_entries_position
+ON waitlist_entries (position);
+
+-- Create referral stats table
+CREATE TABLE IF NOT EXISTS waitlist_referrals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    referrer_code VARCHAR(50) NOT NULL,
+    referral_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(referrer_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_referrals_code
+ON waitlist_referrals (referrer_code);

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -736,3 +736,359 @@ pub async fn sendgrid_webhook(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     sendgrid_webhook_handler(State(Arc::new(state.webhook_handler.clone())), Json(events)).await
 }
+
+// Waitlist handlers
+
+pub async fn waitlist_join(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(payload): Json<crate::waitlist::WaitlistJoinRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ip = client_ip(&headers);
+    let allowed = state
+        .newsletter_rate_limiter
+        .allow(&ip, 5, Duration::from_secs(15 * 60))
+        .await;
+
+    if !allowed {
+        return Ok((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(crate::waitlist::WaitlistJoinResponse {
+                success: false,
+                position: 0,
+                referral_code: String::new(),
+                message: "Too many requests, please try again later.".to_string(),
+            }),
+        ));
+    }
+
+    let email = match normalized_email(&payload.email) {
+        Some(value) => value,
+        None => {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(crate::waitlist::WaitlistJoinResponse {
+                    success: false,
+                    position: 0,
+                    referral_code: String::new(),
+                    message: "Invalid email address.".to_string(),
+                }),
+            ));
+        }
+    };
+
+    if is_disposable_email(&email) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(crate::waitlist::WaitlistJoinResponse {
+                success: false,
+                position: 0,
+                referral_code: String::new(),
+                message: "Disposable emails are not allowed.".to_string(),
+            }),
+        ));
+    }
+
+    // Check if already on waitlist
+    if let Some(existing) = state
+        .db
+        .waitlist_get_by_email(&email)
+        .await
+        .map_err(into_api_error)?
+    {
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(crate::waitlist::WaitlistJoinResponse {
+                success: false,
+                position: existing.position,
+                referral_code: existing.referral_code,
+                message: "Email already on waitlist.".to_string(),
+            }),
+        ));
+    }
+
+    // Validate role if provided
+    let role = payload.user_role.as_deref().and_then(|r| {
+        let normalized = r.trim().to_lowercase();
+        match normalized.as_str() {
+            "trader" | "developer" | "institution" => Some(normalized),
+            _ => None,
+        }
+    });
+
+    // Validate referral code if provided
+    let referred_by = if let Some(ref_code) = payload.referral_code.as_deref() {
+        let code = ref_code.trim().to_uppercase();
+        if !code.is_empty() {
+            // Check if referral code exists
+            let count = state
+                .db
+                .waitlist_get_referral_count(&code)
+                .await
+                .map_err(into_api_error)?;
+            if count >= 0 {
+                Some(code)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Generate unique referral code
+    let mut referral_code = crate::waitlist::generate_referral_code();
+    let mut attempts = 0;
+    while attempts < 10 {
+        if state
+            .db
+            .waitlist_get_referral_count(&referral_code)
+            .await
+            .map_err(into_api_error)?
+            == 0
+        {
+            break;
+        }
+        referral_code = crate::waitlist::generate_referral_code();
+        attempts += 1;
+    }
+
+    let name = payload.name.as_deref().map(|n| {
+        n.trim()
+            .chars()
+            .take(255)
+            .collect::<String>()
+    });
+
+    let entry = state
+        .db
+        .waitlist_create_entry(
+            &email,
+            name.as_deref(),
+            role.as_deref(),
+            Some("direct"),
+            &referral_code,
+            referred_by.as_deref(),
+        )
+        .await
+        .map_err(into_api_error)?;
+
+    // Queue confirmation email
+    let template_data = serde_json::json!({
+        "email": email,
+        "position": entry.position,
+        "referral_code": entry.referral_code,
+        "referral_url": format!("{}/waitlist?ref={}", state.config.base_url.trim_end_matches('/'), entry.referral_code)
+    });
+
+    state
+        .email_queue
+        .enqueue(
+            crate::email::types::EmailJobType::WaitlistConfirmation,
+            &email,
+            "waitlist_confirmation",
+            template_data,
+            0,
+        )
+        .await
+        .map_err(into_api_error)?;
+
+    tracing::info!(
+        "[waitlist] new entry email={} position={} referral_code={} ip={}",
+        email,
+        entry.position,
+        entry.referral_code,
+        ip
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(crate::waitlist::WaitlistJoinResponse {
+            success: true,
+            position: entry.position,
+            referral_code: entry.referral_code,
+            message: "Successfully joined the waitlist!".to_string(),
+        }),
+    ))
+}
+
+pub async fn waitlist_stats(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let stats = state
+        .db
+        .waitlist_get_stats()
+        .await
+        .map_err(into_api_error)?;
+
+    Ok((StatusCode::OK, Json(stats)))
+}
+
+pub async fn waitlist_export(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let entries = state
+        .db
+        .waitlist_get_all_for_export()
+        .await
+        .map_err(into_api_error)?;
+
+    // Convert to CSV
+    let mut csv = String::from("email,name,role,status,position,referral_code,referral_count,joined_at,invited_at,invitation_accepted_at\n");
+    
+    for entry in entries {
+        csv.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{}\n",
+            entry.email,
+            entry.name.unwrap_or_default(),
+            entry.role.unwrap_or_default(),
+            entry.status,
+            entry.position,
+            entry.referral_code,
+            entry.referral_count,
+            entry.joined_at.to_rfc3339(),
+            entry.invited_at.map(|d| d.to_rfc3339()).unwrap_or_default(),
+            entry.invitation_accepted_at.map(|d| d.to_rfc3339()).unwrap_or_default()
+        ));
+    }
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/csv")],
+        csv,
+    ))
+}
+
+pub async fn waitlist_batch_invite(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<crate::waitlist::BatchInviteRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let invited_entries = if let Some(positions) = payload.positions {
+        if positions.is_empty() {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(crate::waitlist::BatchInviteResponse {
+                    success: false,
+                    invited_count: 0,
+                    message: "No positions provided.".to_string(),
+                }),
+            ));
+        }
+
+        let count = state
+            .db
+            .waitlist_invite_by_positions(positions)
+            .await
+            .map_err(into_api_error)?;
+
+        Vec::new() // We don't need the entries for position-based invites
+    } else if let Some(count) = payload.count {
+        if count <= 0 || count > 1000 {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(crate::waitlist::BatchInviteResponse {
+                    success: false,
+                    invited_count: 0,
+                    message: "Count must be between 1 and 1000.".to_string(),
+                }),
+            ));
+        }
+
+        state
+            .db
+            .waitlist_invite_top_n(count)
+            .await
+            .map_err(into_api_error)?
+    } else {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(crate::waitlist::BatchInviteResponse {
+                success: false,
+                invited_count: 0,
+                message: "Either 'count' or 'positions' must be provided.".to_string(),
+            }),
+        ));
+    };
+
+    let invited_count = invited_entries.len() as i32;
+
+    // Queue invitation emails for each invited user
+    for entry in invited_entries {
+        let template_data = serde_json::json!({
+            "email": entry.email,
+            "name": entry.name.unwrap_or_else(|| "there".to_string()),
+            "dashboard_url": format!("{}/dashboard", state.config.base_url.trim_end_matches('/')),
+            "help_url": format!("{}/help", state.config.base_url.trim_end_matches('/')),
+        });
+
+        let _ = state
+            .email_queue
+            .enqueue(
+                crate::email::types::EmailJobType::WelcomeEmail,
+                &entry.email,
+                "welcome_email",
+                template_data,
+                1, // Higher priority for invitations
+            )
+            .await;
+    }
+
+    tracing::info!("[waitlist] batch invite sent to {} users", invited_count);
+
+    Ok((
+        StatusCode::OK,
+        Json(crate::waitlist::BatchInviteResponse {
+            success: true,
+            invited_count,
+            message: format!("Successfully invited {} users.", invited_count),
+        }),
+    ))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WaitlistAcceptanceRequest {
+    pub email: String,
+}
+
+pub async fn waitlist_track_acceptance(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<WaitlistAcceptanceRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let Some(email) = normalized_email(&payload.email) else {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(NewsletterResponse {
+                success: false,
+                message: "Invalid email address.".to_string(),
+            }),
+        ));
+    };
+
+    let updated = state
+        .db
+        .waitlist_mark_invitation_accepted(&email)
+        .await
+        .map_err(into_api_error)?;
+
+    if !updated {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            Json(NewsletterResponse {
+                success: false,
+                message: "No pending invitation found.".to_string(),
+            }),
+        ));
+    }
+
+    tracing::info!("[waitlist] invitation accepted email={}", email);
+
+    Ok((
+        StatusCode::OK,
+        Json(NewsletterResponse {
+            success: true,
+            message: "Invitation acceptance tracked.".to_string(),
+        }),
+    ))
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -6,6 +6,7 @@ mod email;
 mod handlers;
 mod metrics;
 mod newsletter;
+mod waitlist;
 
 use std::sync::Arc;
 
@@ -155,6 +156,27 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/webhooks/sendgrid",
             post(handlers::sendgrid_webhook),
+        )
+        // Waitlist endpoints
+        .route(
+            "/api/v1/waitlist/join",
+            post(handlers::waitlist_join),
+        )
+        .route(
+            "/api/v1/waitlist/stats",
+            get(handlers::waitlist_stats),
+        )
+        .route(
+            "/api/v1/waitlist/export",
+            get(handlers::waitlist_export),
+        )
+        .route(
+            "/api/v1/waitlist/invite",
+            post(handlers::waitlist_batch_invite),
+        )
+        .route(
+            "/api/v1/waitlist/acceptance",
+            post(handlers::waitlist_track_acceptance),
         )
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/services/api/src/waitlist.rs
+++ b/services/api/src/waitlist.rs
@@ -1,0 +1,91 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitlistEntry {
+    pub id: Uuid,
+    pub email: String,
+    pub name: Option<String>,
+    pub role: Option<String>,
+    pub status: String,
+    pub source: Option<String>,
+    pub referral_code: String,
+    pub referred_by_code: Option<String>,
+    pub position: i32,
+    pub priority_score: i32,
+    pub joined_at: DateTime<Utc>,
+    pub invited_at: Option<DateTime<Utc>>,
+    pub invitation_accepted_at: Option<DateTime<Utc>>,
+    pub converted_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitlistJoinRequest {
+    pub email: String,
+    pub name: Option<String>,
+    #[serde(rename = "role")]
+    pub user_role: Option<String>,
+    #[serde(rename = "referralCode")]
+    pub referral_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitlistJoinResponse {
+    pub success: bool,
+    pub position: i32,
+    #[serde(rename = "referralCode")]
+    pub referral_code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitlistExportEntry {
+    pub email: String,
+    pub name: Option<String>,
+    pub role: Option<String>,
+    pub status: String,
+    pub position: i32,
+    pub referral_code: String,
+    pub referral_count: i32,
+    pub joined_at: DateTime<Utc>,
+    pub invited_at: Option<DateTime<Utc>>,
+    pub invitation_accepted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitlistStats {
+    pub total_entries: i64,
+    pub pending_entries: i64,
+    pub invited_entries: i64,
+    pub accepted_entries: i64,
+    pub total_referrals: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchInviteRequest {
+    pub count: Option<i32>,
+    pub positions: Option<Vec<i32>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchInviteResponse {
+    pub success: bool,
+    pub invited_count: i32,
+    pub message: String,
+}
+
+pub fn generate_referral_code() -> String {
+    use rand::Rng;
+    const CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    let mut rng = rand::thread_rng();
+    
+    (0..8)
+        .map(|_| {
+            let idx = rng.gen_range(0..CHARSET.len());
+            CHARSET[idx] as char
+        })
+        .collect()
+}


### PR DESCRIPTION

closes #51 
- Add POST /api/v1/waitlist/join endpoint for user signups
- Add GET /api/v1/waitlist/stats for waitlist statistics
- Add GET /api/v1/waitlist/export for CSV export
- Add POST /api/v1/waitlist/invite for batch invitations
- Add POST /api/v1/waitlist/acceptance for tracking
- Implement referral code generation and tracking
- Add email validation and disposable email blocking
- Implement rate limiting (5 req/15min per IP)
- Create database schema with waitlist_entries and waitlist_referrals tables
- Add waitlist_confirmation email template
- Integrate with email queue for async processing
- Add comprehensive error handling and validation

Closes #8