### PR TITLE
feat: add E2E tests for betting flow (#092)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -462,6 +462,46 @@ jobs:
           fi
         working-directory: contracts/predict-iq
 
+  e2e-betting-flow:
+    name: E2E — Betting Flow
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build frontend
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:3001
+
+      - name: Run betting flow E2E tests
+        run: npx playwright test e2e/user-journeys.spec.ts --project=chromium
+        env:
+          CI: true
+          BASE_URL: http://localhost:3000
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-betting-flow
+          path: frontend/playwright-report/
+          retention-days: 7
+
   all-tests-passed:
     name: All Tests Passed
     needs:
@@ -478,6 +518,7 @@ jobs:
       - oracle-quality-gate
       - format
       - build-optimized
+      - e2e-betting-flow
     runs-on: ubuntu-latest
     steps:
       - name: Success

--- a/frontend/e2e/user-journeys.spec.ts
+++ b/frontend/e2e/user-journeys.spec.ts
@@ -1,4 +1,231 @@
 import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Betting Flow — mocked API, isolated test data per run
+// ---------------------------------------------------------------------------
+
+test.describe('User Journey: Betting Flow (place bet → view position → claim winnings)', () => {
+  // Isolated per-run identifiers
+  const TEST_WALLET = `GTEST${randomUUID().replace(/-/g, '').toUpperCase().slice(0, 51)}`;
+  const MARKET_ID = 42;
+  const TX_HASH = `tx_${randomUUID().replace(/-/g, '')}`;
+
+  test.beforeEach(async ({ page }) => {
+    // Mock: featured markets list
+    await page.route('**/api/markets/featured', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: MARKET_ID,
+            title: 'Will BTC exceed $100k by end of 2025?',
+            volume: 50000,
+            ends_at: '2025-12-31T23:59:59Z',
+            onchain_volume: '50000',
+            resolved_outcome: null,
+          },
+        ]),
+      })
+    );
+
+    // Mock: place bet (POST /api/blockchain/markets/:id/bets)
+    await page.route(`**/api/blockchain/markets/${MARKET_ID}/bets`, (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ tx_hash: TX_HASH, status: 'pending' }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Mock: transaction status
+    await page.route(`**/api/blockchain/tx/${TX_HASH}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tx_hash: TX_HASH, status: 'confirmed', ledger: 1234 }),
+      })
+    );
+
+    // Mock: user bets / position
+    await page.route(`**/api/blockchain/users/${TEST_WALLET}/bets*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          bets: [
+            {
+              market_id: MARKET_ID,
+              outcome: 1,
+              amount: '100',
+              tx_hash: TX_HASH,
+              status: 'confirmed',
+            },
+          ],
+          total: 1,
+        }),
+      })
+    );
+
+    // Mock: oracle result (market resolved, outcome 1 wins)
+    await page.route(`**/api/blockchain/oracle/${MARKET_ID}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ market_id: MARKET_ID, outcome: 1, resolved_at: '2025-12-31T23:59:59Z' }),
+      })
+    );
+
+    // Mock: claim winnings (POST /api/blockchain/markets/:id/claim)
+    await page.route(`**/api/blockchain/markets/${MARKET_ID}/claim`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tx_hash: `claim_${TX_HASH}`, amount: '195', status: 'confirmed' }),
+      })
+    );
+  });
+
+  test('place bet — API receives correct payload and returns tx hash', async ({ page }) => {
+    const betRequests: { body: unknown }[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes(`/api/blockchain/markets/${MARKET_ID}/bets`) && req.method() === 'POST') {
+        betRequests.push({ body: JSON.parse(req.postData() ?? '{}') });
+      }
+    });
+
+    await page.goto('/');
+
+    // Verify the "Place Bets" step is visible in the How It Works section
+    await page.getByRole('link', { name: /how it works/i }).click();
+    await expect(page.getByRole('heading', { name: /place bets/i })).toBeVisible();
+
+    // Simulate placing a bet via the mocked API
+    const betResponse = await page.evaluate(
+      async ({ marketId, wallet }: { marketId: number; wallet: string }) => {
+        const res = await fetch(`/api/blockchain/markets/${marketId}/bets`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wallet, outcome: 1, amount: '100' }),
+        });
+        return res.json();
+      },
+      { marketId: MARKET_ID, wallet: TEST_WALLET }
+    );
+
+    expect(betResponse.tx_hash).toBeTruthy();
+    expect(betResponse.status).toBe('pending');
+  });
+
+  test('view position — user bets endpoint returns placed bet', async ({ page }) => {
+    await page.goto('/');
+
+    const positionResponse = await page.evaluate(
+      async (wallet: string) => {
+        const res = await fetch(`/api/blockchain/users/${wallet}/bets`);
+        return res.json();
+      },
+      TEST_WALLET
+    );
+
+    expect(positionResponse.bets).toHaveLength(1);
+    expect(positionResponse.bets[0].market_id).toBe(MARKET_ID);
+    expect(positionResponse.bets[0].outcome).toBe(1);
+    expect(positionResponse.bets[0].status).toBe('confirmed');
+  });
+
+  test('claim winnings — claim endpoint returns confirmed payout', async ({ page }) => {
+    await page.goto('/');
+
+    // Verify the "Claim Winnings" step is visible
+    await page.getByRole('link', { name: /how it works/i }).click();
+    await expect(page.getByRole('heading', { name: /claim winnings/i })).toBeVisible();
+
+    // Verify oracle resolved the market
+    const oracleResponse = await page.evaluate(
+      async (marketId: number) => {
+        const res = await fetch(`/api/blockchain/oracle/${marketId}`);
+        return res.json();
+      },
+      MARKET_ID
+    );
+    expect(oracleResponse.outcome).toBe(1);
+
+    // Claim winnings
+    const claimResponse = await page.evaluate(
+      async ({ marketId, wallet }: { marketId: number; wallet: string }) => {
+        const res = await fetch(`/api/blockchain/markets/${marketId}/claim`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wallet }),
+        });
+        return res.json();
+      },
+      { marketId: MARKET_ID, wallet: TEST_WALLET }
+    );
+
+    expect(claimResponse.status).toBe('confirmed');
+    expect(Number(claimResponse.amount)).toBeGreaterThan(0);
+  });
+
+  test('full flow — place bet, confirm tx, view position, claim winnings', async ({ page }) => {
+    await page.goto('/');
+
+    // Step 1: Place bet
+    const bet = await page.evaluate(
+      async ({ marketId, wallet }: { marketId: number; wallet: string }) => {
+        const res = await fetch(`/api/blockchain/markets/${marketId}/bets`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wallet, outcome: 1, amount: '100' }),
+        });
+        return res.json();
+      },
+      { marketId: MARKET_ID, wallet: TEST_WALLET }
+    );
+    expect(bet.tx_hash).toBeTruthy();
+
+    // Step 2: Confirm transaction
+    const tx = await page.evaluate(
+      async (txHash: string) => {
+        const res = await fetch(`/api/blockchain/tx/${txHash}`);
+        return res.json();
+      },
+      bet.tx_hash
+    );
+    expect(tx.status).toBe('confirmed');
+
+    // Step 3: View position
+    const position = await page.evaluate(
+      async (wallet: string) => {
+        const res = await fetch(`/api/blockchain/users/${wallet}/bets`);
+        return res.json();
+      },
+      TEST_WALLET
+    );
+    expect(position.bets[0].tx_hash).toBe(TX_HASH);
+
+    // Step 4: Claim winnings
+    const claim = await page.evaluate(
+      async ({ marketId, wallet }: { marketId: number; wallet: string }) => {
+        const res = await fetch(`/api/blockchain/markets/${marketId}/claim`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wallet }),
+        });
+        return res.json();
+      },
+      { marketId: MARKET_ID, wallet: TEST_WALLET }
+    );
+    expect(claim.status).toBe('confirmed');
+    expect(Number(claim.amount)).toBeGreaterThan(0);
+  });
+});
 
 test.describe('User Journey: Homepage → Features → Newsletter Signup', () => {
   test('should complete full journey successfully', async ({ page }) => {


### PR DESCRIPTION
## Summary
Closes #537 

Adds end-to-end tests covering the full betting flow: place bet → view position → claim winnings.

## Changes
- `frontend/e2e/user-journeys.spec.ts` — new `describe` block with 4 Playwright tests
- `.github/workflows/test.yml` — new `e2e-betting-flow` CI job

## Test coverage
- Place bet (POST /api/blockchain/markets/:id/bets)
- Confirm transaction status
- View user position (GET /api/blockchain/users/:wallet/bets)
- Claim winnings (POST /api/blockchain/markets/:id/claim)
- Full end-to-end flow chaining all steps

## Notes
- All API calls are mocked via `page.route()` — no live backend required
- Test wallet and tx hash generated with `randomUUID()` per run for data isolation
- CI job runs on every PR, uploads Playwright report as artifact