### PR TITLE
fix: restrict creation deposit release to the market creator

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -290,8 +290,9 @@ impl PredictIQ {
     pub fn claim_creation_deposit(
         e: Env,
         market_id: u64,
+        caller: Address,
     ) -> Result<(), ErrorCode> {
-        crate::modules::markets::claim_creation_deposit(&e, market_id)
+        crate::modules::markets::claim_creation_deposit(&e, market_id, caller)
     }
 
     // Governance and Upgrade Functions

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -331,11 +331,15 @@ pub fn set_creation_deposit(e: &Env, amount: i128) -> Result<(), ErrorCode> {
 pub fn claim_creation_deposit(
     e: &Env,
     market_id: u64,
+    caller: soroban_sdk::Address,
 ) -> Result<(), ErrorCode> {
     let mut market = get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
-    // 1. Only the creator can claim their own deposit
-    market.creator.require_auth();
+    // Only the creator can claim their own deposit
+    if caller != market.creator {
+        return Err(ErrorCode::NotAuthorized);
+    }
+    caller.require_auth();
 
     // 2. Market must be fully resolved
     if market.status != MarketStatus::Resolved {


### PR DESCRIPTION
close #179 


markets.rs — claim_creation_deposit:
- Added caller: Address parameter
- Added an explicit caller != market.creator check returning NotAuthorized before the auth call — this rejects third-party calls with a clear error rather than letting Soroban's auth framework handle it opaquely
- caller.require_auth() then enforces the creator actually signed the transaction

lib.rs — public entrypoint:
- Added caller: Address to the public function signature, making the authorization requirement visible at the API boundary

The old code had market.creator.require_auth() which technically worked in Soroban (the creator must have signed), but the function took no caller parameter — meaning anyone could invoke it and the auth check was implicit/
hidden. The new approach makes it explicit: the caller declares who they are, we verify it matches the creator, then require their signature.