### PR TITLE
fix: maintain consistent i128 usage for vote weight summation

### DIFF
--- a/contracts/predict-iq/src/modules/resolution.rs
+++ b/contracts/predict-iq/src/modules/resolution.rs
@@ -202,7 +202,7 @@ fn calculate_voting_outcome(e: &Env, market: &crate::types::Market) -> Result<u3
     let mut tie: bool = false;
 
     for outcome in 0..num_outcomes {
-        let tally = voting::get_tally(e, market.id, outcome);
+        let tally: i128 = voting::get_tally(e, market.id, outcome);
         total_votes += tally;
         if tally > max_votes {
             max_votes = tally;


### PR DESCRIPTION
close #167 



Explicitly annotates the tally binding as i128 in calculate_voting_outcome (resolution.rs) to ensure strict type alignment between voting::get_tally's return value and the total_votes/max_votes accumulators. Prevents any 
implicit type inference ambiguity when summing large vote weights.

Changes: contracts/predict-iq/src/modules/resolution.rs — one-line type annotation on tally binding in the outcome loop.
