### PR TITLE
fix: add winner count, boundary, and gas threshold tests

### DIFF
--- a/contracts/predict-iq/benches/gas_benchmark.rs
+++ b/contracts/predict-iq/benches/gas_benchmark.rs
@@ -1,25 +1,47 @@
 // Gas Benchmarking Tests for PredictIQ
-// Measures instruction counts and memory usage for various operations
+// Measures instruction counts and validates gas thresholds for key operations.
+//
+// CI pass/fail thresholds are enforced via assertions on `get_resolution_metrics`.
+// The gas_estimate formula is: 100_000 + (winner_count * 50_000).
+// At MAX_OUTCOMES_PER_MARKET (32) with MAX_PUSH_PAYOUT_WINNERS (50) winners,
+// the ceiling is: 100_000 + (50 * 50_000) = 2_600_000 instructions.
 
 #![cfg(test)]
 
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
-    Address, Env, String, Vec,
+    testutils::Address as _,
+    token, Address, Env, String, Vec,
 };
 
 extern crate predict_iq;
 use predict_iq::{PredictIQ, PredictIQClient};
 
+// ── Gas threshold constants (CI pass/fail gates) ──────────────────────────────
+
+/// Maximum acceptable gas estimate for a dispute/payout flow at max outcomes.
+/// Formula: 100_000 base + (MAX_PUSH_PAYOUT_WINNERS * 50_000 per winner).
+const GAS_THRESHOLD_DISPUTE_PAYOUT: u64 = 2_600_000;
+
+/// Maximum acceptable gas estimate for a single-winner resolution.
+const GAS_THRESHOLD_SINGLE_WINNER: u64 = 200_000;
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
 fn create_test_env() -> (Env, Address, PredictIQClient<'static>) {
     let env = Env::default();
     env.mock_all_auths();
+    env.budget().reset_unlimited();
 
     let contract_id = env.register_contract(None, PredictIQ);
     let client = PredictIQClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    let _ = client.initialize(&admin, &100);
+    let mut guardians = soroban_sdk::Vec::new(&env);
+    guardians.push_back(predict_iq::types::Guardian {
+        address: Address::generate(&env),
+        voting_power: 1,
+    });
+    client.initialize(&admin, &0, &guardians);
 
     (env, admin, client)
 }
@@ -37,256 +59,220 @@ fn create_oracle_config(env: &Env) -> predict_iq::types::OracleConfig {
         oracle_address: Address::generate(env),
         feed_id: String::from_str(env, "test_feed"),
         min_responses: Some(1),
+        max_staleness_seconds: 3600,
+        max_confidence_bps: 200,
     }
 }
+
+/// Create a market and return its id + token address.
+fn create_market_with_token(
+    env: &Env,
+    client: &PredictIQClient,
+    outcome_count: u32,
+) -> (u64, Address) {
+    let creator = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_id.address();
+
+    let options = create_options(env, outcome_count);
+    let oracle_config = create_oracle_config(env);
+
+    let market_id = client.create_market(
+        &creator,
+        &String::from_str(env, "Benchmark Market"),
+        &options,
+        &1000,
+        &2000,
+        &oracle_config,
+        &predict_iq::types::MarketTier::Basic,
+        &token_address,
+        &0u64,
+        &0u32,
+    );
+
+    (market_id, token_address)
+}
+
+/// Mint tokens and place a bet, returning the bettor address.
+fn place_bet(
+    env: &Env,
+    client: &PredictIQClient,
+    market_id: u64,
+    outcome: u32,
+    amount: i128,
+    token_address: &Address,
+) -> Address {
+    let bettor = Address::generate(env);
+    let stellar = token::StellarAssetClient::new(env, token_address);
+    stellar.mint(&bettor, &amount);
+    client.place_bet(&bettor, &market_id, &outcome, &amount, token_address, &None);
+    bettor
+}
+
+// ── Market creation benchmarks ────────────────────────────────────────────────
 
 #[test]
 fn bench_create_market_10_outcomes() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 10);
-    let oracle_config = create_oracle_config(&env);
-    let native_token = Address::generate(&env);
-
-    let native_token = Address::generate(&env);
+    let (env, _admin, client) = create_test_env();
     let result = client.try_create_market(
-        &admin,
+        &Address::generate(&env),
         &String::from_str(&env, "10 Outcome Market"),
-        &options,
+        &create_options(&env, 10),
         &1000,
         &2000,
-        &oracle_config,
+        &create_oracle_config(&env),
         &predict_iq::types::MarketTier::Basic,
-        &native_token,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
+        &Address::generate(&env),
+        &0u64,
+        &0u32,
     );
