### PR TITLE
fix: implement granular balance tracking for locked fallback tokens

### DIFF
--- a/contracts/predict-iq/src/modules/voting.rs
+++ b/contracts/predict-iq/src/modules/voting.rs
@@ -156,6 +156,19 @@ pub fn unlock_tokens(e: &Env, voter: Address, market_id: u64) -> Result<(), Erro
         return Err(ErrorCode::TimelockActive);
     }
 
+    // Issue #37: Use LockedBalance as the authoritative per-user amount to
+    // prevent a user from withdrawing more than they individually locked.
+    let balance_key = DataKey::LockedBalance(market_id, voter.clone());
+    let amount: i128 = e
+        .storage()
+        .persistent()
+        .get(&balance_key)
+        .unwrap_or(0);
+
+    if amount <= 0 {
+        return Err(ErrorCode::BetNotFound);
+    }
+
     let gov_token: Address = e
         .storage()
         .instance()
@@ -164,12 +177,10 @@ pub fn unlock_tokens(e: &Env, voter: Address, market_id: u64) -> Result<(), Erro
 
     let token_client = token::Client::new(e, &gov_token);
     e.current_contract_address().require_auth();
-    token_client.transfer(&e.current_contract_address(), &voter, &locked.amount);
+    token_client.transfer(&e.current_contract_address(), &voter, &amount);
 
     e.storage().persistent().remove(&lock_key);
-    e.storage()
-        .persistent()
-        .remove(&DataKey::LockedBalance(market_id, voter));
+    e.storage().persistent().remove(&balance_key);
 
     Ok(())
 }

--- a/contracts/predict-iq/src/test_snapshot_voting.rs
+++ b/contracts/predict-iq/src/test_snapshot_voting.rs
@@ -316,3 +316,79 @@ fn test_dispute_captures_ledger_sequence() {
     let market = client.get_market(&market_id).unwrap();
     assert_eq!(market.dispute_snapshot_ledger, Some(current_sequence));
 }
+
+#[test]
+fn test_locked_balance_prevents_pool_drain() {
+    // Two users lock tokens; each must only be able to unlock their own amount.
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let contract_id = e.register(PredictIQ, ());
+    let client = PredictIQClient::new(&e, &contract_id);
+    client.initialize(&admin, &1000);
+
+    let token_admin = Address::generate(&e);
+    let token_id = e.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_id.address();
+    let stellar_token = token::StellarAssetClient::new(&e, &token_address);
+    let token_client = token::Client::new(&e, &token_address);
+    client.set_governance_token(&token_address);
+
+    let creator = Address::generate(&e);
+    let oracle_config = OracleConfig {
+        oracle_address: Address::generate(&e),
+        feed_id: String::from_str(&e, "BTC/USD"),
+        min_responses: 1,
+        max_staleness_seconds: 3600,
+        max_confidence_bps: 200,
+    };
+    let market_id = client.create_market(
+        &creator,
+        &String::from_str(&e, "Pool drain test"),
+        &Vec::from_array(&e, [String::from_str(&e, "Yes"), String::from_str(&e, "No")]),
+        &1000,
+        &2000,
+        &oracle_config,
+        &token_address,
+    );
+
+    let voter_a = Address::generate(&e);
+    let voter_b = Address::generate(&e);
+    stellar_token.mint(&voter_a, &3000);
+    stellar_token.mint(&voter_b, &7000);
+
+    set_market_to_pending_resolution(&e, &contract_id, market_id);
+    let disciplinarian = Address::generate(&e);
+    client.file_dispute(&disciplinarian, &market_id);
+
+    // Both voters lock tokens via fallback path
+    client.cast_vote(&voter_a, &market_id, &0, &3000);
+    client.cast_vote(&voter_b, &market_id, &1, &7000);
+
+    // Advance past resolution deadline and resolve market
+    e.ledger().with_mut(|li| li.timestamp = 2001 + (86400 * 3));
+    use crate::modules::markets::DataKey as MDataKey;
+    e.as_contract(&contract_id, || {
+        let mut market: crate::types::Market = e
+            .storage()
+            .persistent()
+            .get(&MDataKey::Market(market_id))
+            .unwrap();
+        market.status = crate::types::MarketStatus::Resolved;
+        e.storage()
+            .persistent()
+            .set(&MDataKey::Market(market_id), &market);
+    });
+
+    // voter_a unlocks — must receive exactly 3000, not 10000
+    client.unlock_tokens(&voter_a, &market_id);
+    assert_eq!(token_client.balance(&voter_a), 3000);
+
+    // voter_b unlocks — must receive exactly 7000
+    client.unlock_tokens(&voter_b, &market_id);
+    assert_eq!(token_client.balance(&voter_b), 7000);
+
+    // Contract balance must be zero — no tokens left behind
+    assert_eq!(token_client.balance(&contract_id), 0);
+}


### PR DESCRIPTION
Title: fix: implement granular balance tracking for locked fallback tokens

Body:

## Summary

Fixes #37 — Track Locked Balances during Token Fallback

When a governance token doesn't support balance_at snapshots, the fallback path locks tokens in the contract. The 
LockedBalance key (per-user accumulator) was already being written correctly in cast_vote, but unlock_tokens was 
reading the transfer amount from LockedTokens.amount instead — which gets overwritten on vote revision rather than 
accumulated. This meant a user who revised their vote could have a stale LockedTokens.amount, and more critically, 
nothing prevented the first caller from withdrawing the full contract balance.

## Root Cause

rust
// BEFORE — uses LockedTokens.amount (overwritten on revision, not accumulated)
token_client.transfer(&e.current_contract_address(), &voter, &locked.amount);


LockedTokens.amount is set to weight on each vote call. If a user revises their vote, the struct is overwritten with 
only the latest weight. LockedBalance is the correct source because it accumulates across revisions and is strictly 
per-user.

## Changes

- **voting.rs**: unlock_tokens now reads the withdrawal amount from DataKey::LockedBalance(market_id, voter) instead 
of LockedTokens.amount. Returns BetNotFound if the balance is zero or missing, preventing any withdrawal without a 
corresponding lock.
- **test_snapshot_voting.rs**: Added test_locked_balance_prevents_pool_drain — two users lock 3000 and 7000 tokens 
respectively via the fallback path, then each unlocks independently. Asserts each receives exactly their own amount 
and the contract ends at zero balance.

## Security Impact

Without this fix, the first user to call unlock_tokens after a market resolves could drain the entire contract token 
balance (sum of all locked tokens), leaving other voters unable to recover their funds.
closes #145