### PR TITLE
Fix market deadlock in parent-child market flow

### DIFF
--- a/contracts/predict-iq/src/errors.rs
+++ b/contracts/predict-iq/src/errors.rs
@@ -55,4 +55,5 @@ pub enum ErrorCode {
     ConfidenceTooLow = 147,
     GovernanceTokenNotSet = 148,
     InsufficientVotingWeight = 149,
+    ResolutionDeadlinePassed = 150,
 }

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -48,17 +48,27 @@ pub fn create_market(
             return Err(ErrorCode::InvalidOutcome);
         }
 
-        // Parent must be resolved
-        if parent_market.status != MarketStatus::Resolved {
-            return Err(ErrorCode::ParentMarketNotResolved);
-        }
-
-        // Parent must have resolved to the required outcome
-        let parent_winning_outcome = parent_market
-            .winning_outcome
-            .ok_or(ErrorCode::ParentMarketNotResolved)?;
-        if parent_winning_outcome != parent_outcome_idx {
-            return Err(ErrorCode::ParentMarketInvalidOutcome);
+        // Allow advance creation while the parent is still Active (e.g. tournament
+        // brackets).  If the parent has already resolved, gate on the outcome so we
+        // never create child markets for outcomes that can never be reached.
+        // Any other parent status (PendingResolution, Disputed, Cancelled) is rejected.
+        match parent_market.status {
+            MarketStatus::Active => {
+                // Parent not yet resolved — child created in advance.
+                // Betting on this child is gated at place_bet time.
+            }
+            MarketStatus::Resolved => {
+                let parent_winning_outcome = parent_market
+                    .winning_outcome
+                    .ok_or(ErrorCode::ParentMarketNotResolved)?;
+                if parent_winning_outcome != parent_outcome_idx {
+                    return Err(ErrorCode::ParentMarketInvalidOutcome);
+                }
+            }
+            _ => {
+                // PendingResolution, Disputed, Cancelled — cannot act as a parent.
+                return Err(ErrorCode::ParentMarketNotResolved);
+            }
         }
     }
 


### PR DESCRIPTION
closes #130
## Summary
- allow child market creation while parent market is Active for advance bracket setup
- keep strict validation when parent is Resolved by requiring matching winning outcome
- reject invalid parent statuses (PendingResolution, Disputed, Cancelled)
- add new error code: ResolutionDeadlinePassed = 150

## Files Changed
- contracts/predict-iq/src/modules/markets.rs
- contracts/predict-iq/src/errors.rs

## Why
This resolves a parent-child market deadlock where dependent markets could not be created early enough for valid workflows like tournament-style branching, while preserving safety checks for resolved parents.