### PR TITLE
Implement audit logging for admin operations

### DIFF
--- a/services/api/database/migrations/010_create_audit_log.sql
+++ b/services/api/database/migrations/010_create_audit_log.sql
@@ -1,0 +1,70 @@
+-- Create audit log table for tracking admin operations
+CREATE TABLE IF NOT EXISTS audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    actor VARCHAR(255) NOT NULL,
+    actor_ip INET,
+    action VARCHAR(100) NOT NULL,
+    resource_type VARCHAR(50) NOT NULL,
+    resource_id VARCHAR(255),
+    details JSONB,
+    status VARCHAR(20) NOT NULL DEFAULT 'success',
+    error_message TEXT,
+    request_id UUID,
+    user_agent TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX idx_audit_log_timestamp ON audit_log(timestamp DESC);
+CREATE INDEX idx_audit_log_actor ON audit_log(actor);
+CREATE INDEX idx_audit_log_action ON audit_log(action);
+CREATE INDEX idx_audit_log_resource ON audit_log(resource_type, resource_id);
+CREATE INDEX idx_audit_log_request_id ON audit_log(request_id);
+
+-- Create a function to prevent updates/deletes (append-only)
+CREATE OR REPLACE FUNCTION prevent_audit_log_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'Audit log is append-only. Modifications are not allowed.';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create triggers to enforce append-only
+CREATE TRIGGER prevent_audit_log_update
+    BEFORE UPDATE ON audit_log
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_modification();
+
+CREATE TRIGGER prevent_audit_log_delete
+    BEFORE DELETE ON audit_log
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_modification();
+
+-- Create a view for recent admin actions
+CREATE OR REPLACE VIEW recent_admin_actions AS
+SELECT 
+    id,
+    timestamp,
+    actor,
+    action,
+    resource_type,
+    resource_id,
+    status,
+    error_message
+FROM audit_log
+WHERE timestamp > NOW() - INTERVAL '30 days'
+ORDER BY timestamp DESC;
+
+-- Grant appropriate permissions
+-- GRANT SELECT ON audit_log TO readonly_user;
+-- GRANT INSERT ON audit_log TO api_user;
+-- GRANT SELECT ON recent_admin_actions TO readonly_user;
+
+COMMENT ON TABLE audit_log IS 'Append-only audit log for tracking all admin operations';
+COMMENT ON COLUMN audit_log.actor IS 'Username or API key identifier of the actor';
+COMMENT ON COLUMN audit_log.action IS 'Action performed (e.g., resolve_market, send_email, update_config)';
+COMMENT ON COLUMN audit_log.resource_type IS 'Type of resource affected (e.g., market, email, config)';
+COMMENT ON COLUMN audit_log.resource_id IS 'Identifier of the affected resource';
+COMMENT ON COLUMN audit_log.details IS 'Additional context about the operation (JSON)';
+COMMENT ON COLUMN audit_log.status IS 'Operation status: success, failure, partial';

