### PR TITLE
fix: invoke host update_current_contract_wasm in execute_upgrade

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), no_std)]
-use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
 
 mod errors;
 mod modules;
@@ -237,7 +237,7 @@ impl PredictIQ {
         crate::modules::governance::get_guardians(&e)
     }
 
-    pub fn initiate_upgrade(e: Env, wasm_hash: String) -> Result<(), ErrorCode> {
+    pub fn initiate_upgrade(e: Env, wasm_hash: BytesN<32>) -> Result<(), ErrorCode> {
         crate::modules::governance::initiate_upgrade(&e, wasm_hash)
     }
 
@@ -245,7 +245,7 @@ impl PredictIQ {
         crate::modules::governance::vote_for_upgrade(&e, voter, vote_for)
     }
 
-    pub fn execute_upgrade(e: Env) -> Result<String, ErrorCode> {
+    pub fn execute_upgrade(e: Env) -> Result<(), ErrorCode> {
         crate::modules::governance::execute_upgrade(&e)
     }
 

--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -3,7 +3,7 @@ use crate::types::{
     ConfigKey, Guardian, PendingUpgrade, MAJORITY_THRESHOLD_PERCENT, TIMELOCK_DURATION,
     GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD,
 };
-use soroban_sdk::{Address, Env, String, Vec};
+use soroban_sdk::{Address, BytesN, Env, Vec};
 
 /// Extend TTL for a governance key so it never expires during long inactivity.
 /// Called after every write to a governance storage slot.
@@ -89,13 +89,8 @@ pub fn remove_guardian(e: &Env, address: Address) -> Result<(), ErrorCode> {
 
 /// Initiate a contract upgrade. Requires admin authorization.
 /// Starts a 48-hour timelock and requires majority vote to execute.
-pub fn initiate_upgrade(e: &Env, wasm_hash: String) -> Result<(), ErrorCode> {
+pub fn initiate_upgrade(e: &Env, wasm_hash: BytesN<32>) -> Result<(), ErrorCode> {
     crate::modules::admin::require_admin(e)?;
-
-    // Validate WASM hash is not empty
-    if wasm_hash.is_empty() {
-        return Err(ErrorCode::InvalidWasmHash);
-    }
 
     // Check if an upgrade is already pending
     if e.storage().persistent().has(&ConfigKey::PendingUpgrade) {
@@ -217,10 +212,8 @@ fn is_majority_met(e: &Env, pending_upgrade: &PendingUpgrade) -> bool {
 }
 
 /// Execute the upgrade if timelock is satisfied and majority voted in favor.
-/// This does NOT directly call update_current_contract_wasm (that's a host function).
-/// Instead, it validates conditions and clears the pending upgrade.
-/// The caller is responsible for invoking the host function.
-pub fn execute_upgrade(e: &Env) -> Result<String, ErrorCode> {
+/// This directly invokes the Soroban host upgrade function.
+pub fn execute_upgrade(e: &Env) -> Result<(), ErrorCode> {
     // Verify timelock has passed
     if !is_timelock_satisfied(e)? {
         return Err(ErrorCode::TimelockActive);
@@ -238,7 +231,10 @@ pub fn execute_upgrade(e: &Env) -> Result<String, ErrorCode> {
     // Clear pending upgrade
     e.storage().persistent().remove(&ConfigKey::PendingUpgrade);
 
-    Ok(wasm_hash)
+    // Execute host-level contract code upgrade.
+    e.deployer().update_current_contract_wasm(wasm_hash);
+
+    Ok(())
 }
 
 /// Get vote statistics for the pending upgrade.

--- a/contracts/predict-iq/src/test.rs
+++ b/contracts/predict-iq/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
-use soroban_sdk::{token, Address, Env, String, Vec};
+use soroban_sdk::{token, Address, BytesN, Env, String, Vec};
 
 fn setup_test_env() -> (Env, Address, soroban_sdk::Address, PredictIQClient<'static>) {
     let e = Env::default();
@@ -14,6 +14,10 @@ fn setup_test_env() -> (Env, Address, soroban_sdk::Address, PredictIQClient<'sta
     client.initialize(&admin, &100); // 1% fee
 
     (e, admin, contract_id, client)
+}
+
+fn upgrade_wasm_hash(e: &Env) -> BytesN<32> {
+    BytesN::from_array(e, &[7; 32])
 }
 
 fn create_test_market(
@@ -467,7 +471,7 @@ fn test_initiate_upgrade_starts_timelock() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
 
     // Set initial ledger time
     e.ledger().set_timestamp(1000);
@@ -494,7 +498,7 @@ fn test_execute_upgrade_before_timelock_fails() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -520,7 +524,7 @@ fn test_execute_upgrade_after_timelock_succeeds() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -535,7 +539,6 @@ fn test_execute_upgrade_after_timelock_succeeds() {
     let result = client.try_execute_upgrade();
     assert!(result.is_ok());
 
-    let _returned_hash = result.unwrap();
     // Verify pending upgrade is cleared after execution
     let pending = client.get_pending_upgrade();
     assert!(pending.is_none());
@@ -565,7 +568,7 @@ fn test_insufficient_votes_to_execute() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -605,7 +608,7 @@ fn test_majority_vote_required() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -635,7 +638,7 @@ fn test_cannot_vote_twice() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -663,7 +666,7 @@ fn test_only_guardians_can_vote() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -692,7 +695,7 @@ fn test_get_upgrade_votes() {
 
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -736,7 +739,7 @@ fn test_persistent_state_preserved_on_upgrade() {
     assert_eq!(stored_fee, 100);
 
     // Initiate upgrade
-    let wasm_hash = String::from_str(&e, "abcd1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().set_timestamp(1000);
     client.initiate_upgrade(&wasm_hash);
 
@@ -1300,7 +1303,7 @@ fn test_pending_upgrade_survives_3_months_inactivity() {
     });
     client.initialize_guardians(&guardians);
 
-    let wasm_hash = String::from_str(&e, "deadbeef1234");
+    let wasm_hash = upgrade_wasm_hash(&e);
     e.ledger().with_mut(|li| li.timestamp = 1000);
 
     client.initiate_upgrade(&wasm_hash);
@@ -1354,7 +1357,8 @@ fn test_vote_on_upgrade_refreshes_ttl() {
     client.initialize_guardians(&guardians);
 
     e.ledger().with_mut(|li| li.timestamp = 1000);
-    client.initiate_upgrade(&String::from_str(&e, "cafebabe"));
+    let wasm_hash = upgrade_wasm_hash(&e);
+    client.initiate_upgrade(&wasm_hash);
 
     // Vote refreshes the TTL on PendingUpgrade
     client.vote_for_upgrade(&guardian, &true);

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Map, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Map, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -142,7 +142,7 @@ pub struct Guardian {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingUpgrade {
-    pub wasm_hash: String,
+    pub wasm_hash: BytesN<32>,
     pub initiated_at: u64,
     pub votes_for: Vec<Address>,
     pub votes_against: Vec<Address>,


### PR DESCRIPTION
## Summary

Closes #126 

The `execute_upgrade` function previously validated all governance conditions (timelock + majority) and cleared the pending upgrade state but then only returned the WASM hash without ever calling the Soroban host upgrade function. The contract code was therefore never replaced.

---

## Changes

### `contracts/predict-iq/src/modules/governance.rs`
- `execute_upgrade` now calls `e.deployer().update_current_contract_wasm(wasm_hash)` after clearing the pending upgrade, making the host actually replace the contract bytecode.
- Return type changed from `Result<String, ErrorCode>` to `Result<(), ErrorCode>` — execution is a side-effect, not a data return.

### `contracts/predict-iq/src/types.rs`
- `PendingUpgrade.wasm_hash` changed from `String` to `BytesN<32>` — the Soroban host `update_current_contract_wasm` requires the exact 32-byte hash type; a plain string is incompatible.

### `contracts/predict-iq/src/lib.rs`
- `initiate_upgrade` parameter updated to `BytesN<32>`.
- `execute_upgrade` return type updated to `Result<(), ErrorCode>`.

### `contracts/predict-iq/src/test.rs`
- Added `upgrade_wasm_hash(&Env) -> BytesN<32>` helper to produce deterministic test hashes.
- All governance tests migrated from placeholder `String` hashes to `BytesN<32>`.
- Removed stale returned-hash assertion from `test_execute_upgrade_after_timelock_succeeds`.

---

## Behaviour preserved
- **Timelock gate** — execution is rejected with `TimelockActive` if 48 hours have not elapsed since initiation.
- **Majority gate** — execution is rejected with `InsufficientVotes` if guardian voting power for < 51 %.
- `PendingUpgrade` is cleared from storage **before** the host call so a failed upgrade cannot be retried with stale state.