### PR TITLE
fix: allow permissionless pruning of expired market data

### DIFF
--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -303,8 +303,6 @@ pub fn bump_market_ttl(e: &Env, market_id: u64) {
 /// Issue #17: Guard prune with total_claimed check.
 /// Issue #47: Permissionless — anyone can call after grace period.
 pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
-    crate::modules::admin::require_admin(e)?;
-
     let market = get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
     if market.status != MarketStatus::Resolved {

--- a/contracts/predict-iq/src/modules/markets_test.rs
+++ b/contracts/predict-iq/src/modules/markets_test.rs
@@ -602,3 +602,48 @@ fn test_prune_market_after_all_rewards_claimed() {
     let result = client.try_prune_market(&market_id);
     assert!(result.is_ok());
 }
+
+/// Issue #47: Any user can prune an expired resolved market without admin privileges.
+#[test]
+fn test_permissionless_prune_by_non_admin() {
+    let (env, client, admin) = setup();
+
+    let options = Vec::from_array(
+        &env,
+        [String::from_str(&env, "Yes"), String::from_str(&env, "No")],
+    );
+
+    let oracle_config = OracleConfig {
+        oracle_address: Address::generate(&env),
+        feed_id: String::from_str(&env, "test"),
+        min_responses: Some(1),
+        max_staleness_seconds: 3600,
+        max_confidence_bps: 100,
+    };
+
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+
+    let market_id = client.create_market(
+        &admin,
+        &String::from_str(&env, "Test Market"),
+        &options,
+        &2000,
+        &3000,
+        &oracle_config,
+        &MarketTier::Basic,
+        &token,
+        &0,
+        &0,
+    );
+
+    client.resolve_market(&market_id, &0);
+
+    // Advance past 30-day grace period (31 days)
+    env.ledger().set_timestamp(1000 + 2_678_401);
+
+    // A random non-admin user triggers pruning
+    let result = client.try_prune_market(&market_id);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Title: fix: allow permissionless pruning of expired market data

Body:



## Summary
Removes the admin requirement from prune_market, allowing any user to trigger pruning for a resolved market that has 
exceeded the 30-day grace period. This makes protocol maintenance self-sustaining and prevents indefinite storage 
accumulation if the admin team is inactive.

## Changes
- markets.rs — removed require_admin(e)? from prune_market
- markets_test.rs — added test_permissionless_prune_by_non_admin to verify a non-admin can prune a 31-day-old resolved
market

## Access Control
All existing safety guards remain intact:
- Market must be in Resolved status
- 30-day grace period (PRUNE_GRACE_PERIOD) must have elapsed
- All winnings must be claimed before pruning is allowed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
closes #155