### PR TITLE
fix: resolve compile errors from issues #477-#480

### DIFF
--- a/contracts/predict-iq/src/modules/governance.rs
+++ b/contracts/predict-iq/src/modules/governance.rs
@@ -98,7 +98,7 @@ pub fn remove_guardian(e: &Env, address: Address) -> Result<(), ErrorCode> {
 
     // Initiate removal proposal
     let pending_removal = crate::types::PendingGuardianRemoval {
-        address: address.clone(),
+        target_guardian: address.clone(),
         initiated_at: e.ledger().timestamp(),
         votes_for: Vec::new(e),
     };
@@ -151,7 +151,7 @@ pub fn vote_on_guardian_removal(e: &Env, voter: Address, approve: bool) -> Resul
         // Majority reached, execute removal
         let mut new_guardians: Vec<Guardian> = Vec::new(e);
         for g in guardians.iter() {
-            if g.address != pending_removal.address {
+            if g.address != pending_removal.target_guardian {
                 new_guardians.push_back(g.clone());
             }
         }

--- a/contracts/predict-iq/src/modules/oracles.rs
+++ b/contracts/predict-iq/src/modules/oracles.rs
@@ -130,7 +130,7 @@ pub fn set_oracle_result(e: &Env, market_id: u64, outcome: u32) -> Result<(), Er
     let oracle_addr = crate::modules::markets::get_market(e, market_id)
         .map(|m| m.oracle_config.oracle_address)
         .unwrap_or_else(|| e.current_contract_address());
-    crate::modules::events::emit_oracle_result_set(e, market_id, oracle_addr, outcome);
+    crate::modules::events::emit_oracle_result_set(e, market_id, 0u32, oracle_addr, outcome);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
---

### #477 — Fix duplicate `get_dispute_window` and dead constant usage
**File:** `modules/resolution.rs`

Already resolved in the codebase: `DISPUTE_WINDOW_SECONDS` is defined and a single `get_dispute_window()` implementation exists. No code change required.

---

### #478 — Add missing timelock config key and bounds constants
**File:** `types.rs`, `modules/governance.rs`

Already resolved: `ConfigKey::TimelockDuration`, `TIMELOCK_MIN_SECONDS`, and `TIMELOCK_MAX_SECONDS` are all defined in `types.rs` and imported correctly in `governance.rs`. No code change required.

---

### #479 — Fix `PendingGuardianRemoval` field name mismatch
**File:** `modules/governance.rs`

`PendingGuardianRemoval` in `types.rs` declares the field as `target_guardian`, but `governance.rs` referenced it as `.address` in two places:
- The struct literal in `remove_guardian`
- The filter comparison in `vote_on_guardian_removal`

Both corrected to use `.target_guardian`.

---

### #480 — Fix missing `oracle_id` argument in oracle result event
**File:** `modules/oracles.rs`

`emit_oracle_result_set` in `events.rs` has the signature:
```rust
fn emit_oracle_result_set(e, market_id, oracle_id: u32, oracle_source: Address, outcome: u32)
```
The call site in `set_oracle_result` was passing only 4 arguments (omitting `oracle_id`). Fixed by passing `0u32` as the `oracle_id`, consistent with the rest of the codebase and the existing event tests.

---

## Testing

Static analysis confirms all call sites and struct field references are now consistent with their definitions. Cargo is not available in this environment; CI will provide full build verification.

Closes #477
Closes #478
Closes #479
Closes #480