-
-    println!("=== 10 Outcome Market ===");
-    println!("Result: {:?}", result);
-    println!("");
-
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "10-outcome market creation must succeed");
 }
 
 #[test]
-fn bench_create_market_50_outcomes() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 50);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
+fn bench_create_market_max_outcomes() {
+    let (env, _admin, client) = create_test_env();
+    // MAX_OUTCOMES_PER_MARKET = 32
     let result = client.try_create_market(
-        &admin,
-        &String::from_str(&env, "50 Outcome Market"),
-        &options,
+        &Address::generate(&env),
+        &String::from_str(&env, "Max Outcome Market"),
+        &create_options(&env, predict_iq::types::MAX_OUTCOMES_PER_MARKET),
         &1000,
         &2000,
-        &oracle_config,
+        &create_oracle_config(&env),
         &predict_iq::types::MarketTier::Basic,
-        &native_token,
+        &Address::generate(&env),
+        &0u64,
+        &0u32,
     );
-
-    println!("=== 50 Outcome Market ===");
-    println!("Result: {:?}", result);
-    println!("");
-
-    assert!(result.is_ok());
-}
-
-#[test]
-fn bench_create_market_100_outcomes() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 100);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
-    let result = client.try_create_market(
-        &admin,
-        &String::from_str(&env, "100 Outcome Market"),
-        &options,
-        &1000,
-        &2000,
-        &oracle_config,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
-    );
-
-    println!("=== 100 Outcome Market ===");
-    println!("Result: {:?}", result);
-    println!("");
-
-    assert!(result.is_ok());
-}
-
-#[test]
-fn bench_place_multiple_bets() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 10);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
-    let market_id = client.create_market(
-        &admin,
-        &String::from_str(&env, "Bet Test Market"),
-        &options,
-        &1000,
-        &2000,
-        &oracle_config,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
-    );
-
-    let token = Address::generate(&env);
-    let bettor = Address::generate(&env);
-
-    println!("=== Multiple Bet Placement ===");
-    println!("Market ID: {}", market_id);
-
-    for i in 1..=5 {
-        let result = client.try_place_bet(&bettor, &market_id, &0, &1000, &token);
-        println!("Bet {}: {:?}", i, result);
-    }
-    println!("");
-}
-
-#[test]
-fn bench_resolve_market() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 50);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
-    let market_id = client.create_market(
-        &admin,
-        &String::from_str(&env, "Resolution Test Market"),
-        &options,
-        &1000,
-        &2000,
-        &oracle_config,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
-    );
-
-    let result = client.try_resolve_market(&market_id, &0);
-
-    println!("=== Market Resolution ===");
-    println!("Market ID: {}", market_id);
-    println!("Result: {:?}", result);
-    println!("");
-
-    assert!(result.is_ok());
-}
-
-#[test]
-fn bench_get_resolution_metrics() {
-    let (env, admin, client) = create_test_env();
-
-    let options = create_options(&env, 50);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
-    let market_id = client.create_market(
-        &admin,
-        &String::from_str(&env, "Metrics Test Market"),
-        &options,
-        &1000,
-        &2000,
-        &oracle_config,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
-    );
-
-    let _ = client.try_resolve_market(&market_id, &0);
-
-    let metrics = client.get_resolution_metrics(&market_id, &0);
-
-    println!("=== Resolution Metrics ===");
-    println!("Market ID: {}", market_id);
-    println!("Winner Count: {}", metrics.winner_count);
-    println!("Total Winning Stake: {}", metrics.total_winning_stake);
-    println!("Gas Estimate: {}", metrics.gas_estimate);
-    println!("");
+    assert!(result.is_ok(), "MAX_OUTCOMES_PER_MARKET market creation must succeed");
 }
 
 #[test]
 fn bench_reject_excessive_outcomes() {
-    let (env, admin, client) = create_test_env();
-
-    // Try to create market with 101 outcomes (should fail)
-    let options = create_options(&env, 101);
-    let oracle_config = create_oracle_config(&env);
-
-    let native_token = Address::generate(&env);
+    let (env, _admin, client) = create_test_env();
     let result = client.try_create_market(
-        &admin,
+        &Address::generate(&env),
         &String::from_str(&env, "Too Many Outcomes"),
-        &options,
+        &create_options(&env, predict_iq::types::MAX_OUTCOMES_PER_MARKET + 1),
         &1000,
         &2000,
-        &oracle_config,
+        &create_oracle_config(&env),
         &predict_iq::types::MarketTier::Basic,
-        &native_token,
+        &Address::generate(&env),
+        &0u64,
+        &0u32,
     );
-
-    println!("=== Excessive Outcomes Test ===");
-    println!("Result: {:?}", result);
-    println!("");
-
-    // Should return error
-    assert!(result.is_err());
+    assert!(result.is_err(), "exceeding MAX_OUTCOMES_PER_MARKET must be rejected");
 }
 
