### PR TITLE
feat: add configurable database query timeout (#049)

### DIFF
--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -38,6 +38,9 @@ pub struct DbPoolConfig {
     pub idle_timeout: Option<Duration>,
     /// When `None`, sqlx uses its default connection lifetime.
     pub max_lifetime: Option<Duration>,
+    /// Per-query execution timeout. Queries that exceed this are cancelled and
+    /// return an error. Configured via `DB_QUERY_TIMEOUT_SECS` (default: 30).
+    pub query_timeout: Duration,
 }
 
 #[derive(Clone, Debug)]
@@ -169,6 +172,13 @@ impl Config {
                 acquire_timeout: db_pool_acquire_timeout,
                 idle_timeout: db_pool_idle_timeout,
                 max_lifetime: db_pool_max_lifetime,
+                query_timeout: Duration::from_secs(
+                    env::var("DB_QUERY_TIMEOUT_SECS")
+                        .ok()
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(30)
+                        .max(1),
+                ),
             },
             blockchain_rpc_url,
             blockchain_network,

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -4,17 +4,49 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+use tokio::time::error::Elapsed;
 
 use crate::{
     cache::{keys, RedisCache},
     metrics::Metrics,
 };
 
+/// Errors that can be returned by [`Database`] methods.
+#[derive(Debug)]
+pub enum DbError {
+    Timeout,
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DbError::Timeout => write!(f, "database query timed out"),
+            DbError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DbError {}
+
+impl From<sqlx::Error> for DbError {
+    fn from(e: sqlx::Error) -> Self {
+        DbError::Other(anyhow::Error::from(e))
+    }
+}
+
+impl From<Elapsed> for DbError {
+    fn from(_: Elapsed) -> Self {
+        DbError::Timeout
+    }
+}
+
 #[derive(Clone)]
 pub struct Database {
     pool: PgPool,
     cache: RedisCache,
     metrics: Metrics,
+    query_timeout: Duration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,6 +102,7 @@ impl Database {
         database_url: &str,
         cache: RedisCache,
         metrics: Metrics,
+        query_timeout: Duration,
     ) -> anyhow::Result<Self> {
         let max_connections = std::env::var("DB_POOL_MAX")
             .ok()
@@ -96,7 +129,25 @@ impl Database {
             pool,
             cache,
             metrics,
+            query_timeout,
         })
+    }
+
+    /// Run `fut` with the configured query timeout.
+    /// On timeout, increments the `db_timeouts` metric and logs a warning.
+    async fn with_timeout<F, T>(&self, operation: &str, fut: F) -> Result<T, DbError>
+    where
+        F: std::future::Future<Output = Result<T, sqlx::Error>>,
+    {
+        match tokio::time::timeout(self.query_timeout, fut).await {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(e)) => Err(DbError::Other(anyhow::Error::from(e))),
+            Err(_elapsed) => {
+                self.metrics.observe_db_timeout(operation);
+                tracing::warn!(operation, timeout_secs = ?self.query_timeout, "db query timed out");
+                Err(DbError::Timeout)
+            }
+        }
     }
 
     pub async fn statistics_cached(&self) -> anyhow::Result<Statistics> {
@@ -107,7 +158,7 @@ impl Database {
         let (value, hit) = self
             .cache
             .get_or_set_json(&key, ttl, || async {
-                let row = sqlx::query(
+                let row = self.with_timeout("statistics", sqlx::query(
                     "SELECT \
                         COUNT(*)::BIGINT AS total_markets, \
                         COUNT(*) FILTER (WHERE status = 'active')::BIGINT AS active_markets, \
@@ -115,8 +166,7 @@ impl Database {
                         COALESCE(SUM(total_volume), 0)::DOUBLE PRECISION AS total_volume \
                     FROM markets",
                 )
-                .fetch_one(&self.pool)
-                .await?;
+                .fetch_one(&self.pool)).await.map_err(anyhow::Error::from)?;
 
                 Ok(Statistics {
                     total_markets: row.try_get::<i64, _>("total_markets")?,
@@ -143,7 +193,7 @@ impl Database {
         let (value, hit) = self
             .cache
             .get_or_set_json(&key, ttl, || async move {
-                let rows = sqlx::query(
+                let rows = self.with_timeout("featured_markets", sqlx::query(
                     "SELECT id, title, total_volume, ends_at \
                     FROM markets \
                     WHERE status = 'active' \
@@ -151,8 +201,7 @@ impl Database {
                     LIMIT $1",
                 )
                 .bind(limit)
-                .fetch_all(&self.pool)
-                .await?;
+                .fetch_all(&self.pool)).await.map_err(anyhow::Error::from)?;
 
                 let mut markets = Vec::with_capacity(rows.len());
                 for row in rows {
@@ -185,7 +234,7 @@ impl Database {
         let (value, hit) = self
             .cache
             .get_or_set_json(&key, ttl, || async move {
-                let rows = sqlx::query(
+                let rows = self.with_timeout("content", sqlx::query(
                     "SELECT id, title, category, published_at \
                     FROM content \
                     WHERE is_published = TRUE \
@@ -193,8 +242,7 @@ impl Database {
                     LIMIT $1",
                 )
                 .bind(limit)
-                .fetch_all(&self.pool)
-                .await?;
+                .fetch_all(&self.pool)).await.map_err(anyhow::Error::from)?;
 
                 let mut items = Vec::with_capacity(rows.len());
                 for row in rows {
@@ -223,14 +271,13 @@ impl Database {
         &self,
         normalized_email: &str,
     ) -> anyhow::Result<Option<NewsletterSubscriber>> {
-        let row = sqlx::query(
+        let row = self.with_timeout("newsletter_get_by_email", sqlx::query(
             "SELECT email, source, confirmed, confirmation_token, created_at, confirmed_at, unsubscribed_at, deleted_at
              FROM newsletter_subscribers
              WHERE email = $1 AND deleted_at IS NULL",
         )
         .bind(normalized_email)
-        .fetch_optional(&self.pool)
-        .await?;
+        .fetch_optional(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         if let Some(row) = row {
             return Ok(Some(NewsletterSubscriber {
@@ -254,7 +301,7 @@ impl Database {
         source: &str,
         confirmation_token: &str,
     ) -> anyhow::Result<()> {
-        sqlx::query(
+        self.with_timeout("newsletter_upsert_pending", sqlx::query(
             "INSERT INTO newsletter_subscribers (email, source, confirmed, confirmation_token, created_at, confirmed_at, unsubscribed_at)
              VALUES ($1, $2, FALSE, $3, NOW(), NULL, NULL)
              ON CONFLICT (email) DO UPDATE SET
@@ -268,8 +315,7 @@ impl Database {
         .bind(normalized_email)
         .bind(source)
         .bind(confirmation_token)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(())
     }
@@ -279,7 +325,7 @@ impl Database {
         token: &str,
         token_ttl_secs: u64,
     ) -> anyhow::Result<bool> {
-        let result = sqlx::query(
+        let result = self.with_timeout("newsletter_confirm_by_token", sqlx::query(
             "UPDATE newsletter_subscribers
              SET confirmed = TRUE, confirmation_token = NULL, confirmed_at = NOW(), unsubscribed_at = NULL
              WHERE confirmation_token = $1
@@ -287,57 +333,52 @@ impl Database {
         )
         .bind(token)
         .bind(token_ttl_secs as i64)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Remove pending (unconfirmed) subscriptions whose token has expired.
     pub async fn newsletter_delete_expired_pending(&self, token_ttl_secs: u64) -> anyhow::Result<u64> {
-        let result = sqlx::query(
+        let result = self.with_timeout("newsletter_delete_expired_pending", sqlx::query(
             "DELETE FROM newsletter_subscribers
              WHERE confirmed = FALSE
                AND created_at <= NOW() - ($1 || ' seconds')::INTERVAL",
         )
         .bind(token_ttl_secs as i64)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected())
     }
 
     pub async fn newsletter_unsubscribe(&self, normalized_email: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query(
+        let result = self.with_timeout("newsletter_unsubscribe", sqlx::query(
             "UPDATE newsletter_subscribers
              SET unsubscribed_at = NOW(), confirmed = FALSE
              WHERE email = $1 AND deleted_at IS NULL",
         )
         .bind(normalized_email)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected() > 0)
     }
 
     pub async fn newsletter_soft_delete(&self, normalized_email: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query(
+        let result = self.with_timeout("newsletter_soft_delete", sqlx::query(
             "UPDATE newsletter_subscribers
              SET deleted_at = NOW()
              WHERE email = $1 AND deleted_at IS NULL",
         )
         .bind(normalized_email)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected() > 0)
     }
 
     pub async fn newsletter_gdpr_delete(&self, normalized_email: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query("DELETE FROM newsletter_subscribers WHERE email = $1")
+        let result = self.with_timeout("newsletter_gdpr_delete", sqlx::query("DELETE FROM newsletter_subscribers WHERE email = $1")
             .bind(normalized_email)
-            .execute(&self.pool)
-            .await?;
+            .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -351,7 +392,7 @@ impl Database {
         template_data: serde_json::Value,
         priority: i32,
     ) -> anyhow::Result<uuid::Uuid> {
-        let row = sqlx::query(
+        let row = self.with_timeout("email_create_job", sqlx::query(
             "INSERT INTO email_jobs (job_type, recipient_email, template_name, template_data, priority)
              VALUES ($1, $2, $3, $4, $5)
              RETURNING id",
@@ -361,22 +402,20 @@ impl Database {
         .bind(template_name)
         .bind(template_data)
         .bind(priority)
-        .fetch_one(&self.pool)
-        .await?;
+        .fetch_one(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(row.try_get("id")?)
     }
 
     pub async fn email_get_job(&self, job_id: uuid::Uuid) -> anyhow::Result<Option<crate::email::EmailJob>> {
-        let row = sqlx::query(
+        let row = self.with_timeout("email_get_job", sqlx::query(
             "SELECT id, job_type, recipient_email, template_name, template_data, status, priority,
                     attempts, max_attempts, scheduled_at, started_at, completed_at, failed_at,
                     error_message, created_at, updated_at
              FROM email_jobs WHERE id = $1",
         )
         .bind(job_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        .fetch_optional(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         if let Some(row) = row {
             return Ok(Some(crate::email::EmailJob {
@@ -408,7 +447,7 @@ impl Database {
         status: &str,
         error_message: Option<&str>,
     ) -> anyhow::Result<()> {
-        sqlx::query(
+        self.with_timeout("email_update_job_status", sqlx::query(
             "UPDATE email_jobs
              SET status = $2, error_message = $3, updated_at = NOW(),
                  completed_at = CASE WHEN $2 = 'completed' THEN NOW() ELSE completed_at END,
@@ -418,8 +457,7 @@ impl Database {
         .bind(job_id)
         .bind(status)
         .bind(error_message)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(())
     }
@@ -430,7 +468,7 @@ impl Database {
         attempts: i32,
         error_message: Option<&str>,
     ) -> anyhow::Result<()> {
-        sqlx::query(
+        self.with_timeout("email_update_job_attempts", sqlx::query(
             "UPDATE email_jobs
              SET attempts = $2, error_message = $3, updated_at = NOW()
              WHERE id = $1",
@@ -438,8 +476,7 @@ impl Database {
         .bind(job_id)
         .bind(attempts)
         .bind(error_message)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(())
     }
@@ -453,7 +490,7 @@ impl Database {
         recipient: &str,
         metadata: serde_json::Value,
     ) -> anyhow::Result<uuid::Uuid> {
-        let row = sqlx::query(
+        let row = self.with_timeout("email_create_event", sqlx::query(
             "INSERT INTO email_events (email_job_id, message_id, event_type, recipient_email, metadata)
              VALUES ($1, $2, $3, $4, $5)
              RETURNING id",
@@ -463,8 +500,7 @@ impl Database {
         .bind(event_type)
         .bind(recipient)
         .bind(metadata)
-        .fetch_one(&self.pool)
-        .await?;
+        .fetch_one(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(row.try_get("id")?)
     }
@@ -477,7 +513,7 @@ impl Database {
         reason: Option<&str>,
         bounce_type: Option<&str>,
     ) -> anyhow::Result<()> {
-        sqlx::query(
+        self.with_timeout("email_add_suppression", sqlx::query(
             "INSERT INTO email_suppressions (email, suppression_type, reason, bounce_type)
              VALUES ($1, $2, $3, $4)
              ON CONFLICT (email) DO UPDATE SET
@@ -490,27 +526,24 @@ impl Database {
         .bind(suppression_type)
         .bind(reason)
         .bind(bounce_type)
-        .execute(&self.pool)
-        .await?;
+        .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(())
     }
 
     pub async fn email_is_suppressed(&self, email: &str) -> anyhow::Result<bool> {
-        let row = sqlx::query("SELECT COUNT(*) as count FROM email_suppressions WHERE email = $1")
+        let row = self.with_timeout("email_is_suppressed", sqlx::query("SELECT COUNT(*) as count FROM email_suppressions WHERE email = $1")
             .bind(email)
-            .fetch_one(&self.pool)
-            .await?;
+            .fetch_one(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         let count: i64 = row.try_get("count")?;
         Ok(count > 0)
     }
 
     pub async fn email_remove_suppression(&self, email: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query("DELETE FROM email_suppressions WHERE email = $1")
+        let result = self.with_timeout("email_remove_suppression", sqlx::query("DELETE FROM email_suppressions WHERE email = $1")
             .bind(email)
-            .execute(&self.pool)
-            .await?;
+            .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -544,11 +577,10 @@ impl Database {
             column, column, column
         );
 
-        sqlx::query(&query_str)
+        self.with_timeout("email_increment_analytics_counter", sqlx::query(&query_str)
             .bind(template)
             .bind(today)
-            .execute(&self.pool)
-            .await?;
+            .execute(&self.pool)).await.map_err(anyhow::Error::from)?;
 
         Ok(())
     }
@@ -560,8 +592,8 @@ impl Database {
     ) -> anyhow::Result<Vec<crate::email::EmailAnalytics>> {
         let start_date = chrono::Utc::now().date_naive() - chrono::Duration::days(days as i64);
 
-        let query = if let Some(template) = template_name {
-            sqlx::query(
+        let rows = if let Some(template) = template_name {
+            self.with_timeout("email_get_analytics", sqlx::query(
                 "SELECT template_name, variant_name, date, sent_count, delivered_count,
                         opened_count, clicked_count, bounced_count, complained_count, unsubscribed_count
                  FROM email_analytics
@@ -570,8 +602,9 @@ impl Database {
             )
             .bind(template)
             .bind(start_date)
+            .fetch_all(&self.pool)).await.map_err(anyhow::Error::from)?
         } else {
-            sqlx::query(
+            self.with_timeout("email_get_analytics", sqlx::query(
                 "SELECT template_name, variant_name, date, sent_count, delivered_count,
                         opened_count, clicked_count, bounced_count, complained_count, unsubscribed_count
                  FROM email_analytics
@@ -579,9 +612,8 @@ impl Database {
                  ORDER BY date DESC",
             )
             .bind(start_date)
+            .fetch_all(&self.pool)).await.map_err(anyhow::Error::from)?
         };
-
-        let rows = query.fetch_all(&self.pool).await?;
 
         let mut analytics = Vec::new();
         for row in rows {
@@ -615,7 +647,7 @@ impl Database {
         email: &str,
         timestamp: i64,
     ) -> anyhow::Result<bool> {
-        let count: i64 = sqlx::query_scalar(
+        let count: i64 = self.with_timeout("email_event_exists", sqlx::query_scalar(
             "SELECT COUNT(*) FROM email_events
              WHERE message_id IS NOT DISTINCT FROM $1
                AND event_type = $2
@@ -626,9 +658,7 @@ impl Database {
         .bind(event_type)
         .bind(email)
         .bind(timestamp as f64)
-        .fetch_one(&self.pool)
-        .await
-        .unwrap_or(0);
+        .fetch_one(&self.pool)).await.unwrap_or(0);
         Ok(count > 0)
     }
 }

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -14,12 +14,14 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::ValidateEmail;
 
-use crate::{blockchain::HealthStatus, cache::keys, email::webhook::sendgrid_webhook_handler, pagination::{PaginatedResponse, PaginationQuery}, AppState};
+use crate::{blockchain::HealthStatus, cache::keys, db::DbError, email::webhook::sendgrid_webhook_handler, pagination::{PaginatedResponse, PaginationQuery}, AppState};
 
 #[derive(Debug, Serialize)]
 pub struct ApiError {
     pub code: &'static str,
     pub message: String,
+    #[serde(skip)]
+    pub status: StatusCode,
 }
 
 impl ApiError {
@@ -27,6 +29,7 @@ impl ApiError {
         Self {
             code: "INTERNAL_ERROR",
             message: err.to_string(),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -34,6 +37,7 @@ impl ApiError {
         Self {
             code: "BAD_REQUEST",
             message: message.into(),
+            status: StatusCode::BAD_REQUEST,
         }
     }
 
@@ -41,6 +45,7 @@ impl ApiError {
         Self {
             code: "NOT_FOUND",
             message: message.into(),
+            status: StatusCode::NOT_FOUND,
         }
     }
 
@@ -48,6 +53,7 @@ impl ApiError {
         Self {
             code: "CONFLICT",
             message: message.into(),
+            status: StatusCode::CONFLICT,
         }
     }
 
@@ -55,17 +61,31 @@ impl ApiError {
         Self {
             code: "RATE_LIMITED",
             message: "Too many requests, please try again later.".to_string(),
+            status: StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self {
+            code: "SERVICE_UNAVAILABLE",
+            message: message.into(),
+            status: StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, Json(self)).into_response()
+        (self.status, Json(self)).into_response()
     }
 }
 
 fn into_api_error(err: anyhow::Error) -> ApiError {
+    if let Some(db_err) = err.downcast_ref::<DbError>() {
+        if matches!(db_err, DbError::Timeout) {
+            return ApiError::service_unavailable("database query timed out");
+        }
+    }
     ApiError::internal(err)
 }
 
@@ -691,7 +711,7 @@ pub async fn resolve_market(
     let map_err = |e: anyhow::Error| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError { code: "INTERNAL_ERROR", message: e.to_string() }),
+            Json(ApiError { code: "INTERNAL_ERROR", message: e.to_string(), status: StatusCode::INTERNAL_SERVER_ERROR }),
         )
     };
 

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
 
     let metrics = Metrics::new()?;
     let cache = RedisCache::new(&config.redis_url).await?;
-    let db = Database::new(&config.database_url, cache.clone(), metrics.clone()).await?;
+    let db = Database::new(&config.database_url, cache.clone(), metrics.clone(), config.db_pool.query_timeout).await?;
     let blockchain = BlockchainClient::new(&config, cache.clone(), metrics.clone())?;
     
     // Initialize email service components

--- a/services/api/src/metrics.rs
+++ b/services/api/src/metrics.rs
@@ -12,6 +12,7 @@ pub struct Metrics {
     request_latency: HistogramVec,
     rpc_errors: IntCounterVec,
     rpc_fallbacks: IntCounterVec,
+    db_timeouts: IntCounterVec,
 }
 
 impl Metrics {
@@ -63,12 +64,19 @@ impl Metrics {
         )
         .context("rpc_fallbacks metric")?;
 
+        let db_timeouts = IntCounterVec::new(
+            prometheus::Opts::new("db_timeouts_total", "DB queries that exceeded the timeout, by operation"),
+            &["operation"],
+        )
+        .context("db_timeouts metric")?;
+
         registry.register(Box::new(cache_hits.clone()))?;
         registry.register(Box::new(cache_misses.clone()))?;
         registry.register(Box::new(invalidations.clone()))?;
         registry.register(Box::new(request_latency.clone()))?;
         registry.register(Box::new(rpc_errors.clone()))?;
         registry.register(Box::new(rpc_fallbacks.clone()))?;
+        registry.register(Box::new(db_timeouts.clone()))?;
 
         Ok(Self {
             registry,
@@ -78,6 +86,7 @@ impl Metrics {
             request_latency,
             rpc_errors,
             rpc_fallbacks,
+            db_timeouts,
         })
     }
 
@@ -111,6 +120,10 @@ impl Metrics {
 
     pub fn observe_rpc_fallback(&self, endpoint: &str) {
         self.rpc_fallbacks.with_label_values(&[endpoint]).inc();
+    }
+
+    pub fn observe_db_timeout(&self, operation: &str) {
+        self.db_timeouts.with_label_values(&[operation]).inc();
     }
 
     pub fn observe_tx_eviction(&self, count: u64) {

--- a/services/api/src/shutdown_tests.rs
+++ b/services/api/src/shutdown_tests.rs
@@ -63,7 +63,7 @@ async fn test_email_queue_worker_graceful_shutdown() {
         .expect("Failed to connect to Redis");
     
     // Create a test database connection
-    let db = crate::db::Database::new(&config.database_url, cache.clone(), metrics)
+    let db = crate::db::Database::new(&config.database_url, cache.clone(), metrics, config.db_pool.query_timeout)
         .await
         .expect("Failed to connect to database");
     


### PR DESCRIPTION
- Add DB_QUERY_TIMEOUT_SECS env var to DbPoolConfig (default: 30s)
- Wrap all sqlx queries with tokio::time::timeout via Database::with_timeout()
- Timed-out queries return DbError::Timeout, mapped to HTTP 503
- Log tracing::warn! and increment db_timeouts_total Prometheus counter on timeout   closes #494 