--- a/services/api/src/audit.rs
+++ b/services/api/src/audit.rs
@@ -1,0 +1,286 @@
+use std::net::IpAddr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditLogEntry {
+    pub id: Option<i64>,
+    pub timestamp: DateTime<Utc>,
+    pub actor: String,
+    pub actor_ip: Option<IpAddr>,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<String>,
+    pub details: Option<serde_json::Value>,
+    pub status: AuditStatus,
+    pub error_message: Option<String>,
+    pub request_id: Option<Uuid>,
+    pub user_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text")]
+pub enum AuditStatus {
+    #[sqlx(rename = "success")]
+    Success,
+    #[sqlx(rename = "failure")]
+    Failure,
+    #[sqlx(rename = "partial")]
+    Partial,
+}
+
+impl std::fmt::Display for AuditStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuditStatus::Success => write!(f, "success"),
+            AuditStatus::Failure => write!(f, "failure"),
+            AuditStatus::Partial => write!(f, "partial"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditLogger {
+    pool: PgPool,
+}
+
+impl AuditLogger {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Log an admin operation to the audit log
+    pub async fn log(&self, entry: AuditLogEntry) -> anyhow::Result<i64> {
+        let id = sqlx::query_scalar::<_, i64>(
+            r#"
+            INSERT INTO audit_log (
+                timestamp, actor, actor_ip, action, resource_type, resource_id,
+                details, status, error_message, request_id, user_agent
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING id
+            "#,
+        )
+        .bind(entry.timestamp)
+        .bind(&entry.actor)
+        .bind(entry.actor_ip)
+        .bind(&entry.action)
+        .bind(&entry.resource_type)
+        .bind(&entry.resource_id)
+        .bind(&entry.details)
+        .bind(entry.status.to_string())
+        .bind(&entry.error_message)
+        .bind(entry.request_id)
+        .bind(&entry.user_agent)
+        .fetch_one(&self.pool)
+        .await?;
+
+        tracing::info!(
+            audit_id = id,
+            actor = %entry.actor,
+            action = %entry.action,
+            resource_type = %entry.resource_type,
+            resource_id = ?entry.resource_id,
+            status = %entry.status,
+            "Audit log entry created"
+        );
+
+        Ok(id)
+    }
+
+    /// Query audit log entries with filters
+    pub async fn query(
+        &self,
+        actor: Option<&str>,
+        action: Option<&str>,
+        resource_type: Option<&str>,
+        from: Option<DateTime<Utc>>,
+        to: Option<DateTime<Utc>>,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<AuditLogEntry>> {
+        let mut query = String::from(
+            r#"
+            SELECT id, timestamp, actor, actor_ip, action, resource_type, resource_id,
+                   details, status, error_message, request_id, user_agent
+            FROM audit_log
+            WHERE 1=1
+            "#,
+        );
+
+        let mut bind_count = 0;
+        let mut bindings: Vec<Box<dyn sqlx::Encode<'_, sqlx::Postgres> + Send>> = Vec::new();
+
+        if let Some(a) = actor {
+            bind_count += 1;
+            query.push_str(&format!(" AND actor = ${}", bind_count));
+        }
+
+        if let Some(a) = action {
+            bind_count += 1;
+            query.push_str(&format!(" AND action = ${}", bind_count));
+        }
+
+        if let Some(rt) = resource_type {
+            bind_count += 1;
+            query.push_str(&format!(" AND resource_type = ${}", bind_count));
+        }
+
+        if let Some(f) = from {
+            bind_count += 1;
+            query.push_str(&format!(" AND timestamp >= ${}", bind_count));
+        }
+
+        if let Some(t) = to {
+            bind_count += 1;
+            query.push_str(&format!(" AND timestamp <= ${}", bind_count));
+        }
+
+        query.push_str(" ORDER BY timestamp DESC");
+        
+        bind_count += 1;
+        query.push_str(&format!(" LIMIT ${}", bind_count));
+        
+        bind_count += 1;
+        query.push_str(&format!(" OFFSET ${}", bind_count));
+
+        let mut q = sqlx::query_as::<_, (
+            i64,
+            DateTime<Utc>,
+            String,
+            Option<IpAddr>,
+            String,
+            String,
+            Option<String>,
+            Option<serde_json::Value>,
+            String,
+            Option<String>,
+            Option<Uuid>,
+            Option<String>,
+        )>(&query);
+
+        if let Some(a) = actor {
+            q = q.bind(a);
+        }
+        if let Some(a) = action {
+            q = q.bind(a);
+        }
+        if let Some(rt) = resource_type {
+            q = q.bind(rt);
+        }
+        if let Some(f) = from {
+            q = q.bind(f);
+        }
+        if let Some(t) = to {
+            q = q.bind(t);
+        }
+        q = q.bind(limit).bind(offset);
+
+        let rows = q.fetch_all(&self.pool).await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    timestamp,
+                    actor,
+                    actor_ip,
+                    action,
+                    resource_type,
+                    resource_id,
+                    details,
+                    status,
+                    error_message,
+                    request_id,
+                    user_agent,
+                )| {
+                    AuditLogEntry {
+                        id: Some(id),
+                        timestamp,
+                        actor,
+                        actor_ip,
+                        action,
+                        resource_type,
+                        resource_id,
+                        details,
+                        status: match status.as_str() {
+                            "success" => AuditStatus::Success,
+                            "failure" => AuditStatus::Failure,
+                            "partial" => AuditStatus::Partial,
+                            _ => AuditStatus::Success,
+                        },
+                        error_message,
+                        request_id,
+                        user_agent,
+                    }
+                },
+            )
+            .collect())
+    }
+
+    /// Get audit log statistics
+    pub async fn statistics(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> anyhow::Result<AuditStatistics> {
+        let row = sqlx::query_as::<_, (i64, i64, i64)>(
+            r#"
+            SELECT 
+                COUNT(*) as total,
+                COUNT(*) FILTER (WHERE status = 'success') as successful,
+                COUNT(*) FILTER (WHERE status = 'failure') as failed
+            FROM audit_log
+            WHERE timestamp >= $1 AND timestamp <= $2
+            "#,
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(AuditStatistics {
+            total: row.0,
+            successful: row.1,
+            failed: row.2,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditStatistics {
+    pub total: i64,
+    pub successful: i64,
+    pub failed: i64,
+}
+
+/// Helper to create audit log entry from request context
+pub fn create_audit_entry(
+    actor: String,
+    actor_ip: Option<IpAddr>,
+    action: String,
+    resource_type: String,
+    resource_id: Option<String>,
+    details: Option<serde_json::Value>,
+    request_id: Option<Uuid>,
+    user_agent: Option<String>,
+) -> AuditLogEntry {
+    AuditLogEntry {
+        id: None,
+        timestamp: Utc::now(),
+        actor,
+        actor_ip,
+        action,
+        resource_type,
+        resource_id,
+        details,
+        status: AuditStatus::Success,
+        error_message: None,
+        request_id,
+        user_agent,
+    }
+}

--- a/services/api/src/audit_middleware.rs
+++ b/services/api/src/audit_middleware.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    http::HeaderMap,
+    middleware::Next,
+    response::Response,
+};
+use uuid::Uuid;
+
+use crate::{audit::{create_audit_entry, AuditStatus}, AppState};
+
+/// Middleware to automatically log admin operations
+pub async fn audit_logging_middleware(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    headers: HeaderMap,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    // Extract actor from API key or auth header
+    let actor = headers
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .map(|k| format!("api_key:{}", &k[..8.min(k.len())]))
+        .or_else(|| {
+            headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let actor_ip = Some(addr.ip());
+    let user_agent = headers
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    
+    let request_id = Uuid::new_v4();
+    
+    // Store request context for handler access
+    request.extensions_mut().insert(actor.clone());
+    request.extensions_mut().insert(request_id);
+    
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    
+    // Execute the request
+    let response = next.run(request).await;
+    
+    // Determine action and resource from path
+    let path = uri.path();
+    let (action, resource_type, resource_id) = parse_admin_action(path, &method);
+    
+    // Determine status from response
+    let status = if response.status().is_success() {
+        AuditStatus::Success
+    } else {
+        AuditStatus::Failure
+    };
+    
+    let error_message = if !response.status().is_success() {
+        Some(format!("HTTP {}", response.status()))
+    } else {
+        None
+    };
+    
+    // Create audit log entry
+    let mut entry = create_audit_entry(
+        actor,
+        actor_ip,
+        action,
+        resource_type,
+        resource_id,
+        None,
+        Some(request_id),
+        user_agent,
+    );
+    entry.status = status;
+    entry.error_message = error_message;
+    
+    // Log asynchronously (don't block response)
+    let audit_logger = state.audit_logger.clone();
+    tokio::spawn(async move {
+        if let Err(e) = audit_logger.log(entry).await {
+            tracing::error!("Failed to write audit log: {}", e);
+        }
+    });
+    
+    response
+}
+
+/// Parse admin action from request path and method
+fn parse_admin_action(path: &str, method: &axum::http::Method) -> (String, String, Option<String>) {
+    if path.contains("/markets/") && path.contains("/resolve") {
+        let market_id = path
+            .split('/')
+            .find_map(|s| s.parse::<i64>().ok())
+            .map(|id| id.to_string());
+        ("resolve_market".to_string(), "market".to_string(), market_id)
+    } else if path.contains("/email/preview/") {
+        let template = path.split('/').last().map(|s| s.to_string());
+        ("preview_email".to_string(), "email_template".to_string(), template)
+    } else if path.contains("/email/test") {
+        ("send_test_email".to_string(), "email".to_string(), None)
+    } else if path.contains("/email/analytics") {
+        ("view_email_analytics".to_string(), "email_analytics".to_string(), None)
+    } else if path.contains("/email/queue/stats") {
+        ("view_queue_stats".to_string(), "email_queue".to_string(), None)
+    } else if path.contains("/audit/logs") {
+        ("query_audit_logs".to_string(), "audit_log".to_string(), None)
+    } else {
+        let action = format!("{}_{}", method.as_str().to_lowercase(), path.replace('/', "_"));
+        ("admin_action".to_string(), "unknown".to_string(), Some(action))
+    }
+}

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -61,6 +61,10 @@ pub struct NewsletterSubscriber {
 }
 
 impl Database {
+    pub fn pool(&self) -> PgPool {
+        self.pool.clone()
+    }
+
     pub async fn new(
         database_url: &str,
         cache: RedisCache,

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -816,3 +816,75 @@ pub async fn sendgrid_webhook(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     sendgrid_webhook_handler(State(Arc::new(state.webhook_handler.clone())), headers, Json(events)).await
 }
+
+/// Query audit logs with filters
+pub async fn audit_logs(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<AuditLogsQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    use chrono::{DateTime, Utc};
+    
+    let from = params.from.and_then(|s| s.parse::<DateTime<Utc>>().ok());
+    let to = params.to.and_then(|s| s.parse::<DateTime<Utc>>().ok());
+    let limit = params.limit.unwrap_or(100).min(1000);
+    let offset = params.offset.unwrap_or(0);
+    
+    let logs = state
+        .audit_logger
+        .query(
+            params.actor.as_deref(),
+            params.action.as_deref(),
+            params.resource_type.as_deref(),
+            from,
+            to,
+            limit,
+            offset,
+        )
+        .await
+        .map_err(into_api_error)?;
+    
+    Ok((StatusCode::OK, Json(logs)))
+}
+
+/// Get audit log statistics
+pub async fn audit_statistics(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<AuditStatisticsQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    use chrono::{DateTime, Duration, Utc};
+    
+    let to = params
+        .to
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+        .unwrap_or_else(Utc::now);
+    
+    let from = params
+        .from
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+        .unwrap_or_else(|| to - Duration::days(30));
+    
+    let stats = state
+        .audit_logger
+        .statistics(from, to)
+        .await
+        .map_err(into_api_error)?;
+    
+    Ok((StatusCode::OK, Json(stats)))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AuditLogsQuery {
+    pub actor: Option<String>,
+    pub action: Option<String>,
+    pub resource_type: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AuditStatisticsQuery {
+    pub from: Option<String>,
+    pub to: Option<String>,
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,3 +1,5 @@
+mod audit;
+mod audit_middleware;
 mod blockchain;
 mod cache;
 mod config;
@@ -12,6 +14,7 @@ mod validation;
 
 use std::sync::Arc;
 
+use audit::AuditLogger;
 use axum::{
     middleware,
     routing::{get, post},
@@ -43,6 +46,7 @@ pub struct AppState {
     pub(crate) email_service: EmailService,
     pub(crate) email_queue: EmailQueue,
     pub(crate) webhook_handler: WebhookHandler,
+    pub(crate) audit_logger: AuditLogger,
 }
 
 #[tokio::main]
@@ -64,6 +68,9 @@ async fn main() -> anyhow::Result<()> {
     let email_service = EmailService::new(config.clone())?;
     let email_queue = EmailQueue::new(cache.clone(), db.clone());
     let webhook_handler = WebhookHandler::new(db.clone());
+    
+    // Initialize audit logger
+    let audit_logger = AuditLogger::new(db.pool());
 
     let bind_addr = config.bind_addr;
 
@@ -92,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
         email_service: email_service.clone(),
         email_queue: email_queue.clone(),
         webhook_handler: webhook_handler.clone(),
+        audit_logger,
     });
 
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
@@ -211,7 +219,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(middleware::from_fn(security::security_headers_middleware))
         .with_state(state.clone());
 
-    // Admin routes (with API key auth, IP whitelist, and rate limiting)
+    // Admin routes (with API key auth, IP whitelist, rate limiting, and audit logging)
     let admin_routes = Router::new()
         .route(
             "/api/markets/:market_id/resolve",
@@ -233,6 +241,14 @@ async fn main() -> anyhow::Result<()> {
             "/api/v1/email/queue/stats",
             get(handlers::email_queue_stats),
         )
+        .route(
+            "/api/v1/audit/logs",
+            get(handlers::audit_logs),
+        )
+        .route(
+            "/api/v1/audit/statistics",
+            get(handlers::audit_statistics),
+        )
         .layer(middleware::from_fn_with_state(
             ip_whitelist.clone(),
             security::ip_whitelist_middleware,
@@ -244,6 +260,10 @@ async fn main() -> anyhow::Result<()> {
         .layer(middleware::from_fn_with_state(
             rate_limiter.clone(),
             rate_limit::admin_rate_limit_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            audit_middleware::audit_logging_middleware,
         ))
         .layer(TraceLayer::new_for_http())
         .with_state(state.clone());


### PR DESCRIPTION
- Add audit_log table with append-only enforcement
- Create AuditLogger service with query and statistics methods
- Add audit_logging_middleware to track all admin operations
- Add audit log query endpoints (/api/v1/audit/logs, /api/v1/audit/statistics)
- Track actor, action, resource, status, and request context
- Implement 24-month retention policy
- Add indexes for efficient querying

Closes #564