### PR TITLE
Implement contract guardian multisig

### DIFF
--- a/contracts/predict-iq/src/errors.rs
+++ b/contracts/predict-iq/src/errors.rs
@@ -47,4 +47,7 @@ pub enum ErrorCode {
     InsufficientVotingWeight = 140,
     MarketNotCancelled = 141,
     BetNotFound = 142,
+    UpgradeAlreadyPending = 143,
+    UpgradeHashInCooldown = 144,
+    InvalidAmount = 145,
 }

--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -231,11 +231,15 @@ impl PredictIQ {
         crate::modules::governance::remove_guardian(&e, address)
     }
 
+    pub fn vote_on_guardian_removal(e: Env, voter: Address, approve: bool) -> Result<(), ErrorCode> {
+        crate::modules::governance::vote_on_guardian_removal(&e, voter, approve)
+    }
+
     pub fn get_guardians(e: Env) -> Vec<crate::types::Guardian> {
         crate::modules::governance::get_guardians(&e)
     }
 
-    pub fn initiate_upgrade(e: Env, wasm_hash: String) -> Result<(), ErrorCode> {
+    pub fn initiate_upgrade(e: Env, wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ErrorCode> {
         crate::modules::governance::initiate_upgrade(&e, wasm_hash)
     }
 
@@ -243,7 +247,7 @@ impl PredictIQ {
         crate::modules::governance::vote_for_upgrade(&e, voter, vote_for)
     }
 
-    pub fn execute_upgrade(e: Env) -> Result<String, ErrorCode> {
+    pub fn execute_upgrade(e: Env) -> Result<(), ErrorCode> {
         crate::modules::governance::execute_upgrade(&e)
     }
 
@@ -251,12 +255,20 @@ impl PredictIQ {
         crate::modules::governance::get_pending_upgrade(&e)
     }
 
-    pub fn get_upgrade_votes(e: Env) -> Result<(u32, u32), ErrorCode> {
+    pub fn get_upgrade_votes(e: Env) -> Result<crate::types::UpgradeVoteStats, ErrorCode> {
         crate::modules::governance::get_upgrade_votes(&e)
     }
 
     pub fn is_timelock_satisfied(e: Env) -> Result<bool, ErrorCode> {
         crate::modules::governance::is_timelock_satisfied(&e)
+    }
+
+    pub fn set_timelock_duration(e: Env, seconds: u64) -> Result<(), ErrorCode> {
+        crate::modules::governance::set_timelock_duration(&e, seconds)
+    }
+
+    pub fn get_timelock_duration(e: Env) -> u64 {
+        crate::modules::governance::get_timelock_duration(&e)
     }
 
     /// Prune (archive) a resolved market after 30 days grace period

--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -1,6 +1,6 @@
 use crate::errors::ErrorCode;
 use crate::types::{
-    ConfigKey, Guardian, PendingUpgrade, GOV_TTL_HIGH_THRESHOLD, GOV_TTL_LOW_THRESHOLD,
+    ConfigKey, Guardian, PendingUpgrade, TTL_HIGH_THRESHOLD, TTL_LOW_THRESHOLD,
     MAJORITY_THRESHOLD_PERCENT, TIMELOCK_DURATION, TIMELOCK_MIN_SECONDS, TIMELOCK_MAX_SECONDS,
     UPGRADE_COOLDOWN_DURATION,
 };
@@ -11,7 +11,7 @@ use soroban_sdk::{Address, BytesN, Env, Vec};
 fn bump_gov_ttl(e: &Env, key: &ConfigKey) {
     e.storage()
         .persistent()
-        .extend_ttl(key, GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD);
+        .extend_ttl(key, TTL_LOW_THRESHOLD, TTL_HIGH_THRESHOLD);
 }
 
 /// Initialize the GuardianSet with a list of guardians and their voting power.
@@ -98,7 +98,7 @@ pub fn remove_guardian(e: &Env, address: Address) -> Result<(), ErrorCode> {
 
     // Initiate removal proposal
     let pending_removal = crate::types::PendingGuardianRemoval {
-        target_guardian: address.clone(),
+        address: address.clone(),
         initiated_at: e.ledger().timestamp(),
         votes_for: Vec::new(e),
     };
@@ -151,7 +151,7 @@ pub fn vote_on_guardian_removal(e: &Env, voter: Address, approve: bool) -> Resul
         // Majority reached, execute removal
         let mut new_guardians: Vec<Guardian> = Vec::new(e);
         for g in guardians.iter() {
-            if g.address != pending_removal.target_guardian {
+            if g.address != pending_removal.address {
                 new_guardians.push_back(g.clone());
             }
         }
@@ -391,9 +391,9 @@ pub fn execute_upgrade(e: &Env) -> Result<(), ErrorCode> {
 }
 
 /// Get vote statistics for the pending upgrade.
-pub fn get_upgrade_votes(e: &Env) -> Result<crate::types::UpgradeStats, ErrorCode> {
+pub fn get_upgrade_votes(e: &Env) -> Result<crate::types::UpgradeVoteStats, ErrorCode> {
     let pending_upgrade = get_pending_upgrade(e).ok_or(ErrorCode::UpgradeNotInitiated)?;
-    Ok(crate::types::UpgradeStats {
+    Ok(crate::types::UpgradeVoteStats {
         votes_for: pending_upgrade.votes_for.len() as u32,
         votes_against: pending_upgrade.votes_against.len() as u32,
     })

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -114,6 +114,8 @@ pub enum ConfigKey {
     PendingUpgrade,
     UpgradeVotes,
     TimelockDuration,
+    PendingGuardianRemoval,
+    UpgradeRejectedAt(soroban_sdk::BytesN<32>),
 }
 
 #[contracttype]
@@ -136,7 +138,7 @@ pub struct Guardian {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingUpgrade {
-    pub wasm_hash: String,
+    pub wasm_hash: soroban_sdk::BytesN<32>,
     pub initiated_at: u64,
     pub votes_for: Vec<Address>,
     pub votes_against: Vec<Address>,
@@ -147,14 +149,14 @@ pub const TIMELOCK_DURATION: u64 = 48 * 60 * 60; // 48 hours in seconds
 pub const TIMELOCK_MIN_SECONDS: u64 = 3600; // 1 hour minimum
 pub const TIMELOCK_MAX_SECONDS: u64 = 7 * 24 * 3600; // 7 days maximum
 pub const MAJORITY_THRESHOLD_PERCENT: u32 = 51; // 51% for majority
+pub const UPGRADE_COOLDOWN_DURATION: u64 = 7 * 24 * 3600; // 7 days cooldown for rejected upgrades
 
-// Governance stats and pending removal types
+// Governance stats type for vote counting
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UpgradeStats {
-    pub total_upgrades: u32,
-    pub last_upgrade_at: u64,
-    pub last_wasm_hash: String,
+pub struct UpgradeVoteStats {
+    pub votes_for: u32,
+    pub votes_against: u32,
 }
 
 #[contracttype]


### PR DESCRIPTION
- Guardian actions require M-of-N signatures via voting mechanism
- Add vote_on_guardian_removal for guardian rotation with majority consensus
- Multisig configuration is admin-controlled via add_guardian/remove_guardian
- Guardian rotation supported through voting process
- Add configurable timelock duration with set_timelock_duration
- Fix PendingUpgrade to use BytesN<32> for wasm_hash (proper type)
- Add UpgradeVoteStats type for vote counting
- Add missing error codes: UpgradeAlreadyPending, UpgradeHashInCooldown, InvalidAmount
- Add ConfigKey variants: PendingGuardianRemoval, UpgradeRejectedAt
- Add UPGRADE_COOLDOWN_DURATION constant (7 days)
- Fix TTL constant imports throughout governance module

Closes #560