### PR TITLE
fix(#290): replace .expect panic in generate_signature with fallible Result API

### DIFF
--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -341,13 +341,30 @@ pub mod signing {
         mac.verify_slice(&expected).is_ok()
     }
 
-    pub fn generate_signature(payload: &[u8], secret: &str) -> String {
-        let mut mac =
-            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    pub fn generate_signature(payload: &[u8], secret: &str) -> Result<String, SigningError> {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+            .map_err(|_| SigningError::InvalidKey)?;
         mac.update(payload);
         let result = mac.finalize();
-        BASE64.encode(result.into_bytes())
+        Ok(BASE64.encode(result.into_bytes()))
     }
+
+    /// Error type for fallible signing operations.
+    #[derive(Debug, PartialEq)]
+    pub enum SigningError {
+        /// The secret key was rejected by the HMAC constructor (empty key).
+        InvalidKey,
+    }
+
+    impl std::fmt::Display for SigningError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                SigningError::InvalidKey => write!(f, "signing key is invalid"),
+            }
+        }
+    }
+
+    impl std::error::Error for SigningError {}
 }
 
 #[derive(Serialize)]

--- a/services/api/tests/security_tests.rs
+++ b/services/api/tests/security_tests.rs
@@ -81,7 +81,7 @@ mod tests {
         let payload = b"test payload";
         let secret = "test-secret";
 
-        let signature = signing::generate_signature(payload, secret);
+        let signature = signing::generate_signature(payload, secret).unwrap();
         assert!(signing::verify_signature(payload, &signature, secret));
 
         // Wrong payload should fail
@@ -105,5 +105,38 @@ mod tests {
         assert_eq!(sanitize::numeric_id("  456  "), Some(456));
         assert_eq!(sanitize::numeric_id("abc"), None);
         assert_eq!(sanitize::numeric_id("12.34"), None);
+    }
+
+    // -------------------------------------------------------------------------
+    // #290: generate_signature — fallible API + panic-safety tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn generate_signature_returns_ok_for_valid_inputs() {
+        let sig = signing::generate_signature(b"hello", "secret");
+        assert!(sig.is_ok(), "expected Ok for valid payload and secret");
+    }
+
+    #[test]
+    fn generate_signature_ok_is_verifiable() {
+        let payload = b"data";
+        let secret = "key";
+        let sig = signing::generate_signature(payload, secret).unwrap();
+        assert!(signing::verify_signature(payload, &sig, secret));
+    }
+
+    #[test]
+    fn generate_signature_empty_secret_returns_err() {
+        // HMAC rejects a zero-length key; previously this would have panicked
+        // via .expect(). Now it must surface as Err(SigningError::InvalidKey).
+        let result = signing::generate_signature(b"payload", "");
+        assert_eq!(result, Err(signing::SigningError::InvalidKey));
+    }
+
+    #[test]
+    fn generate_signature_error_is_display_safe() {
+        // Ensure the error can be formatted without panicking (used in logs/responses).
+        let err = signing::SigningError::InvalidKey;
+        assert!(!err.to_string().is_empty());
     }
 }


### PR DESCRIPTION
Problem
-------
signing::generate_signature called HmacSha256::new_from_slice(...).expect(...) which panics if the key slice is empty. While HMAC technically accepts any key length, the hmac crate's InvalidLength error is still reachable (e.g. zero-length secret from a misconfigured environment variable). A panic in a request-handling path crashes the process rather than returning an error.

Changes
-------
services/api/src/security.rs
  - generate_signature now returns Result<String, SigningError> instead of String. The .expect() is replaced with .map_err(|_| SigningError::InvalidKey)?.
  - New SigningError enum with a single InvalidKey variant, implementing Debug, PartialEq, Display, and std::error::Error so callers can log, match, or propagate it through standard error-handling chains.

services/api/tests/security_tests.rs
  - Existing test_request_signing: updated call site to .unwrap() (valid secret, so Ok is guaranteed; keeps the test intent unchanged).
  - generate_signature_returns_ok_for_valid_inputs: baseline Ok path.
  - generate_signature_ok_is_verifiable: Result output round-trips through verify_signature correctly.
  - generate_signature_empty_secret_returns_err: empty secret must return Err(SigningError::InvalidKey) — previously this would have panicked.
  - generate_signature_error_is_display_safe: SigningError::Display does not panic and produces a non-empty message (safe for logs/responses).
resolves #290 