+// ── Gas threshold assertions for dispute/payout flows ─────────────────────────
+
+/// At max outcomes with a single winner, gas estimate must stay within threshold.
 #[test]
-fn bench_full_market_lifecycle() {
-    let (env, admin, client) = create_test_env();
+fn bench_gas_threshold_single_winner_max_outcomes() {
+    let (env, _admin, client) = create_test_env();
+    let (market_id, token_address) =
+        create_market_with_token(&env, &client, predict_iq::types::MAX_OUTCOMES_PER_MARKET);
 
-    println!("=== Full Market Lifecycle ===");
+    place_bet(&env, &client, market_id, 0, 1000, &token_address);
 
-    // Create market
-    let options = create_options(&env, 10);
-    let oracle_config = create_oracle_config(&env);
+    client.resolve_market(&market_id, &0);
 
-    let native_token = Address::generate(&env);
-    let market_id = client.create_market(
-        &admin,
-        &String::from_str(&env, "Lifecycle Test"),
-        &options,
-        &1000,
-        &2000,
-        &oracle_config,
-        &predict_iq::types::MarketTier::Basic,
-        &native_token,
-    );
-    println!("1. Market created: {}", market_id);
-
-    // Place bets
-    let token = Address::generate(&env);
-    let bettor1 = Address::generate(&env);
-    let bettor2 = Address::generate(&env);
-
-    let _ = client.try_place_bet(&bettor1, &market_id, &0, &1000, &token);
-    let _ = client.try_place_bet(&bettor2, &market_id, &1, &2000, &token);
-    println!("2. Bets placed");
-
-    // Resolve market
-    let _ = client.try_resolve_market(&market_id, &0);
-    println!("3. Market resolved");
-
-    // Get metrics
     let metrics = client.get_resolution_metrics(&market_id, &0);
-    println!(
-        "4. Metrics retrieved: {} winners, {} stake",
-        metrics.winner_count, metrics.total_winning_stake
+    assert_eq!(metrics.winner_count, 1, "must have exactly 1 winner");
+    assert!(
+        metrics.gas_estimate <= GAS_THRESHOLD_SINGLE_WINNER,
+        "single-winner gas estimate {} exceeds threshold {}",
+        metrics.gas_estimate,
+        GAS_THRESHOLD_SINGLE_WINNER
+    );
+}
+
+/// At max outcomes with MAX_PUSH_PAYOUT_WINNERS winners, gas estimate must stay
+/// within the dispute/payout threshold. This is the worst-case Push resolution.
+#[test]
+fn bench_gas_threshold_max_push_winners_max_outcomes() {
+    let (env, _admin, client) = create_test_env();
+    let (market_id, token_address) =
+        create_market_with_token(&env, &client, predict_iq::types::MAX_OUTCOMES_PER_MARKET);
+
+    let max_winners = predict_iq::types::MAX_PUSH_PAYOUT_WINNERS;
+    for _ in 0..max_winners {
+        place_bet(&env, &client, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let metrics = client.get_resolution_metrics(&market_id, &0);
+    assert_eq!(
+        metrics.winner_count, max_winners,
+        "must have exactly MAX_PUSH_PAYOUT_WINNERS winners"
+    );
+    assert!(
+        metrics.gas_estimate <= GAS_THRESHOLD_DISPUTE_PAYOUT,
+        "max-push-winners gas estimate {} exceeds CI threshold {}",
+        metrics.gas_estimate,
+        GAS_THRESHOLD_DISPUTE_PAYOUT
+    );
+}
+
+/// One winner above MAX_PUSH_PAYOUT_WINNERS triggers Pull mode.
+/// Gas estimate must still be within threshold (Pull mode doesn't iterate winners).
+#[test]
+fn bench_gas_threshold_pull_mode_triggered_at_max_outcomes() {
+    let (env, _admin, client) = create_test_env();
+    let (market_id, token_address) =
+        create_market_with_token(&env, &client, predict_iq::types::MAX_OUTCOMES_PER_MARKET);
+
+    let over_threshold = predict_iq::types::MAX_PUSH_PAYOUT_WINNERS + 1;
+    for _ in 0..over_threshold {
+        place_bet(&env, &client, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        predict_iq::types::PayoutMode::Pull,
+        "exceeding MAX_PUSH_PAYOUT_WINNERS must trigger Pull mode"
     );
 
-    // Claim winnings
-    let _ = client.try_claim_winnings(&bettor1, &market_id, &token);
-    println!("5. Winnings claimed");
+    let metrics = client.get_resolution_metrics(&market_id, &0);
+    // Gas estimate is still computed; assert it doesn't overflow u64 and is bounded.
+    let expected_max = 100_000 + (over_threshold as u64 * 50_000);
+    assert_eq!(
+        metrics.gas_estimate, expected_max,
+        "gas estimate formula must be deterministic"
+    );
+}
 
-    println!("");
+// ── Full lifecycle benchmark ──────────────────────────────────────────────────
+
+#[test]
+fn bench_full_market_lifecycle_max_outcomes() {
+    let (env, _admin, client) = create_test_env();
+    let (market_id, token_address) =
+        create_market_with_token(&env, &client, predict_iq::types::MAX_OUTCOMES_PER_MARKET);
+
+    // Place bets across multiple outcomes to stress the winner_counts map.
+    let bettor0 = place_bet(&env, &client, market_id, 0, 1000, &token_address);
+    place_bet(&env, &client, market_id, 1, 500, &token_address);
+
+    client.resolve_market(&market_id, &0);
+
+    let metrics = client.get_resolution_metrics(&market_id, &0);
+    assert_eq!(metrics.winner_count, 1);
+    assert!(
+        metrics.gas_estimate <= GAS_THRESHOLD_SINGLE_WINNER,
+        "lifecycle gas estimate {} exceeds threshold {}",
+        metrics.gas_estimate,
+        GAS_THRESHOLD_SINGLE_WINNER
+    );
+
+    // Winner claims payout.
+    let result = client.try_claim_winnings(&bettor0, &market_id);
+    assert!(result.is_ok(), "winner must be able to claim winnings");
 }

--- a/contracts/predict-iq/src/test_disputes_winner_count.rs
+++ b/contracts/predict-iq/src/test_disputes_winner_count.rs
@@ -1,0 +1,401 @@
+#![cfg(test)]
+use crate::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, Env, String, Vec};
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address, PredictIQClient<'static>) {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let admin = Address::generate(&e);
+    let contract_id = e.register_contract(None, PredictIQ);
+    let client = PredictIQClient::new(&e, &contract_id);
+    let mut guardians = Vec::new(&e);
+    guardians.push_back(types::Guardian {
+        address: Address::generate(&e),
+        voting_power: 1,
+    });
+    client.initialize(&admin, &0, &guardians);
+
+    (e, admin, contract_id, client)
+}
+
+/// Create a 2-outcome market and return (market_id, token_address).
+fn create_market(
+    client: &PredictIQClient,
+    e: &Env,
+    deadline: u64,
+    resolution_deadline: u64,
+) -> (u64, Address) {
+    let creator = Address::generate(e);
+    let token_admin = Address::generate(e);
+    let token_id = e.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_id.address();
+
+    let mut options = Vec::new(e);
+    options.push_back(String::from_str(e, "Yes"));
+    options.push_back(String::from_str(e, "No"));
+
+    let oracle_config = types::OracleConfig {
+        oracle_address: Address::generate(e),
+        feed_id: String::from_str(e, "feed"),
+        min_responses: Some(1),
+        max_staleness_seconds: 3600,
+        max_confidence_bps: 200,
+    };
+
+    let market_id = client.create_market(
+        &creator,
+        &String::from_str(e, "Test"),
+        &options,
+        &deadline,
+        &resolution_deadline,
+        &oracle_config,
+        &types::MarketTier::Basic,
+        &token_address,
+        &0u64,
+        &0u32,
+    );
+
+    (market_id, token_address)
+}
+
+/// Place a bet and return the bettor address.
+fn place_bet(
+    client: &PredictIQClient,
+    e: &Env,
+    market_id: u64,
+    outcome: u32,
+    amount: i128,
+    token_address: &Address,
+) -> Address {
+    let token_admin = Address::generate(e);
+    let token_id = e.register_stellar_asset_contract_v2(token_admin.clone());
+    // Mint on the market token, not a new one — we need the market's token.
+    // Use StellarAssetClient on the market token.
+    let bettor = Address::generate(e);
+    let stellar = token::StellarAssetClient::new(e, token_address);
+    stellar.mint(&bettor, &amount);
+    client.place_bet(&bettor, &market_id, &outcome, &amount, token_address, &None);
+    bettor
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Heuristic divergence proof: the old `tally/100` formula returns 0 for a
+/// market with 3 bettors each staking 10 tokens (total tally = 0 because
+/// voting tallies are separate from bet stakes).  The exact counter must
+/// return 3.
+///
+/// This test would have PASSED with the heuristic (returning 0 ≠ 3) and
+/// now FAILS if the exact counter is broken — proving the migration is live.
+#[test]
+fn test_exact_count_matches_actual_bettor_count_not_heuristic() {
+    let (e, _admin, _, client) = setup();
+
+    let deadline = 1000u64;
+    let resolution_deadline = 2000u64;
+    let (market_id, token_address) = create_market(&client, &e, deadline, resolution_deadline);
+
+    // 3 distinct bettors on outcome 0, each with a small stake (10 units).
+    // Old heuristic: voting_tally(outcome 0) == 0 → estimate = 0.
+    // Exact counter: winner_counts[0] == 3.
+    for _ in 0..3 {
+        place_bet(&client, &e, market_id, 0, 10, &token_address);
+    }
+
+    let metrics = client.get_resolution_metrics(&market_id, &0);
+    assert_eq!(
+        metrics.winner_count, 3,
+        "exact counter must equal the number of distinct bettors, not tally/100"
+    );
+}
+
+/// A single bettor placing multiple bets on the same outcome is counted once.
+#[test]
+fn test_repeated_bets_by_same_bettor_counted_once() {
+    let (e, _admin, _, client) = setup();
+
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    let bettor = Address::generate(&e);
+    let stellar = token::StellarAssetClient::new(&e, &token_address);
+    stellar.mint(&bettor, &300);
+
+    // Three separate place_bet calls from the same address.
+    client.place_bet(&bettor, &market_id, &0, &100, &token_address, &None);
+    client.place_bet(&bettor, &market_id, &0, &100, &token_address, &None);
+    client.place_bet(&bettor, &market_id, &0, &100, &token_address, &None);
+
+    let metrics = client.get_resolution_metrics(&market_id, &0);
+    assert_eq!(
+        metrics.winner_count, 1,
+        "same bettor placing multiple bets must still count as 1 winner"
+    );
+}
+
+/// Bets on different outcomes are tracked independently.
+#[test]
+fn test_winner_counts_are_per_outcome() {
+    let (e, _admin, _, client) = setup();
+
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // 2 bettors on outcome 0, 1 bettor on outcome 1.
+    place_bet(&client, &e, market_id, 0, 50, &token_address);
+    place_bet(&client, &e, market_id, 0, 50, &token_address);
+    place_bet(&client, &e, market_id, 1, 50, &token_address);
+
+    assert_eq!(client.get_resolution_metrics(&market_id, &0).winner_count, 2);
+    assert_eq!(client.get_resolution_metrics(&market_id, &1).winner_count, 1);
+}
+
+/// resolve_market selects Push mode when winner_count ≤ max_push_payout_winners.
+/// With the heuristic this was unreliable; with exact counting it is deterministic.
+#[test]
+fn test_resolve_market_selects_push_mode_when_winners_within_threshold() {
+    let (e, _admin, _, client) = setup();
+
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // 3 bettors on outcome 0 — well within the default threshold of 50.
+    place_bet(&client, &e, market_id, 0, 100, &token_address);
+    place_bet(&client, &e, market_id, 0, 100, &token_address);
+    place_bet(&client, &e, market_id, 0, 100, &token_address);
+
+    // Resolve as admin.
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        types::PayoutMode::Push,
+        "3 winners ≤ threshold(50) must select Push mode"
+    );
+}
+
+/// resolve_market selects Pull mode when winner_count > max_push_payout_winners.
+#[test]
+fn test_resolve_market_selects_pull_mode_when_winners_exceed_threshold() {
+    let (e, _admin, _, client) = setup();
+
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // Default threshold is 50, so place 51 distinct bettors.
+    for _ in 0..51 {
+        place_bet(&client, &e, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        types::PayoutMode::Pull,
+        "51 winners > default threshold(50) must select Pull mode"
+    );
+}
+
+/// Zero bettors on the winning outcome → winner_count is 0, Push mode selected.
+#[test]
+fn test_zero_bettors_on_winning_outcome_gives_push_mode() {
+    let (e, _admin, _, client) = setup();
+
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // Bets only on outcome 1; outcome 0 has no bettors.
+    place_bet(&client, &e, market_id, 1, 100, &token_address);
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    // 0 ≤ threshold → Push
+    assert_eq!(market.payout_mode, types::PayoutMode::Push);
+    assert_eq!(
+        client.get_resolution_metrics(&market_id, &0).winner_count,
+        0
+    );
+}
+
+// ── Issue 1: Heuristic vs exact count divergence proof ────────────────────────
+
+/// Demonstrates that the old tally/100 heuristic would return 0 for a market
+/// where 3 bettors each stake 10 tokens (total stake = 30, 30/100 = 0).
+/// The exact counter must return 3, proving the migration is live and correct.
+/// If this test fails, the exact counting path is broken.
+#[test]
+fn test_heuristic_diverges_from_exact_count_micro_bets() {
+    let (e, _admin, _, client) = setup();
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // 3 bettors, each staking 10 tokens.
+    // Old heuristic: total_stake(outcome 0) = 30 → 30 / 100 = 0 (integer division).
+    // Exact counter: winner_counts[0] = 3.
+    for _ in 0..3 {
+        place_bet(&client, &e, market_id, 0, 10, &token_address);
+    }
+
+    let exact = client.count_bets_for_outcome(&market_id, &0);
+    // Simulate what the heuristic would have returned: stake / 100
+    let stake = client.get_outcome_stake(&market_id, &0);
+    let heuristic = (stake / 100) as u32;
+
+    assert_ne!(
+        exact, heuristic,
+        "heuristic ({heuristic}) must diverge from exact count ({exact}) for micro-bet markets"
+    );
+    assert_eq!(exact, 3, "exact counter must equal the number of distinct bettors");
+    assert_eq!(heuristic, 0, "heuristic must undercount to 0 for 10-token micro-bets");
+}
+
+/// Demonstrates heuristic divergence at the boundary where stake is just below 100.
+/// 5 bettors each staking 19 tokens → total stake = 95 → heuristic = 0, exact = 5.
+#[test]
+fn test_heuristic_diverges_below_100_stake_boundary() {
+    let (e, _admin, _, client) = setup();
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    for _ in 0..5 {
+        place_bet(&client, &e, market_id, 0, 19, &token_address);
+    }
+
+    let exact = client.count_bets_for_outcome(&market_id, &0);
+    let stake = client.get_outcome_stake(&market_id, &0);
+    let heuristic = (stake / 100) as u32;
+
+    assert_ne!(exact, heuristic, "heuristic diverges: exact={exact}, heuristic={heuristic}");
+    assert_eq!(exact, 5);
+    assert_eq!(heuristic, 0);
+}
+
+// ── Issue 2: Boundary coverage for max_push_winners threshold ─────────────────
+
+/// winner_count == max_push_winners (exactly at threshold) → Push mode.
+/// The condition is `actual_winners > max_push_winners`, so equals must be Push.
+#[test]
+fn test_resolve_push_mode_when_winners_equal_threshold() {
+    let (e, _admin, _, client) = setup();
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    // Set threshold to 5 so we can test equality cheaply.
+    client.set_max_push_payout_winners(&5);
+    assert_eq!(client.get_max_push_payout_winners(), 5);
+
+    // Place exactly 5 bets (== threshold).
+    for _ in 0..5 {
+        place_bet(&client, &e, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        types::PayoutMode::Push,
+        "winner_count == threshold must select Push (condition is strictly greater-than)"
+    );
+}
+
+/// winner_count == max_push_winners - 1 (one below threshold) → Push mode.
+#[test]
+fn test_resolve_push_mode_when_winners_one_below_threshold() {
+    let (e, _admin, _, client) = setup();
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    client.set_max_push_payout_winners(&5);
+
+    // Place 4 bets (threshold - 1).
+    for _ in 0..4 {
+        place_bet(&client, &e, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        types::PayoutMode::Push,
+        "winner_count < threshold must select Push"
+    );
+}
+
+/// winner_count == max_push_winners + 1 (one above threshold) → Pull mode.
+#[test]
+fn test_resolve_pull_mode_when_winners_one_above_threshold() {
+    let (e, _admin, _, client) = setup();
+    let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+
+    client.set_max_push_payout_winners(&5);
+
+    // Place 6 bets (threshold + 1).
+    for _ in 0..6 {
+        place_bet(&client, &e, market_id, 0, 100, &token_address);
+    }
+
+    client.resolve_market(&market_id, &0);
+
+    let market = client.get_market(&market_id).unwrap();
+    assert_eq!(
+        market.payout_mode,
+        types::PayoutMode::Pull,
+        "winner_count > threshold must select Pull"
+    );
+}
+
+/// Boundary triple: verify all three cases (below, equal, above) in one sweep
+/// using a custom threshold, ensuring no off-by-one in the branch condition.
+#[test]
+fn test_threshold_boundary_all_three_cases() {
+    let threshold: u32 = 3;
+
+    // --- below threshold ---
+    {
+        let (e, _admin, _, client) = setup();
+        let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+        client.set_max_push_payout_winners(&threshold);
+        for _ in 0..(threshold - 1) {
+            place_bet(&client, &e, market_id, 0, 100, &token_address);
+        }
+        client.resolve_market(&market_id, &0);
+        assert_eq!(
+            client.get_market(&market_id).unwrap().payout_mode,
+            types::PayoutMode::Push,
+            "below threshold ({}) must be Push", threshold - 1
+        );
+    }
+
+    // --- equal to threshold ---
+    {
+        let (e, _admin, _, client) = setup();
+        let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+        client.set_max_push_payout_winners(&threshold);
+        for _ in 0..threshold {
+            place_bet(&client, &e, market_id, 0, 100, &token_address);
+        }
+        client.resolve_market(&market_id, &0);
+        assert_eq!(
+            client.get_market(&market_id).unwrap().payout_mode,
+            types::PayoutMode::Push,
+            "equal to threshold ({}) must be Push", threshold
+        );
+    }
+
+    // --- above threshold ---
+    {
+        let (e, _admin, _, client) = setup();
+        let (market_id, token_address) = create_market(&client, &e, 1000, 2000);
+        client.set_max_push_payout_winners(&threshold);
+        for _ in 0..(threshold + 1) {
+            place_bet(&client, &e, market_id, 0, 100, &token_address);
+        }
+        client.resolve_market(&market_id, &0);
+        assert_eq!(
+            client.get_market(&market_id).unwrap().payout_mode,
+            types::PayoutMode::Pull,
+            "above threshold ({}) must be Pull", threshold + 1
+        );
+    }
+}


### PR DESCRIPTION
closes #253 
closes #272 
closes #254 

Issue 1 - Heuristic vs exact count divergence:
- test_heuristic_diverges_from_exact_count_micro_bets: proves tally/100 returns 0 for 3 bettors at 10 tokens each while exact counter returns 3
- test_heuristic_diverges_below_100_stake_boundary: 5 bettors at 19 tokens each (total 95) → heuristic=0, exact=5

Issue 2 - Off-by-one boundary coverage for max_push_winners:
- test_resolve_push_mode_when_winners_equal_threshold: count == threshold → Push
- test_resolve_push_mode_when_winners_one_below_threshold: count < threshold → Push
- test_resolve_pull_mode_when_winners_one_above_threshold: count > threshold → Pull
- test_threshold_boundary_all_three_cases: sweeps below/equal/above in one test

Issue 3 - Gas threshold assertions in CI:
- Rewrote gas_benchmark.rs with correct API signatures
- bench_gas_threshold_single_winner_max_outcomes: asserts gas ≤ 200_000
- bench_gas_threshold_max_push_winners_max_outcomes: asserts gas ≤ 2_600_000 at MAX_OUTCOMES_PER_MARKET with MAX_PUSH_PAYOUT_WINNERS winners
- bench_gas_threshold_pull_mode_triggered_at_max_outcomes: verifies Pull mode triggers and gas formula is deterministic