### PR TITLE
feat: add blockchain event replay (#110) and complete contract upgrad…

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -235,7 +235,7 @@ impl PredictIQ {
         crate::modules::governance::get_guardians(&e)
     }
 
-    pub fn initiate_upgrade(e: Env, wasm_hash: String) -> Result<(), ErrorCode> {
+    pub fn initiate_upgrade(e: Env, wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), ErrorCode> {
         crate::modules::governance::initiate_upgrade(&e, wasm_hash)
     }
 
@@ -243,7 +243,7 @@ impl PredictIQ {
         crate::modules::governance::vote_for_upgrade(&e, voter, vote_for)
     }
 
-    pub fn execute_upgrade(e: Env) -> Result<String, ErrorCode> {
+    pub fn execute_upgrade(e: Env) -> Result<soroban_sdk::BytesN<32>, ErrorCode> {
         crate::modules::governance::execute_upgrade(&e)
     }
 
@@ -257,6 +257,26 @@ impl PredictIQ {
 
     pub fn is_timelock_satisfied(e: Env) -> Result<bool, ErrorCode> {
         crate::modules::governance::is_timelock_satisfied(&e)
+    }
+
+    pub fn vote_on_guardian_removal(
+        e: Env,
+        voter: Address,
+        approve: bool,
+    ) -> Result<(), ErrorCode> {
+        crate::modules::governance::vote_on_guardian_removal(&e, voter, approve)
+    }
+
+    pub fn get_timelock_duration(e: Env) -> u64 {
+        crate::modules::governance::get_timelock_duration(&e)
+    }
+
+    pub fn set_timelock_duration(e: Env, seconds: u64) -> Result<(), ErrorCode> {
+        crate::modules::governance::set_timelock_duration(&e, seconds)
+    }
+
+    pub fn emergency_pause(e: Env, voter: Address) -> Result<(), ErrorCode> {
+        crate::modules::governance::emergency_pause(&e, voter)
     }
 
     /// Prune (archive) a resolved market after 30 days grace period

--- a/contracts/predict-iq/src/modules/events.rs
+++ b/contracts/predict-iq/src/modules/events.rs
@@ -193,3 +193,31 @@ pub fn emit_monitoring_state_reset(
         (previous_error_count, previous_last_observation),
     );
 }
+
+pub fn emit_upgrade_initiated(e: &Env, initiator: Address, wasm_hash: soroban_sdk::BytesN<32>) {
+    e.events().publish(
+        (symbol_short!("upg_init"), initiator),
+        wasm_hash,
+    );
+}
+
+pub fn emit_upgrade_voted(e: &Env, voter: Address, vote_for: bool) {
+    e.events().publish(
+        (symbol_short!("upg_vote"), voter),
+        vote_for,
+    );
+}
+
+pub fn emit_upgrade_executed(e: &Env, executor: Address, wasm_hash: soroban_sdk::BytesN<32>) {
+    e.events().publish(
+        (symbol_short!("upg_exec"), executor),
+        wasm_hash,
+    );
+}
+
+pub fn emit_upgrade_rejected(e: &Env, wasm_hash: soroban_sdk::BytesN<32>) {
+    e.events().publish(
+        (symbol_short!("upg_rej"),),
+        wasm_hash,
+    );
+}

--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -202,6 +202,10 @@ pub fn initiate_upgrade(e: &Env, wasm_hash: BytesN<32>) -> Result<(), ErrorCode>
         .persistent()
         .set(&ConfigKey::PendingUpgrade, &pending_upgrade);
     bump_gov_ttl(e, &ConfigKey::PendingUpgrade);
+
+    let admin = crate::modules::admin::get_admin(e).unwrap_or(e.current_contract_address());
+    crate::modules::events::emit_upgrade_initiated(e, admin, wasm_hash);
+
     Ok(())
 }
 
@@ -292,6 +296,9 @@ pub fn vote_for_upgrade(e: &Env, voter: Address, vote_for: bool) -> Result<bool,
         .persistent()
         .set(&ConfigKey::PendingUpgrade, &pending_upgrade);
     bump_gov_ttl(e, &ConfigKey::PendingUpgrade);
+
+    crate::modules::events::emit_upgrade_voted(e, voter, vote_for);
+
     Ok(true)
 }
 
@@ -362,7 +369,7 @@ fn is_majority_met(e: &Env, pending_upgrade: &PendingUpgrade) -> bool {
 
 /// Execute the upgrade if timelock is satisfied and majority voted in favor.
 /// This directly invokes the Soroban host upgrade function.
-pub fn execute_upgrade(e: &Env) -> Result<(), ErrorCode> {
+pub fn execute_upgrade(e: &Env) -> Result<BytesN<32>, ErrorCode> {
     // Verify timelock has passed
     if !is_timelock_satisfied(e)? {
         return Err(ErrorCode::TimelockActive);
@@ -372,9 +379,9 @@ pub fn execute_upgrade(e: &Env) -> Result<(), ErrorCode> {
 
     // Verify majority vote
     if !is_majority_met(e, &pending_upgrade) {
-        // A failed execution after the timelock is treated as a governance rejection.
         set_upgrade_rejected_at(e, &pending_upgrade.wasm_hash);
         e.storage().persistent().remove(&ConfigKey::PendingUpgrade);
+        crate::modules::events::emit_upgrade_rejected(e, pending_upgrade.wasm_hash);
         return Err(ErrorCode::InsufficientVotes);
     }
 
@@ -384,19 +391,22 @@ pub fn execute_upgrade(e: &Env) -> Result<(), ErrorCode> {
     e.storage().persistent().remove(&ConfigKey::PendingUpgrade);
     clear_upgrade_rejected_at(e, &wasm_hash);
 
-    // Execute host-level contract code upgrade.
-    e.deployer().update_current_contract_wasm(wasm_hash);
+    let executor = crate::modules::admin::get_admin(e).unwrap_or(e.current_contract_address());
+    crate::modules::events::emit_upgrade_executed(e, executor, wasm_hash.clone());
 
-    Ok(())
+    // Execute host-level contract code upgrade.
+    e.deployer().update_current_contract_wasm(wasm_hash.clone());
+
+    Ok(wasm_hash)
 }
 
 /// Get vote statistics for the pending upgrade.
-pub fn get_upgrade_votes(e: &Env) -> Result<crate::types::UpgradeStats, ErrorCode> {
+pub fn get_upgrade_votes(e: &Env) -> Result<(u32, u32), ErrorCode> {
     let pending_upgrade = get_pending_upgrade(e).ok_or(ErrorCode::UpgradeNotInitiated)?;
-    Ok(crate::types::UpgradeStats {
-        votes_for: pending_upgrade.votes_for.len() as u32,
-        votes_against: pending_upgrade.votes_against.len() as u32,
-    })
+    Ok((
+        pending_upgrade.votes_for.len() as u32,
+        pending_upgrade.votes_against.len() as u32,
+    ))
 }
 
 /// Emergency pause triggered by 2/3 Guardian majority (community panic override)

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Map, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Map, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -114,6 +114,8 @@ pub enum ConfigKey {
     PendingUpgrade,
     UpgradeVotes,
     TimelockDuration,
+    PendingGuardianRemoval,
+    UpgradeRejectedAt(BytesN<32>),
 }
 
 #[contracttype]
@@ -136,7 +138,7 @@ pub struct Guardian {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingUpgrade {
-    pub wasm_hash: String,
+    pub wasm_hash: BytesN<32>,
     pub initiated_at: u64,
     pub votes_for: Vec<Address>,
     pub votes_against: Vec<Address>,
@@ -147,20 +149,20 @@ pub const TIMELOCK_DURATION: u64 = 48 * 60 * 60; // 48 hours in seconds
 pub const TIMELOCK_MIN_SECONDS: u64 = 3600; // 1 hour minimum
 pub const TIMELOCK_MAX_SECONDS: u64 = 7 * 24 * 3600; // 7 days maximum
 pub const MAJORITY_THRESHOLD_PERCENT: u32 = 51; // 51% for majority
+pub const UPGRADE_COOLDOWN_DURATION: u64 = 24 * 60 * 60; // 24 hours cooldown after rejection
 
 // Governance stats and pending removal types
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpgradeStats {
-    pub total_upgrades: u32,
-    pub last_upgrade_at: u64,
-    pub last_wasm_hash: String,
+    pub votes_for: u32,
+    pub votes_against: u32,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingGuardianRemoval {
-    pub address: Address,
+    pub target_guardian: Address,
     pub initiated_at: u64,
     pub votes_for: Vec<Address>,
 }
@@ -169,3 +171,7 @@ pub struct PendingGuardianRemoval {
 pub const TTL_LOW_THRESHOLD: u32 = 17_280; // ~1 day (86400 seconds / 5)
 pub const TTL_HIGH_THRESHOLD: u32 = 518_400; // ~30 days (2592000 seconds / 5)
 pub const PRUNE_GRACE_PERIOD: u64 = 2_592_000; // 30 days in seconds
+
+// Governance TTL constants (same values, governance-specific aliases)
+pub const GOV_TTL_LOW_THRESHOLD: u32 = TTL_LOW_THRESHOLD;
+pub const GOV_TTL_HIGH_THRESHOLD: u32 = TTL_HIGH_THRESHOLD;

--- a/services/api/src/blockchain.rs
+++ b/services/api/src/blockchain.rs
@@ -100,6 +100,7 @@ pub struct BlockchainHealth {
     pub is_healthy: bool,
     pub contract_reachable: bool,
     pub checked_at_unix: u64,
+    pub status: HealthStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,6 +110,26 @@ pub struct ContractEvent {
     pub topic: String,
     pub tx_hash: Option<String>,
     pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayRequest {
+    pub from_ledger: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayProgress {
+    pub from_ledger: u32,
+    pub events_replayed: usize,
+    pub completed: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -545,6 +566,13 @@ impl BlockchainClient {
                     is_healthy: latest > 0 && contract_reachable,
                     contract_reachable,
                     checked_at_unix,
+                    status: if latest > 0 && contract_reachable {
+                        HealthStatus::Healthy
+                    } else if latest > 0 {
+                        HealthStatus::Degraded
+                    } else {
+                        HealthStatus::Unhealthy
+                    },
                 })
             })
             .await?;
@@ -719,6 +747,50 @@ impl BlockchainClient {
         } else {
             tracing::warn!("watched_txs cap reached ({MAX_WATCHED}), dropping tx: {hash}");
         }
+    }
+
+    /// Replay missed events from `from_ledger` up to the current confirmed tip.
+    /// Idempotent: events are stored by their unique ID so re-running is safe.
+    /// Progress is persisted in Redis so callers can poll for completion.
+    pub async fn replay_events(&self, from_ledger: u32) -> anyhow::Result<ReplayProgress> {
+        let progress_key = keys::chain_replay_progress(&self.network, from_ledger);
+
+        // Return cached progress if already completed
+        if let Some(cached) = self.cache.get_json::<ReplayProgress>(&progress_key).await? {
+            if cached.completed {
+                return Ok(cached);
+            }
+        }
+
+        let latest = self.latest_ledger().await?;
+        let confirmed_tip = latest.saturating_sub(self.confirmation_ledger_lag);
+
+        let events = self.fetch_events_since(from_ledger).await?;
+        let events_replayed = events.len();
+
+        for event in events {
+            // Only store events up to the confirmed tip (idempotent by key)
+            if event.ledger > confirmed_tip {
+                continue;
+            }
+            let event_key = format!("{}:event:{}", keys::CHAIN_PREFIX, event.id);
+            self.cache
+                .set_json(&event_key, &event, Duration::from_secs(30 * 60))
+                .await?;
+        }
+
+        let progress = ReplayProgress {
+            from_ledger,
+            events_replayed,
+            completed: true,
+        };
+
+        self.cache
+            .set_json(&progress_key, &progress, Duration::from_secs(60 * 60))
+            .await?;
+
+        tracing::info!(from_ledger, events_replayed, "event replay completed");
+        Ok(progress)
     }
 
     pub fn start_background_tasks(self: Arc<Self>) {

--- a/services/api/src/cache/mod.rs
+++ b/services/api/src/cache/mod.rs
@@ -159,4 +159,8 @@ pub mod keys {
     pub fn chain_sync_cursor(network: &str) -> String {
         format!("{CHAIN_PREFIX}:sync_cursor:{network}")
     }
+
+    pub fn chain_replay_progress(network: &str, from_ledger: u32) -> String {
+        format!("{CHAIN_PREFIX}:replay:{network}:{from_ledger}")
+    }
 }

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -702,6 +702,18 @@ pub async fn blockchain_tx_status(
     Ok((StatusCode::OK, Json(data)))
 }
 
+pub async fn blockchain_replay(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<crate::blockchain::ReplayRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let progress = state
+        .blockchain
+        .replay_events(payload.from_ledger)
+        .await
+        .map_err(into_api_error)?;
+    Ok((StatusCode::OK, Json(progress)))
+}
+
 pub async fn warm_critical_caches(state: Arc<AppState>) -> anyhow::Result<()> {
     let _ = state.db.statistics_cached().await?;
     let _ = state

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -218,6 +218,10 @@ async fn main() -> anyhow::Result<()> {
             post(handlers::resolve_market),
         )
         .route(
+            "/api/blockchain/replay",
+            post(handlers::blockchain_replay),
+        )
+        .route(
             "/api/v1/email/preview/:template_name",
             get(handlers::email_preview),
         )


### PR DESCRIPTION
closes #555 
closes #556 

…e mechanism (#111)

Issue 110 — Blockchain Event Replay (services/api) ---------------------------------------------------
- Add HealthStatus enum (Healthy/Degraded/Unhealthy) to blockchain.rs; was referenced in handlers but never defined, causing a compile error.
- Add ReplayRequest / ReplayProgress types.
- Add BlockchainHealth.status field populated from latest_ledger + contract_reachable state.
- Add BlockchainClient::replay_events(from_ledger):
  * Fetches all contract events since the given ledger via the existing paginated fetch_events_since helper.
  * Skips events beyond the confirmed tip (reorg-safe).
  * Stores each event by its unique ID — idempotent; re-running the same replay window is safe.
  * Persists a ReplayProgress record in Redis (TTL 1 h) so callers can poll for completion status.
  * Returns immediately if a completed replay for the same from_ledger is already cached.
  * Does not touch the live sync cursor — replay runs independently of the background sync worker.
- Add chain_replay_progress(network, from_ledger) cache key.
- Add blockchain_replay handler (POST /api/blockchain/replay).
- Register route under admin_routes (API key + IP whitelist protected).

Issue 111 — Contract Upgrade Mechanism (contracts/predict-iq) -------------------------------------------------------------- Type / struct fixes in types.rs:
- Import BytesN from soroban_sdk.
- PendingUpgrade.wasm_hash: String -> BytesN<32> (matches governance.rs).
- PendingGuardianRemoval.address -> target_guardian (matches governance.rs).
- UpgradeStats fields: replace total_upgrades/last_upgrade_at/last_wasm_hash with votes_for: u32 / votes_against: u32.
- Add missing ConfigKey variants: PendingGuardianRemoval, UpgradeRejectedAt(BytesN<32>).
- Add missing constants: UPGRADE_COOLDOWN_DURATION (24 h), GOV_TTL_LOW_THRESHOLD, GOV_TTL_HIGH_THRESHOLD (aliases of TTL constants).

Upgrade events in events.rs:
- emit_upgrade_initiated  — topics: [upg_init, initiator]
- emit_upgrade_voted      — topics: [upg_vote, voter], data: vote_for bool
- emit_upgrade_executed   — topics: [upg_exec, executor], data: wasm_hash
- emit_upgrade_rejected   — topics: [upg_rej],            data: wasm_hash

governance.rs wiring:
- initiate_upgrade: emits upg_init after storing PendingUpgrade.
- vote_for_upgrade: emits upg_vote after recording the vote.
- execute_upgrade: emits upg_exec on success, upg_rej on insufficient votes; return type changed to Result<BytesN<32>, ErrorCode> (returns hash on success so callers can confirm which wasm was deployed).
- get_upgrade_votes: return type changed to Result<(u32, u32), ErrorCode>
  to match the lib.rs public interface.

lib.rs public interface:
- initiate_upgrade: parameter type String -> BytesN<32>.
- execute_upgrade: return type Result<String,_> -> Result<BytesN<32>,_>.
- Expose previously missing governance entry-points: vote_on_guardian_removal, get_timelock_duration, set_timelock_duration, emergency_pause.