### PR TITLE
Fix/issue 129 self referral

### DIFF
--- a/contracts/predict-iq/src/modules/admin.rs
+++ b/contracts/predict-iq/src/modules/admin.rs
@@ -1,5 +1,5 @@
 use crate::errors::ErrorCode;
-use crate::types::{ConfigKey, GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD};
+use crate::types::{ConfigKey, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD};
 use soroban_sdk::{Address, Env};
 
 fn bump_gov_ttl(e: &Env, key: &ConfigKey) {

--- a/contracts/predict-iq/src/modules/bets.rs
+++ b/contracts/predict-iq/src/modules/bets.rs
@@ -146,9 +146,7 @@ pub fn claim_winnings(
         return Err(ErrorCode::MarketNotResolved);
     }
 
-    let winning_outcome = market
-        .winning_outcome
-        .ok_or(ErrorCode::MarketNotResolved)?;
+    let winning_outcome = market.winning_outcome.ok_or(ErrorCode::MarketNotResolved)?;
 
     let bet_key = DataKey::Bet(market_id, bettor.clone());
     let claimed_key = DataKey::Claimed(market_id, bettor.clone());
@@ -187,7 +185,14 @@ pub fn claim_winnings(
 
     // Emit standardized RewardsClaimed event
     // Topics: [RewardsClaimed, market_id, bettor]
-    crate::modules::events::emit_rewards_claimed(e, market_id, bettor, winnings, token_address, false);
+    crate::modules::events::emit_rewards_claimed(
+        e,
+        market_id,
+        bettor,
+        winnings,
+        token_address,
+        false,
+    );
 
     Ok(winnings)
 }
@@ -228,12 +233,21 @@ pub fn withdraw_refund(
     // Update market accounting to maintain accuracy
     market.total_staked = market.total_staked.saturating_sub(refund_amount);
     let outcome_stake = market.outcome_stakes.get(bet_outcome).unwrap_or(0);
-    market.outcome_stakes.set(bet_outcome, outcome_stake.saturating_sub(refund_amount));
+    market
+        .outcome_stakes
+        .set(bet_outcome, outcome_stake.saturating_sub(refund_amount));
     markets::update_market(e, market);
 
     // Emit standardized RewardsClaimed event (refund variant)
     // Topics: [RewardsClaimed, market_id, bettor]
-    crate::modules::events::emit_rewards_claimed(e, market_id, bettor, refund_amount, token_address, true);
+    crate::modules::events::emit_rewards_claimed(
+        e,
+        market_id,
+        bettor,
+        refund_amount,
+        token_address,
+        true,
+    );
 
     Ok(refund_amount)
 }

--- a/contracts/predict-iq/src/modules/bets_test.rs
+++ b/contracts/predict-iq/src/modules/bets_test.rs
@@ -36,10 +36,7 @@ fn create_simple_market(
 ) -> u64 {
     let options = Vec::from_array(
         env,
-        [
-            String::from_str(env, "Yes"),
-            String::from_str(env, "No"),
-        ],
+        [String::from_str(env, "Yes"), String::from_str(env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -367,7 +364,14 @@ fn test_referral_rewards_tracked() {
     let market_id = create_simple_market(&client, &env, &user, &token);
 
     // Place bet with referrer
-    client.place_bet(&user, &market_id, &0, &1000, &token, &Some(referrer.clone()));
+    client.place_bet(
+        &user,
+        &market_id,
+        &0,
+        &1000,
+        &token,
+        &Some(referrer.clone()),
+    );
 
     // Referrer should have pending rewards
     let rewards = client.try_claim_referral_rewards(&referrer, &token);
@@ -402,8 +406,8 @@ fn test_withdraw_refund_clears_bet_record() {
 
     // Cancel the market
     client.resolve_market(&market_id, &0); // resolve first so we can test via admin cancel path
-    // Use admin cancel instead
-    // Re-create a fresh market for the cancel path
+                                           // Use admin cancel instead
+                                           // Re-create a fresh market for the cancel path
     let market_id2 = create_simple_market(&client, &env, &user, &token);
     client.place_bet(&user, &market_id2, &0, &2000, &token, &None);
     client.cancel_market_admin(&market_id2);

--- a/contracts/predict-iq/src/modules/cancellation.rs
+++ b/contracts/predict-iq/src/modules/cancellation.rs
@@ -1,96 +1,112 @@
-use soroban_sdk::{Env, Address, Symbol};
-use crate::types::MarketStatus;
-use crate::modules::{markets, admin, sac};
 use crate::errors::ErrorCode;
+use crate::modules::{admin, events, markets, sac};
+use crate::types::MarketStatus;
+use soroban_sdk::{Address, Env};
 
 const FAILED_MARKET_THRESHOLD_BPS: i128 = 7500; // 75% vote required to cancel
 
 /// Admin override to cancel a market
 pub fn cancel_market_admin(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     admin::require_admin(e)?;
-    
+
     let mut market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
-    
+
     if market.status == MarketStatus::Resolved || market.status == MarketStatus::Cancelled {
         return Err(ErrorCode::CannotChangeOutcome);
     }
-    
+
     market.status = MarketStatus::Cancelled;
     markets::update_market(e, market);
-    
-    e.events().publish(
-        (Symbol::new(e, "market_cancelled"), market_id),
-        (),
-    );
-    
+
+    let admin_addr = e.current_contract_address();
+    events::emit_market_cancelled(e, market_id, admin_addr);
+
     Ok(())
 }
 
 /// Community vote to cancel a market (requires 75% threshold)
 pub fn cancel_market_vote(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     let mut market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
-    
+
     if market.status != MarketStatus::Disputed {
         return Err(ErrorCode::MarketNotDisputed);
     }
-    
+
     // Calculate if cancellation threshold is met
     let cancel_votes = crate::modules::voting::get_tally(e, market_id, u32::MAX);
     let mut total_votes = cancel_votes;
-    
+
     for outcome in 0..market.options.len() {
         total_votes += crate::modules::voting::get_tally(e, market_id, outcome);
     }
-    
+
     if total_votes == 0 {
         return Err(ErrorCode::InsufficientVotingWeight);
     }
-    
+
     let cancel_pct = (cancel_votes * 10000) / total_votes;
     if cancel_pct < FAILED_MARKET_THRESHOLD_BPS {
         return Err(ErrorCode::InsufficientVotingWeight);
     }
-    
+
     market.status = MarketStatus::Cancelled;
     markets::update_market(e, market);
-    
-    e.events().publish(
-        (Symbol::new(e, "market_cancelled_vote"), market_id),
-        (),
-    );
-    
+
+    let resolver = e.current_contract_address();
+    events::emit_market_cancelled_vote(e, market_id, resolver);
+
     Ok(())
 }
 
 /// Withdraw refund for cancelled market (100% principal, zero fees).
 /// `outcome` identifies which outcome position to refund. Bettors who placed
 /// on multiple outcomes must call this once per outcome to reclaim all funds.
-pub fn withdraw_refund(e: &Env, bettor: Address, market_id: u64, outcome: u32) -> Result<i128, ErrorCode> {
+pub fn withdraw_refund(
+    e: &Env,
+    bettor: Address,
+    market_id: u64,
+    outcome: u32,
+) -> Result<i128, ErrorCode> {
     bettor.require_auth();
-    
+
     let market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
-    
+
     if market.status != MarketStatus::Cancelled {
         return Err(ErrorCode::MarketNotActive);
     }
-    
+
     let bet_key = crate::modules::bets::DataKey::Bet(market_id, bettor.clone(), outcome);
-    let bet: crate::types::Bet = e.storage().persistent()
+    let bet: crate::types::Bet = e
+        .storage()
+        .persistent()
         .get(&bet_key)
         .ok_or(ErrorCode::BetNotFound)?;
-    
+
     let refund_amount = bet.amount;
-    
+
     e.storage().persistent().remove(&bet_key);
 
     // Use SAC-safe transfer for refund
     e.current_contract_address().require_auth();
-    sac::safe_transfer(e, &market.token_address, &e.current_contract_address(), &bettor, &refund_amount)?;
-    
+    sac::safe_transfer(
+        e,
+        &market.token_address,
+        &e.current_contract_address(),
+        &bettor,
+        &refund_amount,
+    )?;
+
     // Emit standardized RewardsClaimed event (refund variant), aligned with bets.rs standard
     // Topics: [reward_fx, market_id, bettor]
     // Data: (refund_amount, token_address, is_refund=true)
-    crate::modules::events::emit_rewards_claimed(e, market_id, bettor, refund_amount, market.token_address, true);
-    
+    crate::modules::events::emit_rewards_claimed(
+        e,
+        market_id,
+        bettor,
+        refund_amount,
+        market.token_address,
+        true,
+    );
+
     Ok(refund_amount)
 }

--- a/contracts/predict-iq/src/modules/circuit_breaker.rs
+++ b/contracts/predict-iq/src/modules/circuit_breaker.rs
@@ -1,12 +1,14 @@
 use crate::errors::ErrorCode;
 use crate::modules::admin;
-use crate::types::{CircuitBreakerState, ConfigKey, GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD};
+use crate::types::{CircuitBreakerState, ConfigKey, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD};
 use soroban_sdk::Env;
 
 fn bump_gov_ttl(e: &Env) {
-    e.storage()
-        .persistent()
-        .extend_ttl(&ConfigKey::CircuitBreakerState, GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD);
+    e.storage().persistent().extend_ttl(
+        &ConfigKey::CircuitBreakerState,
+        GOV_TTL_LOW_THRESHOLD,
+        GOV_TTL_HIGH_THRESHOLD,
+    );
 }
 
 pub fn set_state(e: &Env, state: CircuitBreakerState) -> Result<(), ErrorCode> {

--- a/contracts/predict-iq/src/modules/circuit_breaker_test.rs
+++ b/contracts/predict-iq/src/modules/circuit_breaker_test.rs
@@ -58,10 +58,7 @@ fn test_pause_blocks_operations() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -103,10 +100,7 @@ fn test_unpause_allows_operations() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -171,10 +165,7 @@ fn test_require_closed_when_open() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {

--- a/contracts/predict-iq/src/modules/events.rs
+++ b/contracts/predict-iq/src/modules/events.rs
@@ -111,3 +111,83 @@ pub fn emit_oracle_result_set(e: &Env, market_id: u64, oracle_address: Address, 
         outcome,
     );
 }
+
+/// Emit OracleResolved event (when oracle resolution succeeds)
+/// Topics: [oracle_res, market_id, oracle_address]
+/// Data: (outcome)
+pub fn emit_oracle_resolved(e: &Env, market_id: u64, oracle_address: Address, outcome: u32) {
+    e.events().publish(
+        (symbol_short!("oracle_res"), market_id, oracle_address),
+        outcome,
+    );
+}
+
+/// Emit MarketFinalized event (resolution finalized without dispute)
+/// Topics: [mkt_final, market_id, resolver]
+/// Data: (winning_outcome)
+pub fn emit_market_finalized(e: &Env, market_id: u64, resolver: Address, winning_outcome: u32) {
+    e.events().publish(
+        (symbol_short!("mkt_final"), market_id, resolver),
+        winning_outcome,
+    );
+}
+
+/// Emit DisputeResolved event (voting concluded)
+/// Topics: [disp_resol, market_id, resolver]
+/// Data: (winning_outcome)
+pub fn emit_dispute_resolved(e: &Env, market_id: u64, resolver: Address, winning_outcome: u32) {
+    e.events().publish(
+        (symbol_short!("disp_resol"), market_id, resolver),
+        winning_outcome,
+    );
+}
+
+/// Emit MarketCancelled event (admin cancellation)
+/// Topics: [mkt_cancel, market_id, admin]
+/// Data: ()
+pub fn emit_market_cancelled(e: &Env, market_id: u64, admin: Address) {
+    e.events()
+        .publish((symbol_short!("mkt_cancel"), market_id, admin), ());
+}
+
+/// Emit MarketCancelledVote event (community vote cancellation)
+/// Topics: [mkt_cncl_v, market_id, resolver]
+/// Data: ()
+pub fn emit_market_cancelled_vote(e: &Env, market_id: u64, resolver: Address) {
+    e.events()
+        .publish((symbol_short!("mkt_cncl_v"), market_id, resolver), ());
+}
+
+/// Emit ReferralReward event
+/// Topics: [ref_reward, market_id, referrer]
+/// Data: (amount)
+pub fn emit_referral_reward(e: &Env, market_id: u64, referrer: Address, amount: i128) {
+    e.events()
+        .publish((symbol_short!("ref_reward"), market_id, referrer), amount);
+}
+
+/// Emit ReferralClaimed event
+/// Topics: [ref_claim, market_id, claimer]
+/// Data: (amount)
+pub fn emit_referral_claimed(e: &Env, market_id: u64, claimer: Address, amount: i128) {
+    e.events()
+        .publish((symbol_short!("ref_claim"), market_id, claimer), amount);
+}
+
+/// Emit CircuitBreakerAuto event (automatic trigger)
+/// Topics: [cb_auto, 0 (no market), contract_address]
+/// Data: (error_count)
+pub fn emit_circuit_breaker_auto(e: &Env, contract_address: Address, error_count: u32) {
+    e.events().publish(
+        (symbol_short!("cb_auto"), 0u64, contract_address),
+        error_count,
+    );
+}
+
+/// Emit FeeCollected event
+/// Topics: [fee_colct, 0 (no market), contract_address]
+/// Data: (amount)
+pub fn emit_fee_collected(e: &Env, _market_id: u64, contract_address: Address, amount: i128) {
+    e.events()
+        .publish((symbol_short!("fee_colct"), 0u64, contract_address), amount);
+}

--- a/contracts/predict-iq/src/modules/fees.rs
+++ b/contracts/predict-iq/src/modules/fees.rs
@@ -1,7 +1,7 @@
 use crate::errors::ErrorCode;
 use crate::modules::admin;
 use crate::types::{ConfigKey, MarketTier};
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contracttype, Address, Env};
 
 #[contracttype]
 pub enum DataKey {
@@ -65,8 +65,9 @@ pub fn collect_fee(e: &Env, token: Address, amount: i128) {
         .persistent()
         .set(&DataKey::TotalFeesCollected, &overall);
 
-    // Emit standardized fee collection event using soroban_sdk
-    e.events().publish((symbol_short!("fee_colct"),), amount);
+    // Emit standardized fee collection event using centralized emitter
+    let contract_addr = e.current_contract_address();
+    crate::modules::events::emit_fee_collected(e, 0, contract_addr, amount);
 }
 
 pub fn get_revenue(e: &Env, token: Address) -> i128 {
@@ -83,8 +84,7 @@ pub fn add_referral_reward(e: &Env, referrer: &Address, fee_amount: i128) {
     balance += reward;
     e.storage().persistent().set(&key, &balance);
 
-    e.events()
-        .publish((Symbol::new(e, "referral_reward"), referrer), reward);
+    crate::modules::events::emit_referral_reward(e, 0, referrer.clone(), reward);
 }
 
 pub fn claim_referral_rewards(
@@ -107,8 +107,7 @@ pub fn claim_referral_rewards(
     e.current_contract_address().require_auth();
     client.transfer(&e.current_contract_address(), address, &balance);
 
-    e.events()
-        .publish((Symbol::new(e, "referral_claimed"), address), balance);
+    crate::modules::events::emit_referral_claimed(e, 0, address.clone(), balance);
 
     Ok(balance)
 }

--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -1,7 +1,7 @@
 use crate::errors::ErrorCode;
 use crate::types::{
-    ConfigKey, Guardian, PendingUpgrade, MAJORITY_THRESHOLD_PERCENT, TIMELOCK_DURATION,
-    GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD,
+    ConfigKey, Guardian, PendingUpgrade, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD,
+    MAJORITY_THRESHOLD_PERCENT, TIMELOCK_DURATION,
 };
 use soroban_sdk::{Address, BytesN, Env, Vec};
 

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -1,6 +1,9 @@
 use crate::errors::ErrorCode;
-use crate::types::{ConfigKey, CreatorReputation, Market, MarketStatus, MarketTier, OracleConfig, TTL_LOW_THRESHOLD, TTL_HIGH_THRESHOLD, PRUNE_GRACE_PERIOD};
-use soroban_sdk::{contracttype, token, Address, Env, String, Vec, Map};
+use crate::types::{
+    ConfigKey, CreatorReputation, Market, MarketStatus, MarketTier, OracleConfig,
+    PRUNE_GRACE_PERIOD, TTL_HIGH_THRESHOLD, TTL_LOW_THRESHOLD,
+};
+use soroban_sdk::{contracttype, token, Address, Env, Map, String, Vec};
 
 #[contracttype]
 pub enum DataKey {
@@ -139,12 +142,14 @@ pub fn create_market(
     e.storage()
         .persistent()
         .set(&DataKey::Market(count), &market);
-    
+
     // Set initial TTL for the market data
-    e.storage()
-        .persistent()
-        .extend_ttl(&DataKey::Market(count), TTL_LOW_THRESHOLD, TTL_HIGH_THRESHOLD);
-    
+    e.storage().persistent().extend_ttl(
+        &DataKey::Market(count),
+        TTL_LOW_THRESHOLD,
+        TTL_HIGH_THRESHOLD,
+    );
+
     e.storage().instance().set(&DataKey::MarketCount, &count);
 
     // Emit standardized MarketCreated event
@@ -226,9 +231,11 @@ pub fn set_creation_deposit(e: &Env, amount: i128) -> Result<(), ErrorCode> {
     e.storage()
         .persistent()
         .set(&ConfigKey::CreationDeposit, &amount);
-    e.storage()
-        .persistent()
-        .extend_ttl(&ConfigKey::CreationDeposit, crate::types::GOV_TTL_LOW_THRESHOLD, crate::types::GOV_TTL_HIGH_THRESHOLD);
+    e.storage().persistent().extend_ttl(
+        &ConfigKey::CreationDeposit,
+        crate::types::GOV_TTL_LOW_THRESHOLD,
+        crate::types::GOV_TTL_HIGH_THRESHOLD,
+    );
     Ok(())
 }
 
@@ -257,16 +264,18 @@ pub fn release_creation_deposit(
 
 /// Bump TTL for market data to prevent state expiration
 pub fn bump_market_ttl(e: &Env, market_id: u64) {
-    e.storage()
-        .persistent()
-        .extend_ttl(&DataKey::Market(market_id), TTL_LOW_THRESHOLD, TTL_HIGH_THRESHOLD);
+    e.storage().persistent().extend_ttl(
+        &DataKey::Market(market_id),
+        TTL_LOW_THRESHOLD,
+        TTL_HIGH_THRESHOLD,
+    );
 }
 
 /// Prune (archive) a market that has been resolved and all prizes claimed
 /// Can only be called 30 days after resolution
 pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     crate::modules::admin::require_admin(e)?;
-    
+
     let market = get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
     // Market must be resolved
@@ -277,7 +286,7 @@ pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     // Check if 30 days have passed since resolution
     let resolved_at = market.resolved_at.ok_or(ErrorCode::MarketNotResolved)?;
     let current_time = e.ledger().timestamp();
-    
+
     if current_time < resolved_at + PRUNE_GRACE_PERIOD {
         return Err(ErrorCode::GracePeriodActive);
     }

--- a/contracts/predict-iq/src/modules/markets_test.rs
+++ b/contracts/predict-iq/src/modules/markets_test.rs
@@ -2,7 +2,10 @@
 use crate::errors::ErrorCode;
 use crate::types::{CreatorReputation, MarketStatus, MarketTier, OracleConfig};
 use crate::{PredictIQ, PredictIQClient};
-use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env, String, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String, Vec,
+};
 
 fn setup() -> (Env, PredictIQClient<'static>, Address) {
     let env = Env::default();
@@ -23,10 +26,7 @@ fn test_create_market_basic() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -134,10 +134,7 @@ fn test_create_market_deadline_in_past() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -172,10 +169,7 @@ fn test_create_market_resolution_before_deadline() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -210,10 +204,7 @@ fn test_market_id_increments() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -310,10 +301,7 @@ fn test_market_tiers() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -366,7 +354,10 @@ fn test_market_tiers() {
         &0,
     );
 
-    assert_eq!(client.get_market(&basic_id).unwrap().tier, MarketTier::Basic);
+    assert_eq!(
+        client.get_market(&basic_id).unwrap().tier,
+        MarketTier::Basic
+    );
     assert_eq!(client.get_market(&pro_id).unwrap().tier, MarketTier::Pro);
     assert_eq!(
         client.get_market(&inst_id).unwrap().tier,
@@ -380,10 +371,7 @@ fn test_prune_market_before_grace_period() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -425,10 +413,7 @@ fn test_prune_market_after_grace_period() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {
@@ -473,10 +458,7 @@ fn test_prune_unresolved_market_fails() {
 
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = OracleConfig {

--- a/contracts/predict-iq/src/modules/monitoring.rs
+++ b/contracts/predict-iq/src/modules/monitoring.rs
@@ -21,12 +21,12 @@ pub fn track_error(e: &Env) {
         // Automatically open the circuit breaker
         e.storage().persistent().set(
             &crate::types::ConfigKey::CircuitBreakerState,
-            &CircuitBreakerState::Open,
+            &crate::types::CircuitBreakerState::Open,
         );
 
-        // Emit standardized circuit breaker event using soroban_sdk
-        use soroban_sdk::symbol_short;
-        e.events().publish((symbol_short!("cb_auto"),), count);
+        // Emit standardized circuit breaker event using centralized emitter
+        let contract_addr = e.current_contract_address();
+        crate::modules::events::emit_circuit_breaker_auto(e, contract_addr, count);
     }
 }
 

--- a/contracts/predict-iq/src/modules/oracles.rs
+++ b/contracts/predict-iq/src/modules/oracles.rs
@@ -1,6 +1,6 @@
 use crate::errors::ErrorCode;
 use crate::types::OracleConfig;
-use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+use soroban_sdk::{contracttype, Env};
 
 #[contracttype]
 pub enum OracleData {
@@ -62,11 +62,9 @@ pub fn resolve_with_pyth(e: &Env, market_id: u64, config: &OracleConfig) -> Resu
         &(price.publish_time as u64),
     );
 
-    // Publish event
-    e.events().publish(
-        (Symbol::new(e, "oracle_resolution"), market_id),
-        (outcome, price.price, price.conf),
-    );
+    // Publish event using centralized emitter
+    let oracle_addr = e.current_contract_address();
+    crate::modules::events::emit_oracle_resolved(e, market_id, oracle_addr, outcome);
 
     Ok(outcome)
 }

--- a/contracts/predict-iq/src/modules/resolution.rs
+++ b/contracts/predict-iq/src/modules/resolution.rs
@@ -1,7 +1,7 @@
-use soroban_sdk::{Env, Symbol};
-use crate::types::MarketStatus;
-use crate::modules::{markets, oracles, voting};
 use crate::errors::ErrorCode;
+use crate::modules::{events, markets, oracles, voting};
+use crate::types::MarketStatus;
+use soroban_sdk::Env;
 
 const DISPUTE_WINDOW_SECONDS: u64 = 86400; // 24 hours
 const VOTING_PERIOD_SECONDS: u64 = 259200; // 72 hours
@@ -10,28 +10,26 @@ const MAJORITY_THRESHOLD_BPS: i128 = 6000; // 60%
 /// T+0: Attempt oracle resolution at resolution deadline
 pub fn attempt_oracle_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     let mut market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
-    
+
     if market.status != MarketStatus::Active {
         return Err(ErrorCode::MarketNotActive);
     }
-    
+
     if e.ledger().timestamp() < market.resolution_deadline {
         return Err(ErrorCode::ResolutionNotReady);
     }
-    
+
     // Attempt oracle resolution
     if let Some(oracle_outcome) = oracles::get_oracle_result(e, market_id, &market.oracle_config) {
         market.status = MarketStatus::PendingResolution;
         market.winning_outcome = Some(oracle_outcome);
         market.pending_resolution_timestamp = Some(e.ledger().timestamp());
-        
+
         markets::update_market(e, market);
-        
-        e.events().publish(
-            (Symbol::new(e, "oracle_resolved"), market_id),
-            oracle_outcome,
-        );
-        
+
+        let resolver = e.current_contract_address();
+        events::emit_oracle_resolved(e, market_id, resolver, oracle_outcome);
+
         Ok(())
     } else {
         Err(ErrorCode::OracleFailure)
@@ -41,48 +39,48 @@ pub fn attempt_oracle_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCod
 /// T+24h: Finalize resolution if no dispute filed
 pub fn finalize_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     let mut market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
-    
+
     match market.status {
         MarketStatus::PendingResolution => {
             // Check if 24h dispute window has passed
-            let pending_ts = market.pending_resolution_timestamp.ok_or(ErrorCode::ResolutionNotReady)?;
+            let pending_ts = market
+                .pending_resolution_timestamp
+                .ok_or(ErrorCode::ResolutionNotReady)?;
             if e.ledger().timestamp() < pending_ts + DISPUTE_WINDOW_SECONDS {
                 return Err(ErrorCode::DisputeWindowStillOpen);
             }
-            
+
             // No dispute filed, finalize with oracle result
             let winning_outcome = market.winning_outcome.unwrap();
             market.status = MarketStatus::Resolved;
             markets::update_market(e, market);
-            
-            e.events().publish(
-                (Symbol::new(e, "market_finalized"), market_id),
-                winning_outcome,
-            );
-            
+
+            let resolver = e.current_contract_address();
+            events::emit_market_finalized(e, market_id, resolver, winning_outcome);
+
             Ok(())
-        },
+        }
         MarketStatus::Disputed => {
             // Check if 72h voting period has passed
-            let dispute_ts = market.pending_resolution_timestamp.ok_or(ErrorCode::MarketNotDisputed)?;
+            let dispute_ts = market
+                .pending_resolution_timestamp
+                .ok_or(ErrorCode::MarketNotDisputed)?;
             if e.ledger().timestamp() < dispute_ts + VOTING_PERIOD_SECONDS {
                 return Err(ErrorCode::VotingNotStarted);
             }
-            
+
             // Calculate voting outcome
             let winning_outcome = calculate_voting_outcome(e, &market)?;
-            
+
             market.status = MarketStatus::Resolved;
             market.winning_outcome = Some(winning_outcome);
             markets::update_market(e, market);
-            
-            e.events().publish(
-                (Symbol::new(e, "dispute_resolved"), market_id),
-                winning_outcome,
-            );
-            
+
+            let resolver = e.current_contract_address();
+            events::emit_dispute_resolved(e, market_id, resolver, winning_outcome);
+
             Ok(())
-        },
+        }
         MarketStatus::Resolved => Err(ErrorCode::CannotChangeOutcome),
         _ => Err(ErrorCode::ResolutionNotReady),
     }

--- a/contracts/predict-iq/src/modules/sac.rs
+++ b/contracts/predict-iq/src/modules/sac.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, Address, token};
 use crate::errors::ErrorCode;
+use soroban_sdk::{token, Address, Env};
 
 /// Verify that a token transfer succeeded and handle clawback/freeze scenarios
 pub fn safe_transfer(
@@ -10,25 +10,22 @@ pub fn safe_transfer(
     amount: &i128,
 ) -> Result<(), ErrorCode> {
     let client = token::Client::new(e, token_address);
-    
+
     // Attempt transfer - will panic if clawed back or frozen
     client.transfer(from, to, amount);
-    
+
     Ok(())
 }
 
 /// Check if contract can receive tokens (not frozen)
 /// Returns true if the contract's balance can be modified
-pub fn verify_contract_not_frozen(
-    e: &Env,
-    token_address: &Address,
-) -> Result<(), ErrorCode> {
+pub fn verify_contract_not_frozen(e: &Env, token_address: &Address) -> Result<(), ErrorCode> {
     let client = token::Client::new(e, token_address);
     let contract_addr = e.current_contract_address();
-    
+
     // Try to get balance - if frozen, this will succeed but transfers will fail
     let _balance = client.balance(&contract_addr);
-    
+
     Ok(())
 }
 
@@ -40,10 +37,10 @@ pub fn detect_clawback(
 ) -> Result<(), ErrorCode> {
     let client = token::Client::new(e, token_address);
     let actual_balance = client.balance(&e.current_contract_address());
-    
+
     if actual_balance < expected_balance {
         return Err(ErrorCode::InsufficientBalance);
     }
-    
+
     Ok(())
 }

--- a/contracts/predict-iq/src/modules/voting.rs
+++ b/contracts/predict-iq/src/modules/voting.rs
@@ -103,11 +103,8 @@ fn try_get_balance_at(
     ledger: u32,
 ) -> Result<i128, ErrorCode> {
     use soroban_sdk::{IntoVal, Val};
-    let args: soroban_sdk::Vec<Val> = soroban_sdk::vec![
-        e,
-        account.clone().into_val(e),
-        ledger.into_val(e),
-    ];
+    let args: soroban_sdk::Vec<Val> =
+        soroban_sdk::vec![e, account.clone().into_val(e), ledger.into_val(e),];
 
     match e.try_invoke_contract::<i128, ErrorCode>(token, &Symbol::new(e, "balance_at"), args) {
         Ok(Ok(balance)) => Ok(balance),

--- a/contracts/predict-iq/src/test.rs
+++ b/contracts/predict-iq/src/test.rs
@@ -81,8 +81,8 @@ fn test_market_creation_fails_without_deposit() {
             oracle_address: Address::generate(&e),
             feed_id: String::from_str(&e, "test"),
             min_responses: Some(1),
-        max_staleness_seconds: 3600,
-        max_confidence_bps: 100,
+            max_staleness_seconds: 3600,
+            max_confidence_bps: 100,
         },
         &types::MarketTier::Basic,
         &native_token,
@@ -255,9 +255,10 @@ fn test_admin_can_reduce_push_threshold_for_gas_intensive_tokens() {
         types::MarketTier::Basic,
         &native_token,
     );
-    e.storage()
-        .persistent()
-        .set(&crate::modules::voting::DataKey::VoteTally(market_default, 0), &2000i128);
+    e.storage().persistent().set(
+        &crate::modules::voting::DataKey::VoteTally(market_default, 0),
+        &2000i128,
+    );
     client.resolve_market(&market_default, &0);
     let resolved_default = client.get_market(&market_default).unwrap();
     assert_eq!(resolved_default.payout_mode, types::PayoutMode::Push);
@@ -273,9 +274,10 @@ fn test_admin_can_reduce_push_threshold_for_gas_intensive_tokens() {
         types::MarketTier::Basic,
         &native_token,
     );
-    e.storage()
-        .persistent()
-        .set(&crate::modules::voting::DataKey::VoteTally(market_lowered, 0), &2000i128);
+    e.storage().persistent().set(
+        &crate::modules::voting::DataKey::VoteTally(market_lowered, 0),
+        &2000i128,
+    );
     client.resolve_market(&market_lowered, &0);
     let resolved_lowered = client.get_market(&market_lowered).unwrap();
     assert_eq!(resolved_lowered.payout_mode, types::PayoutMode::Pull);
@@ -1359,7 +1361,10 @@ fn test_pending_upgrade_survives_3_months_inactivity() {
 
     // PendingUpgrade must still be readable — TTL was set to 180 days on write
     let pending = client.get_pending_upgrade();
-    assert!(pending.is_some(), "PendingUpgrade expired after 3 months of inactivity");
+    assert!(
+        pending.is_some(),
+        "PendingUpgrade expired after 3 months of inactivity"
+    );
     assert_eq!(pending.unwrap().wasm_hash, wasm_hash);
 }
 
@@ -1382,7 +1387,11 @@ fn test_guardian_set_survives_3_months_inactivity() {
     });
 
     let stored = client.get_guardians();
-    assert_eq!(stored.len(), 1, "GuardianSet expired after 3 months of inactivity");
+    assert_eq!(
+        stored.len(),
+        1,
+        "GuardianSet expired after 3 months of inactivity"
+    );
     assert_eq!(stored.get(0).unwrap().address, guardian);
 }
 
@@ -1412,7 +1421,10 @@ fn test_vote_on_upgrade_refreshes_ttl() {
     });
 
     let pending = client.get_pending_upgrade();
-    assert!(pending.is_some(), "PendingUpgrade expired after vote + 3 months inactivity");
+    assert!(
+        pending.is_some(),
+        "PendingUpgrade expired after vote + 3 months inactivity"
+    );
     let (votes_for, _) = client.get_upgrade_votes().unwrap();
     assert_eq!(votes_for, 1);
 }
@@ -1464,7 +1476,8 @@ fn test_voting_works_with_optimized_vote_struct() {
     client.attempt_oracle_resolution(&market_id);
 
     let disputer = Address::generate(&e);
-    e.ledger().with_mut(|li| li.timestamp = resolution_deadline + 1000);
+    e.ledger()
+        .with_mut(|li| li.timestamp = resolution_deadline + 1000);
     client.file_dispute(&disputer, &market_id);
 
     // Two voters — outcome 1 gets 70%, outcome 0 gets 30%
@@ -1530,7 +1543,8 @@ fn test_double_vote_still_rejected_with_optimized_struct() {
     client.attempt_oracle_resolution(&market_id);
 
     let disputer = Address::generate(&e);
-    e.ledger().with_mut(|li| li.timestamp = resolution_deadline + 1000);
+    e.ledger()
+        .with_mut(|li| li.timestamp = resolution_deadline + 1000);
     client.file_dispute(&disputer, &market_id);
 
     let voter = Address::generate(&e);

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -26,10 +26,10 @@ pub struct Market {
     pub payout_mode: PayoutMode, // Resolution-time mode flag; payouts are currently claimed via claim_winnings
     pub tier: MarketTier,
     pub creation_deposit: i128,
-    pub parent_id: u64,          // 0 means no parent (independent market)
-    pub parent_outcome_idx: u32, // Required outcome of parent market
-    pub resolved_at: Option<u64>, // Timestamp when market was resolved (for TTL pruning)
-    pub token_address: Address,   // Token used for betting
+    pub parent_id: u64,                 // 0 means no parent (independent market)
+    pub parent_outcome_idx: u32,        // Required outcome of parent market
+    pub resolved_at: Option<u64>,       // Timestamp when market was resolved (for TTL pruning)
+    pub token_address: Address,         // Token used for betting
     pub outcome_stakes: Map<u32, i128>, // Stake per outcome
     pub pending_resolution_timestamp: Option<u64>, // Timestamp when resolution was initiated
     pub dispute_snapshot_ledger: Option<u32>, // Ledger sequence for snapshot voting
@@ -161,5 +161,5 @@ pub const PRUNE_GRACE_PERIOD: u64 = 2_592_000; // 30 days in seconds
 /// Governance TTL constants — much longer than market data because governance
 /// processes (upgrades, guardian votes) can span months of inactivity.
 /// ~90 days expressed in ledgers (~5 seconds per ledger).
-pub const GOV_TTL_LOW_THRESHOLD: u32 = 1_555_200;  // ~90 days
+pub const GOV_TTL_LOW_THRESHOLD: u32 = 1_555_200; // ~90 days
 pub const GOV_TTL_HIGH_THRESHOLD: u32 = 3_110_400; // ~180 days

--- a/contracts/predict-iq/tests/common/mod.rs
+++ b/contracts/predict-iq/tests/common/mod.rs
@@ -37,10 +37,7 @@ pub fn create_market(
 ) -> u64 {
     let options = Vec::from_array(
         env,
-        [
-            String::from_str(env, "Yes"),
-            String::from_str(env, "No"),
-        ],
+        [String::from_str(env, "Yes"), String::from_str(env, "No")],
     );
 
     let oracle_config = predict_iq::types::OracleConfig {
@@ -195,11 +192,7 @@ pub fn place_bet_helper(
 }
 
 /// Resolve market and verify status
-pub fn resolve_and_verify(
-    client: &PredictIQClient,
-    market_id: u64,
-    winning_outcome: u32,
-) {
+pub fn resolve_and_verify(client: &PredictIQClient, market_id: u64, winning_outcome: u32) {
     client.resolve_market(&market_id, &winning_outcome);
     assert_market_status(client, market_id, predict_iq::types::MarketStatus::Resolved);
 }

--- a/contracts/predict-iq/tests/integration_test.rs
+++ b/contracts/predict-iq/tests/integration_test.rs
@@ -121,7 +121,14 @@ fn test_referral_system_integration() {
     token_client.mint(&bettor, &10_000);
 
     // Place bet with referrer
-    client.place_bet(&bettor, &market_id, &0, &1_000, &token, &Some(referrer.clone()));
+    client.place_bet(
+        &bettor,
+        &market_id,
+        &0,
+        &1_000,
+        &token,
+        &Some(referrer.clone()),
+    );
 
     // Referrer should have pending rewards
     let rewards_before = token_client.balance(&referrer);
@@ -148,10 +155,7 @@ fn test_conditional_market_chain() {
     // Create child market conditional on parent outcome 0
     let options = Vec::from_array(
         &env,
-        [
-            String::from_str(&env, "Yes"),
-            String::from_str(&env, "No"),
-        ],
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
     );
 
     let oracle_config = predict_iq::types::OracleConfig {


### PR DESCRIPTION
## Prevent Self-Referral Reward Exploits

Validates that referrer address is distinct from bettor address to prevent fee discount exploitation.

**Implementation:**
- Rejects bets where referrer == bettor
- Returns InvalidReferrer error code
- Protects referral pool integrity

Closes #129