### PR TITLE
fix: move all circuit breaker state to instance storage for consistency

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -34,7 +34,7 @@ impl PredictIQ {
 
         admin::set_admin(&e, admin);
         e.storage().persistent().set(&ConfigKey::BaseFee, &base_fee);
-        e.storage().persistent().set(
+        e.storage().instance().set(
             &ConfigKey::CircuitBreakerState,
             &CircuitBreakerState::Closed,
         );

--- a/contracts/predict-iq/src/modules/circuit_breaker.rs
+++ b/contracts/predict-iq/src/modules/circuit_breaker.rs
@@ -1,6 +1,6 @@
 use crate::errors::ErrorCode;
 use crate::modules::admin;
-use crate::types::{CircuitBreakerState, ConfigKey, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD};
+use crate::types::{CircuitBreakerState, ConfigKey};
 use soroban_sdk::Env;
 
 /// Cool-down period before Open transitions to HalfOpen (Issue #12).
@@ -14,12 +14,8 @@ pub enum DataKey {
     OpenedAt,
 }
 
-fn bump_gov_ttl(e: &Env) {
-    e.storage().persistent().extend_ttl(
-        &ConfigKey::CircuitBreakerState,
-        GOV_TTL_LOW_THRESHOLD,
-        GOV_TTL_HIGH_THRESHOLD,
-    );
+fn bump_gov_ttl(_e: &Env) {
+    // CircuitBreakerState is now in instance storage; no persistent TTL bump needed.
 }
 
 pub fn set_state(e: &Env, state: CircuitBreakerState) -> Result<(), ErrorCode> {
@@ -35,8 +31,10 @@ fn _set_state_internal(e: &Env, state: CircuitBreakerState) -> Result<(), ErrorC
             .set(&crate::modules::circuit_breaker::DataKey::OpenedAt, &e.ledger().timestamp());
     }
 
+    // Issue #38: CircuitBreakerState moved to instance storage so it stays
+    // co-located with OpenedAt and monitoring counters — all expire together.
     e.storage()
-        .persistent()
+        .instance()
         .set(&ConfigKey::CircuitBreakerState, &state);
     bump_gov_ttl(e);
 
@@ -54,7 +52,7 @@ fn _set_state_internal(e: &Env, state: CircuitBreakerState) -> Result<(), ErrorC
 
 pub fn get_state(e: &Env) -> CircuitBreakerState {
     e.storage()
-        .persistent()
+        .instance()
         .get(&ConfigKey::CircuitBreakerState)
         .unwrap_or(CircuitBreakerState::Closed)
 }

--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -398,7 +398,7 @@ pub fn emergency_pause(e: &Env, voter: Address) -> Result<(), ErrorCode> {
     }
 
     // Trigger emergency pause
-    e.storage().persistent().set(
+    e.storage().instance().set(
         &ConfigKey::CircuitBreakerState,
         &crate::types::CircuitBreakerState::Paused,
     );

--- a/contracts/predict-iq/src/modules/monitoring.rs
+++ b/contracts/predict-iq/src/modules/monitoring.rs
@@ -13,17 +13,17 @@ pub enum DataKey {
 pub fn track_error(e: &Env) {
     let mut count: u32 = e
         .storage()
-        .persistent()
+        .instance()
         .get(&DataKey::ErrorCount)
         .unwrap_or(0);
     count += 1;
-    e.storage().persistent().set(&DataKey::ErrorCount, &count);
+    e.storage().instance().set(&DataKey::ErrorCount, &count);
     e.storage()
-        .persistent()
+        .instance()
         .set(&DataKey::LastObservation, &e.ledger().timestamp());
 
     if count > 10 {
-        e.storage().persistent().set(
+        e.storage().instance().set(
             &crate::types::ConfigKey::CircuitBreakerState,
             &crate::types::CircuitBreakerState::Open,
         );
@@ -37,17 +37,17 @@ pub fn track_error(e: &Env) {
 pub fn reset_monitoring(e: &Env) {
     let previous_error_count: u32 = e
         .storage()
-        .persistent()
+        .instance()
         .get(&DataKey::ErrorCount)
         .unwrap_or(0);
     let previous_last_observation: u64 = e
         .storage()
-        .persistent()
+        .instance()
         .get(&DataKey::LastObservation)
         .unwrap_or(0);
 
-    e.storage().persistent().set(&DataKey::ErrorCount, &0u32);
-    e.storage().persistent().set(&DataKey::LastObservation, &0u64);
+    e.storage().instance().set(&DataKey::ErrorCount, &0u32);
+    e.storage().instance().set(&DataKey::LastObservation, &0u64);
 
     let resetter = crate::modules::admin::get_admin(e).unwrap_or(e.current_contract_address());
     crate::modules::events::emit_monitoring_state_reset(
@@ -71,10 +71,10 @@ mod tests {
         track_error(&e);
         track_error(&e);
 
-        let before_count: u32 = e.storage().persistent().get(&DataKey::ErrorCount).unwrap_or(0);
+        let before_count: u32 = e.storage().instance().get(&DataKey::ErrorCount).unwrap_or(0);
         let before_obs: u64 = e
             .storage()
-            .persistent()
+            .instance()
             .get(&DataKey::LastObservation)
             .unwrap_or(0);
         assert_eq!(before_count, 2);
@@ -82,10 +82,10 @@ mod tests {
 
         reset_monitoring(&e);
 
-        let after_count: u32 = e.storage().persistent().get(&DataKey::ErrorCount).unwrap_or(1);
+        let after_count: u32 = e.storage().instance().get(&DataKey::ErrorCount).unwrap_or(1);
         let after_obs: u64 = e
             .storage()
-            .persistent()
+            .instance()
             .get(&DataKey::LastObservation)
             .unwrap_or(1);
 


### PR DESCRIPTION
Title: fix: move all circuit breaker state to instance storage for consistency

Body:

## Summary

Fixes #38 — Unify Circuit Breaker Storage Layers

CircuitBreakerState lived in persistent storage while OpenedAt (cool-down timer) lived in instance storage, and 
ErrorCount/LastObservation also lived in persistent. If instance storage expired while persistent state survived, the 
breaker could be Open with OpenedAt = 0, causing the cool-down to immediately resolve to HalfOpen on the next call — 
or counters could reset to zero while the breaker stayed Open with no path to re-trigger it correctly.

## Root Cause

The inconsistency meant the three components of the circuit breaker had different expiry lifecycles:

| Key | Before | After |
|---|---|---|
| CircuitBreakerState | persistent | instance |
| OpenedAt | instance | instance (unchanged) |
| ErrorCount | persistent | instance |
| LastObservation | persistent | instance |

## Changes

- **circuit_breaker.rs**: _set_state_internal and get_state now use instance storage. Removed the persistent TTL bump 
for CircuitBreakerState — instance storage expires as a unit, so no manual TTL management is needed.
- **monitoring.rs**: track_error and reset_monitoring now use instance storage for ErrorCount and LastObservation, 
including the auto-open write to CircuitBreakerState. Inline tests updated accordingly.
- **governance.rs**: emergency_pause writes CircuitBreakerState to instance.
- **lib.rs**: initialize writes the initial Closed state to instance.

## Consistency Guarantee

All safety-related state now shares the same storage layer and expiry lifecycle. If instance storage expires, every 
key resets together — get_state returns Closed (the safe default), counters return 0, and the system is in a coherent 
state rather than a partially-reset one.

closes #146