### PR TITLE
505 506 507 508 stellar wave features

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -226,6 +226,26 @@ impl PredictIQ {
         crate::modules::markets::release_creation_deposit(&e, market_id, native_token)
     }
 
+    /// Issue #507: Set market creation fee (admin only)
+    pub fn set_creation_fee(e: Env, amount: i128) -> Result<(), ErrorCode> {
+        crate::modules::markets::set_creation_fee(&e, amount)
+    }
+
+    /// Issue #507: Get market creation fee
+    pub fn get_creation_fee(e: Env) -> i128 {
+        crate::modules::markets::get_creation_fee(&e)
+    }
+
+    /// Issue #507: Set protocol treasury address (admin only)
+    pub fn set_protocol_treasury(e: Env, treasury: Address) -> Result<(), ErrorCode> {
+        crate::modules::markets::set_protocol_treasury(&e, treasury)
+    }
+
+    /// Issue #507: Get protocol treasury address
+    pub fn get_protocol_treasury(e: Env) -> Address {
+        crate::modules::markets::get_protocol_treasury(&e)
+    }
+
     // Governance and Upgrade Functions
     pub fn initialize_guardians(
         e: Env,

--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -163,6 +163,13 @@ impl PredictIQ {
         crate::modules::oracles::set_oracle_result(&e, market_id, outcome)
     }
 
+    /// Issue #508: Validate oracle staleness for a market
+    pub fn validate_oracle_staleness(e: Env, market_id: u64) -> Result<(), ErrorCode> {
+        let market = crate::modules::markets::get_market(&e, market_id)
+            .ok_or(ErrorCode::MarketNotFound)?;
+        crate::modules::oracles::validate_oracle_staleness(&e, market_id, &market.oracle_config)
+    }
+
     pub fn resolve_market(e: Env, market_id: u64, winning_outcome: u32) -> Result<(), ErrorCode> {
         crate::modules::admin::require_admin(&e)?;
         crate::modules::disputes::resolve_market(&e, market_id, winning_outcome)

--- a/contracts/predict-iq/src/modules/events.rs
+++ b/contracts/predict-iq/src/modules/events.rs
@@ -9,6 +9,22 @@ use soroban_sdk::{symbol_short, Address, Env};
 ///
 /// This standardization ensures external indexers can perfectly reconstruct
 /// market states by following a consistent event schema.
+///
+/// EVENT SCHEMA VERSION: 1.0
+/// Last Updated: 2026-04-25
+///
+/// Indexer Integration Guide:
+/// 1. Subscribe to contract events using market_id as primary filter
+/// 2. Process events in ledger order to maintain state consistency
+/// 3. For event replay: query all events for a market_id and replay sequentially
+/// 4. All timestamps are in Unix seconds (ledger.timestamp())
+/// 5. All amounts are in stroops (1 XLM = 10^7 stroops)
+///
+/// Event Replay Support:
+/// - All events are immutable once emitted
+/// - Events include sufficient context for state reconstruction
+/// - market_id is always present for efficient indexing
+/// - Timestamps enable temporal queries
 
 pub fn emit_market_created(
     e: &Env,
@@ -226,5 +242,20 @@ pub fn emit_upgrade_rejected(e: &Env, wasm_hash: soroban_sdk::BytesN<32>) {
     e.events().publish(
         (symbol_short!("upg_rej"),),
         wasm_hash,
+    );
+}
+
+/// Issue #506: Emit MarketStateChanged event for indexing
+/// Includes all fields needed for off-chain state reconstruction
+pub fn emit_market_state_changed(
+    e: &Env,
+    market_id: u64,
+    old_status: soroban_sdk::String,
+    new_status: soroban_sdk::String,
+    timestamp: u64,
+) {
+    e.events().publish(
+        (symbol_short!("mkt_state"), market_id),
+        (old_status, new_status, timestamp),
     );
 }

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -54,6 +54,7 @@ pub fn create_market(
 
     let reputation = get_creator_reputation(e, &creator);
     let creation_deposit = get_creation_deposit(e);
+    let creation_fee = get_creation_fee(e);
 
     // Check if deposit is required based on reputation
     let deposit_required = !matches!(
@@ -61,15 +62,31 @@ pub fn create_market(
         CreatorReputation::Pro | CreatorReputation::Institutional
     );
 
+    let token_client = token::Client::new(e, &native_token);
+    let balance = token_client.balance(&creator);
+
+    // Calculate total amount needed (deposit + fee)
+    let total_required = if deposit_required {
+        creation_deposit
+    } else {
+        0
+    } + creation_fee;
+
+    if total_required > 0 && balance < total_required {
+        return Err(ErrorCode::InsufficientDeposit);
+    }
+
+    // Collect creation fee to protocol treasury
+    if creation_fee > 0 {
+        let treasury = get_protocol_treasury(e);
+        token_client.transfer(&creator, &treasury, &creation_fee);
+        
+        // Emit fee collection event
+        crate::modules::events::emit_fee_collected(e, 0, treasury, creation_fee);
+    }
+
+    // Lock deposit if required
     if deposit_required && creation_deposit > 0 {
-        let token_client = token::Client::new(e, &native_token);
-        let balance = token_client.balance(&creator);
-
-        if balance < creation_deposit {
-            return Err(ErrorCode::InsufficientDeposit);
-        }
-
-        // Lock deposit
         token_client.transfer(&creator, &e.current_contract_address(), &creation_deposit);
     }
 
@@ -205,6 +222,40 @@ pub fn set_creation_deposit(e: &Env, amount: i128) -> Result<(), ErrorCode> {
     e.storage()
         .persistent()
         .set(&ConfigKey::CreationDeposit, &amount);
+    Ok(())
+}
+
+/// Issue #507: Get market creation fee (configurable by admin)
+pub fn get_creation_fee(e: &Env) -> i128 {
+    e.storage()
+        .persistent()
+        .get(&ConfigKey::CreationFee)
+        .unwrap_or(0)
+}
+
+/// Issue #507: Set market creation fee (admin only)
+pub fn set_creation_fee(e: &Env, amount: i128) -> Result<(), ErrorCode> {
+    crate::modules::admin::require_admin(e)?;
+    e.storage()
+        .persistent()
+        .set(&ConfigKey::CreationFee, &amount);
+    Ok(())
+}
+
+/// Issue #507: Get protocol treasury address
+pub fn get_protocol_treasury(e: &Env) -> Address {
+    e.storage()
+        .persistent()
+        .get(&ConfigKey::ProtocolTreasury)
+        .unwrap_or_else(|| e.current_contract_address())
+}
+
+/// Issue #507: Set protocol treasury address (admin only)
+pub fn set_protocol_treasury(e: &Env, treasury: Address) -> Result<(), ErrorCode> {
+    crate::modules::admin::require_admin(e)?;
+    e.storage()
+        .persistent()
+        .set(&ConfigKey::ProtocolTreasury, &treasury);
     Ok(())
 }
 

--- a/contracts/predict-iq/src/modules/oracles.rs
+++ b/contracts/predict-iq/src/modules/oracles.rs
@@ -27,7 +27,7 @@ pub fn validate_price(e: &Env, price: &PythPrice, config: &OracleConfig) -> Resu
     let current_time = e.ledger().timestamp() as i64;
     let age = current_time - price.publish_time;
 
-    // Check freshness
+    // Check freshness - Issue #508: Enforce staleness validation
     if age > config.max_staleness_seconds as i64 {
         return Err(ErrorCode::StalePrice);
     }
@@ -45,6 +45,32 @@ pub fn validate_price(e: &Env, price: &PythPrice, config: &OracleConfig) -> Resu
     }
 
     Ok(())
+}
+
+/// Issue #508: Validate oracle staleness before resolution
+pub fn validate_oracle_staleness(
+    e: &Env,
+    market_id: u64,
+    config: &OracleConfig,
+) -> Result<(), ErrorCode> {
+    let last_update = e
+        .storage()
+        .persistent()
+        .get::<_, u64>(&OracleData::LastUpdate(market_id, 0));
+
+    if let Some(update_time) = last_update {
+        let current_time = e.ledger().timestamp();
+        let age = current_time - update_time;
+
+        // Check if oracle data is stale
+        if age > config.max_staleness_seconds {
+            return Err(ErrorCode::StalePrice);
+        }
+        Ok(())
+    } else {
+        // No oracle data available
+        Err(ErrorCode::OracleFailure)
+    }
 }
 
 pub fn resolve_with_pyth(e: &Env, market_id: u64, config: &OracleConfig) -> Result<u32, ErrorCode> {

--- a/contracts/predict-iq/src/modules/resolution.rs
+++ b/contracts/predict-iq/src/modules/resolution.rs
@@ -23,6 +23,9 @@ pub fn attempt_oracle_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCod
         return Err(ErrorCode::ResolutionNotReady);
     }
     
+    // Issue #508: Validate oracle staleness before resolution
+    oracles::validate_oracle_staleness(e, market_id, &market.oracle_config)?;
+    
     // Attempt oracle resolution
     if let Some(oracle_outcome) = oracles::get_oracle_result(e, market_id, &market.oracle_config) {
         let old_status = soroban_sdk::String::from_slice(e, "Active");

--- a/contracts/predict-iq/src/modules/resolution.rs
+++ b/contracts/predict-iq/src/modules/resolution.rs
@@ -25,11 +25,23 @@ pub fn attempt_oracle_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCod
     
     // Attempt oracle resolution
     if let Some(oracle_outcome) = oracles::get_oracle_result(e, market_id, &market.oracle_config) {
+        let old_status = soroban_sdk::String::from_slice(e, "Active");
+        let new_status = soroban_sdk::String::from_slice(e, "PendingResolution");
+        
         market.status = MarketStatus::PendingResolution;
         market.winning_outcome = Some(oracle_outcome);
         market.pending_resolution_timestamp = Some(e.ledger().timestamp());
         
         markets::update_market(e, market);
+        
+        // Emit market state change event for indexing
+        crate::modules::events::emit_market_state_changed(
+            e,
+            market_id,
+            old_status,
+            new_status,
+            e.ledger().timestamp(),
+        );
         
         e.events().publish(
             (Symbol::new(e, "oracle_resolved"), market_id),
@@ -56,8 +68,21 @@ pub fn finalize_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
             
             // No dispute filed, finalize with oracle result
             let winning_outcome = market.winning_outcome.unwrap();
+            let old_status = soroban_sdk::String::from_slice(e, "PendingResolution");
+            let new_status = soroban_sdk::String::from_slice(e, "Resolved");
+            
             market.status = MarketStatus::Resolved;
+            market.resolved_at = Some(e.ledger().timestamp());
             markets::update_market(e, market);
+            
+            // Emit market state change event for indexing
+            crate::modules::events::emit_market_state_changed(
+                e,
+                market_id,
+                old_status,
+                new_status,
+                e.ledger().timestamp(),
+            );
             
             e.events().publish(
                 (Symbol::new(e, "market_finalized"), market_id),
@@ -76,10 +101,22 @@ pub fn finalize_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
             
             // Calculate voting outcome
             let winning_outcome = calculate_voting_outcome(e, &market)?;
+            let old_status = soroban_sdk::String::from_slice(e, "Disputed");
+            let new_status = soroban_sdk::String::from_slice(e, "Resolved");
             
             market.status = MarketStatus::Resolved;
             market.winning_outcome = Some(winning_outcome);
+            market.resolved_at = Some(e.ledger().timestamp());
             markets::update_market(e, market);
+            
+            // Emit market state change event for indexing
+            crate::modules::events::emit_market_state_changed(
+                e,
+                market_id,
+                old_status,
+                new_status,
+                e.ledger().timestamp(),
+            );
             
             e.events().publish(
                 (Symbol::new(e, "dispute_resolved"), market_id),

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -111,6 +111,8 @@ pub enum ConfigKey {
     BaseFee,
     CircuitBreakerState,
     CreationDeposit,
+    CreationFee,
+    ProtocolTreasury,
     GuardianSet,
     PendingUpgrade,
     UpgradeVotes,

--- a/services/api/src/metrics.rs
+++ b/services/api/src/metrics.rs
@@ -39,9 +39,12 @@ impl Metrics {
         let request_latency = HistogramVec::new(
             prometheus::HistogramOpts::new(
                 "http_request_duration_seconds",
-                "HTTP latency in seconds",
-            ),
-            &["endpoint"],
+                "HTTP request latency in seconds",
+            )
+            .buckets(vec![
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ]),
+            &["route", "status_code"],
         )
         .context("request_latency metric")?;
 
@@ -96,9 +99,9 @@ impl Metrics {
         }
     }
 
-    pub fn observe_request(&self, endpoint: &str, duration: Duration) {
+    pub fn observe_request(&self, route: &str, status_code: &str, duration: Duration) {
         self.request_latency
-            .with_label_values(&[endpoint])
+            .with_label_values(&[route, status_code])
             .observe(duration.as_secs_f64());
     }
 


### PR DESCRIPTION
### Changes Implemented

#### Issue #505: Add Prometheus histogram for request latency
- **File**: `services/api/src/metrics.rs`
- Added histogram with appropriate buckets (1ms to 10s) for latency distribution
- Changed labels from `endpoint` to `route` and `status_code` for granular metrics
- Enables P50/P95/P99 latency queries per route and HTTP status code
- **Impact**: Better visibility into API performance characteristics

#### Issue #506: Add contract event indexing for market state changes
- **Files**: `contracts/predict-iq/src/modules/events.rs`, `contracts/predict-iq/src/modules/resolution.rs`
- Added comprehensive event schema documentation (v1.0) with indexer integration guide
- Implemented `emit_market_state_changed()` event with all fields needed for off-chain indexing
- Updated resolution flow to emit state change events during transitions (Active → PendingResolution → Resolved)
- Events include old_status, new_status, and timestamp for complete state reconstruction
- **Impact**: Off-chain indexers can now perfectly reconstruct market states and support event replay

#### Issue #507: Implement market creation fee collection
- **Files**: `contracts/predict-iq/src/modules/markets.rs`, `contracts/predict-iq/src/types.rs`, `contracts/predict-iq/src/lib.rs`
- Implemented fee collection on market creation with transfer to protocol treasury
- Added configurable fee amount via `set_creation_fee()` (admin only)
- Added configurable treasury address via `set_protocol_treasury()` (admin only)
- Added new ConfigKey variants: `CreationFee` and `ProtocolTreasury`
- Emits `emit_fee_collected()` events for tracking protocol revenue
- **Impact**: Protocol can now capture revenue from market creation activities

#### Issue #508: Add oracle staleness validation in resolution flow
- **Files**: `contracts/predict-iq/src/modules/oracles.rs`, `contracts/predict-iq/src/modules/resolution.rs`, `contracts/predict-iq/src/lib.rs`
- Implemented `validate_oracle_staleness()` function with per-market configuration
- Enforces staleness check at resolution time using `max_staleness_seconds` from OracleConfig
- Returns clear `StalePrice` error when oracle data exceeds staleness threshold
- Integrated validation into `attempt_oracle_resolution()` to prevent stale price resolution
- Added public contract method for external staleness validation
- **Impact**: Markets cannot be resolved with stale oracle data, preventing incorrect outcomes

### Testing Recommendations

- **#505**: Verify histogram metrics are recorded with correct labels in Prometheus
- **#506**: Query events by market_id and verify state transitions are captured
- **#507**: Test fee collection with various fee amounts and verify treasury receives funds
- **#508**: Test resolution with fresh and stale oracle data, verify StalePrice error is returned

### Closes
- Closes #505
- Closes #506
- Closes #507
- Closes #508