### PR TITLE
Implement contract fee treasury management

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -138,6 +138,18 @@ impl PredictIQ {
         crate::modules::fees::get_revenue(&e, token)
     }
 
+    pub fn set_fee_admin(e: Env, fee_admin: Address) -> Result<(), ErrorCode> {
+        crate::modules::fees::set_fee_admin(&e, fee_admin)
+    }
+
+    pub fn withdraw_protocol_fees(
+        e: Env,
+        token: Address,
+        recipient: Address,
+    ) -> Result<i128, ErrorCode> {
+        crate::modules::fees::withdraw_protocol_fees(&e, &token, &recipient)
+    }
+
     pub fn claim_referral_rewards(
         e: Env,
         address: Address,

--- a/contracts/predict-iq/src/modules/fees.rs
+++ b/contracts/predict-iq/src/modules/fees.rs
@@ -1,6 +1,6 @@
 use crate::errors::ErrorCode;
 use crate::modules::admin;
-use crate::types::{ConfigKey, MarketTier, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD};
+use crate::types::{ConfigKey, MarketTier, TTL_HIGH_THRESHOLD, TTL_LOW_THRESHOLD};
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 const BPS_DENOMINATOR: i128 = 10_000;
@@ -17,7 +17,7 @@ pub enum DataKey {
 fn bump_config_ttl(e: &Env, key: &ConfigKey) {
     e.storage()
         .persistent()
-        .extend_ttl(key, GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD);
+        .extend_ttl(key, TTL_LOW_THRESHOLD, TTL_HIGH_THRESHOLD);
 }
 
 pub fn get_base_fee(e: &Env) -> i128 {


### PR DESCRIPTION
- Add treasury withdrawal functionality with admin authorization
- Expose set_fee_admin and withdraw_protocol_fees in contract interface
- Treasury balance is queryable via get_revenue
- Withdrawal events are emitted
- Fix TTL constant imports (use TTL_* instead of GOV_TTL_*)

Closes #558