### PR TITLE
fix: structured API errors, webhook sig verification, OpenAPI sync

### DIFF
--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -25,7 +25,7 @@ info:
     announcement before being removed.
 
 servers:
-  - url: http://localhost:8080
+  - url: http://0.0.0.0:8080
     description: Local development (default bind 0.0.0.0:8080)
 
 tags:
@@ -467,6 +467,21 @@ paths:
       tags: [webhooks]
       operationId: sendgridWebhook
       summary: SendGrid event webhook receiver
+      security:
+        - SendGridWebhook: []
+      parameters:
+        - name: X-Twilio-Email-Event-Webhook-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+          description: HMAC-SHA256 signature of timestamp+body, base64-encoded
+        - name: X-Twilio-Email-Event-Webhook-Timestamp
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Unix timestamp of the request (replay protection window is 300 s)
       requestBody:
         required: true
         content:
@@ -478,6 +493,8 @@ paths:
       responses:
         "200":
           description: Webhook processed
+        "401":
+          $ref: "#/components/responses/ApiError"
 
 components:
   parameters:
@@ -661,7 +678,7 @@ components:
 
   responses:
     ApiError:
-      description: Internal server error
+      description: Error response with machine-readable code
       content:
         application/json:
           schema:
@@ -679,3 +696,8 @@ components:
       in: header
       name: X-API-Key
       description: Admin API key required for protected endpoints
+    SendGridWebhook:
+      type: apiKey
+      in: header
+      name: X-Twilio-Email-Event-Webhook-Signature
+      description: HMAC-SHA256 signature provided by SendGrid on webhook delivery

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -1041,8 +1041,14 @@ pub async fn sendgrid_webhook(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(events): Json<Vec<crate::email::webhook::SendGridEvent>>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
-    sendgrid_webhook_handler(State(Arc::new(state.webhook_handler.clone())), headers, Json(events)).await
+) -> Result<impl IntoResponse, ApiError> {
+    sendgrid_webhook_handler(State(Arc::new(state.webhook_handler.clone())), headers, Json(events))
+        .await
+        .map_err(|(status, msg)| ApiError {
+            code: "WEBHOOK_ERROR",
+            message: msg,
+            status,
+        })
 }
 
 /// Query audit logs with filters

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -188,6 +188,10 @@ async fn main() -> anyhow::Result<()> {
 
     let webhook_routes = Router::new()
         .route("/webhooks/sendgrid", post(handlers::sendgrid_webhook))
+        .layer(middleware::from_fn_with_state(
+            state.config.sendgrid_webhook_secret.clone(),
+            security::sendgrid_webhook_middleware,
+        ))
         .layer(middleware::from_fn(correlation::correlation_id_middleware))
         .layer(TraceLayer::new_for_http())
         .layer(middleware::from_fn(security::security_headers_middleware))

--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -410,6 +410,9 @@ pub async fn metrics_auth_middleware(
 /// against the raw request body. When `SENDGRID_WEBHOOK_SECRET` is not configured
 /// the middleware passes through (permissive default for local dev).
 ///
+/// Replay protection: rejects requests whose `X-Twilio-Email-Event-Webhook-Timestamp`
+/// is more than 300 seconds old relative to the server clock.
+///
 /// # OpenAPI policy
 /// Route: `POST /webhooks/sendgrid`
 /// Auth: provider-signed (SendGrid HMAC) — no API key required.
@@ -425,12 +428,28 @@ pub async fn sendgrid_webhook_middleware(
             .and_then(|h| h.to_str().ok())
             .unwrap_or("");
 
+        // Replay protection: reject stale timestamps (> 300 s)
+        let ts_str = headers
+            .get("x-twilio-email-event-webhook-timestamp")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("");
+        let ts: i64 = ts_str.parse().unwrap_or(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        if (now - ts).abs() > 300 {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+
         let (parts, body) = request.into_parts();
         let bytes = axum::body::to_bytes(body, usize::MAX)
             .await
             .map_err(|_| StatusCode::BAD_REQUEST)?;
 
-        if !signing::verify_signature(&bytes, sig, secret) {
+        // Signature covers timestamp + payload per SendGrid spec
+        let signed_payload = format!("{}{}", ts_str, String::from_utf8_lossy(&bytes));
+        if !signing::verify_signature(signed_payload.as_bytes(), sig, secret) {
             return Err(StatusCode::UNAUTHORIZED);
         }
 


### PR DESCRIPTION
Issue 024: Wire sendgrid_webhook_middleware onto webhook route; add timestamp replay protection (300s window); sign timestamp+body per SendGrid spec.

Issue 029: Change sendgrid_webhook handler return type to ApiError for consistent error schema across all routes.

Issue 030: Correct OpenAPI server URL to 0.0.0.0:8080; add SendGridWebhook security scheme; document webhook signature headers; fix ApiError response description.

Issue 031: No change needed — single cancel_market_admin entrypoint already exists in contracts/predict-iq/src/lib.rs.

Closes #469 
Closes #474 
Closes #475 
Closes #476 