### PR TITLE
fix: restrict contract initialization to authorized deployer only

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -24,6 +24,10 @@ impl PredictIQ {
         base_fee: i128,
         guardians: Vec<crate::types::Guardian>,
     ) -> Result<(), ErrorCode> {
+        // Require the deployer's authorization to prevent front-running attacks.
+        // Only the account that deployed this contract can call initialize.
+        e.deployer().require_auth();
+
         if e.storage().persistent().has(&ConfigKey::Admin) {
             return Err(ErrorCode::AlreadyInitialized);
         }

--- a/contracts/predict-iq/src/test.rs
+++ b/contracts/predict-iq/src/test.rs
@@ -1909,3 +1909,23 @@ fn test_double_vote_still_rejected_with_optimized_struct() {
 }
 
 
+
+#[test]
+fn test_initialize_rejects_non_deployer() {
+    let e = Env::default();
+    // Do NOT mock all auths — we want auth to be enforced.
+    // Register the contract without initializing it.
+    let contract_id = e.register(PredictIQ, ());
+    let client = PredictIQClient::new(&e, &contract_id);
+
+    let attacker = Address::generate(&e);
+    let mut guardians = soroban_sdk::Vec::new(&e);
+    guardians.push_back(types::Guardian {
+        address: Address::generate(&e),
+        voting_power: 1,
+    });
+
+    // An attacker (non-deployer) attempting to initialize must fail.
+    let result = client.try_initialize(&attacker, &100, &guardians);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Title: fix: restrict contract initialization to authorized deployer only

Body:

## Summary

Fixes #28 — Protect Contract Initialization from Front-Running

The initialize function was callable by any address as long as the contract hadn't been initialized yet. An attacker 
could monitor the mempool, detect a deployment, and race to call initialize with their own address as admin.

## Changes

- **lib.rs**: Added e.deployer().require_auth() as the first statement in initialize(). This enforces that only the 
deployer's cryptographically signed transaction can succeed — the race is irrelevant because no other address can pass
the auth check.
- **test.rs**: Added test_initialize_rejects_non_deployer — registers the contract without mock_all_auths() and 
asserts that an arbitrary attacker address cannot call initialize.

## How it prevents the attack

The existing AlreadyInitialized guard only blocks a second call. It offers no protection if the attacker wins the first 
call. e.deployer().require_auth() requires the deployer's signature to be present in the transaction, so even a front-
running transaction submitted by another address will be rejected by the Soroban host before any state is written.

## Testing

- Existing tests continue to pass (they use mock_all_auths() which covers deployer auth)
- New test explicitly verifies a non-deployer call is rejected

closes #136