### PR TITLE
feat(api): add database connection health check (#495)

### DIFF
--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -607,6 +607,18 @@ impl Database {
         Ok(())
     }
 
+    /// Ping the database with a bounded timeout. Returns Ok(()) if reachable.
+    pub async fn ping(&self) -> anyhow::Result<()> {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            sqlx::query("SELECT 1").execute(&self.pool),
+        )
+        .await
+        .context("db ping timed out")?
+        .context("db ping failed")?;
+        Ok(())
+    }
+
     /// Check whether an email event already exists (replay-attack guard).
     pub async fn email_event_exists(
         &self,

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -104,6 +104,9 @@ pub async fn health(State(state): State<Arc<AppState>>, headers: HeaderMap) -> i
             "pool_size": pool.size,
             "pool_available": pool.available,
         },
+        "db": {
+            "status": "ok",
+        },
         "workers": {
             "blockchain_sync": "running",
             "blockchain_monitor": "running",
@@ -115,6 +118,11 @@ pub async fn health(State(state): State<Arc<AppState>>, headers: HeaderMap) -> i
     if state.cache.ping().await.is_err() {
         health_status["status"] = "degraded".into();
         health_status["redis"]["status"] = "unhealthy".into();
+    }
+
+    if state.db.ping().await.is_err() {
+        health_status["status"] = "degraded".into();
+        health_status["db"]["status"] = "unhealthy".into();
     }
 
     if let Ok(processing_count) = state.email_queue.get_processing_count().await {


### PR DESCRIPTION
- Add Database::ping() with 2s timeout using SELECT 1
- Wire db ping into health handler alongside existing Redis check
- DB failure sets status=degraded and db.status=unhealthy
- Health response now includes db field
Closes #495 