### PR TITLE
feat: wire and globalise admin security & validation middleware

### DIFF
--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -161,9 +161,6 @@ async fn main() -> anyhow::Result<()> {
         .layer(middleware::from_fn(correlation::correlation_id_middleware))
         .layer(TraceLayer::new_for_http())
         .layer(middleware::from_fn(versioning::versioning_middleware))
-        .layer(middleware::from_fn(security::security_headers_middleware))
-        .layer(middleware::from_fn(validation::request_validation_middleware))
-        .layer(middleware::from_fn(validation::request_size_validation_middleware))
         .layer(middleware::from_fn_with_state(
             (rate_limiter.clone(), security::TrustProxy(config_trust_proxy)),
             security::global_rate_limit_middleware,
@@ -194,7 +191,6 @@ async fn main() -> anyhow::Result<()> {
         ))
         .layer(middleware::from_fn(correlation::correlation_id_middleware))
         .layer(TraceLayer::new_for_http())
-        .layer(middleware::from_fn(security::security_headers_middleware))
         .with_state(state.clone());
 
     let admin_routes = Router::new()
@@ -261,6 +257,9 @@ async fn main() -> anyhow::Result<()> {
         .merge(newsletter_routes)
         .merge(webhook_routes)
         .merge(admin_routes)
+        .layer(middleware::from_fn(validation::request_validation_middleware))
+        .layer(middleware::from_fn(validation::request_size_validation_middleware))
+        .layer(middleware::from_fn(security::security_headers_middleware))
         .layer(compression::compression_layer())
         .layer(allowed_origins);
 

--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -325,7 +325,11 @@ impl IpWhitelist {
     }
 }
 
-/// IP whitelist middleware
+/// IP whitelist middleware for admin routes.
+///
+/// Allows all IPs when `ADMIN_WHITELIST_IPS` is empty (open-by-default for
+/// local/dev). When the env var is set to a comma-separated list of IPs, only
+/// those addresses may reach admin endpoints; all others receive `403 Forbidden`.
 pub async fn ip_whitelist_middleware(
     State((whitelist, TrustProxy(trust_proxy))): State<(Arc<IpWhitelist>, TrustProxy)>,
     headers: HeaderMap,
@@ -570,6 +574,28 @@ mod tests {
         assert_eq!(headers["x-content-type-options"], "nosniff");
     }
 
+    #[tokio::test]
+    async fn security_headers_middleware_no_duplicates() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn(super::security_headers_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+        // get_all returns an iterator; exactly one value means no duplicates.
+        assert_eq!(headers.get_all("x-frame-options").iter().count(), 1);
+        assert_eq!(headers.get_all("content-security-policy").iter().count(), 1);
+        assert_eq!(headers.get_all("strict-transport-security").iter().count(), 1);
+        assert_eq!(headers.get_all("referrer-policy").iter().count(), 1);
+    }
+
     #[test]
     fn test_extract_client_ip_precedence() {
         let mut headers = HeaderMap::new();
@@ -657,6 +683,166 @@ mod tests {
         );
 
         assert_eq!(extract_client_ip(&headers, None, false), "unknown");
+    }
+
+    // ── api_key_middleware ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn api_key_middleware_allows_valid_key() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let auth = Arc::new(ApiKeyAuth::new(vec!["secret".to_string()]));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(auth, super::api_key_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("x-api-key", "secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn api_key_middleware_rejects_missing_key() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let auth = Arc::new(ApiKeyAuth::new(vec!["secret".to_string()]));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(auth, super::api_key_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn api_key_middleware_rejects_wrong_key() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let auth = Arc::new(ApiKeyAuth::new(vec!["secret".to_string()]));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(auth, super::api_key_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("x-api-key", "wrong")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ── ip_whitelist_middleware ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ip_whitelist_allows_whitelisted_ip() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let whitelist = Arc::new(IpWhitelist::new(vec!["127.0.0.1".parse().unwrap()]));
+        let state = (whitelist, TrustProxy(false));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(state, super::ip_whitelist_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        // No ConnectInfo → ip resolves to "unknown" → not in whitelist → 403.
+        // To test an allowed IP we use X-Real-IP with trust_proxy=true.
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn ip_whitelist_allows_when_list_empty() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let whitelist = Arc::new(IpWhitelist::new(vec![])); // empty = allow all
+        let state = (whitelist, TrustProxy(false));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(state, super::ip_whitelist_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn ip_whitelist_blocks_non_whitelisted_ip() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let whitelist = Arc::new(IpWhitelist::new(vec!["10.0.0.1".parse().unwrap()]));
+        let state = (whitelist, TrustProxy(true));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(state, super::ip_whitelist_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("x-real-ip", "1.2.3.4") // not in whitelist
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn ip_whitelist_allows_matching_ip_via_header() {
+        use axum::{body::Body, http::Request, middleware, routing::get, Router};
+        use tower::ServiceExt;
+
+        let whitelist = Arc::new(IpWhitelist::new(vec!["10.0.0.1".parse().unwrap()]));
+        let state = (whitelist, TrustProxy(true));
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(state, super::ip_whitelist_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("x-real-ip", "10.0.0.1") // in whitelist
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }
 

--- a/services/api/src/validation.rs
+++ b/services/api/src/validation.rs
@@ -35,7 +35,14 @@ pub fn request_body_max_bytes_from_env() -> usize {
     parse_request_body_max_bytes(std::env::var(REQUEST_BODY_MAX_BYTES_ENV).ok().as_deref())
 }
 
-/// Request validation middleware
+/// Request validation middleware — applied globally to all routes.
+///
+/// Rejects requests with `400 Bad Request` when:
+/// - Query string or path contains SQL injection patterns (detected via [`sanitize::contains_sql_injection`])
+/// - Query string exceeds 2 048 characters
+/// - Path contains `..` (directory traversal) or `//` (double-slash)
+///
+/// Safe traffic passes through unmodified.
 pub async fn request_validation_middleware(
     request: Request,
     next: Next,
@@ -129,4 +136,137 @@ pub async fn request_size_validation_middleware(
     }
 
     Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware, routing::get, Router};
+    use tower::ServiceExt;
+
+    async fn validation_app() -> Router {
+        Router::new()
+            .route("/api/v1/items/:id", get(|| async { "ok" }))
+            .layer(middleware::from_fn(request_validation_middleware))
+    }
+
+    // ── request_validation_middleware ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn allows_clean_request() {
+        let response = validation_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/42?sort=asc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn blocks_sql_injection_in_query() {
+        let response = validation_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/42?id=1%20OR%201%3D1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn blocks_sql_injection_in_path() {
+        let response = validation_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/1%20UNION%20SELECT%201")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn blocks_path_traversal() {
+        let response = validation_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/items/../secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn blocks_query_string_too_long() {
+        let long_query = "a=".to_string() + &"x".repeat(2048);
+        let uri = format!("/api/v1/items/1?{long_query}");
+        let response = validation_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ── request_size_validation_middleware ────────────────────────────────
+
+    #[tokio::test]
+    async fn allows_request_within_size_limit() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn(request_size_validation_middleware));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("content-length", "100")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn blocks_request_exceeding_size_limit() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(middleware::from_fn(request_size_validation_middleware));
+
+        let over_limit = DEFAULT_REQUEST_BODY_MAX_BYTES + 1;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("content-length", over_limit.to_string())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
 }


### PR DESCRIPTION
## Summary

closes #446 
closes #447 
closes #448 
closes  #449 

All four issues share the same root cause: middleware existed but was either missing tests, missing documentation, or not applied to all route groups. This PR resolves all four in a single commit.

---

### #446 — Wire admin authentication middleware into admin routes
`api_key_middleware` was already wired into `admin_routes`. What was missing were tests.
- Added 3 tests: valid key → 200, missing key → 401, wrong key → 401.

### #447 — Wire IP whitelist middleware for admin endpoints
`ip_whitelist_middleware` was already wired into `admin_routes`. What was missing were documentation and tests.
- Added doc comment explaining `ADMIN_WHITELIST_IPS` env var and open-by-default (empty list = allow all) behaviour.
- Added 4 tests: empty list allows all, matching IP via header → 200, non-matching IP → 403, no ConnectInfo + non-empty list → 403.

### #448 — Attach security headers middleware globally
`security_headers_middleware` was applied to `public_routes` and `webhook_routes` but missing from `newsletter_routes` and `admin_routes`.
- Removed per-group layers from `public_routes` and `webhook_routes`.
- Applied once on the top-level `app` — covers all four route groups with no duplicate headers.
- Added `security_headers_middleware_no_duplicates` test.

### #449 — Attach request validation middleware globally
`request_validation_middleware` and `request_size_validation_middleware` were applied to `public_routes` only; `webhook_routes` and `admin_routes` were unprotected.
- Removed per-group layers from `public_routes`.
- Applied both globally on the top-level `app`.
- `content_type_validation_middleware` intentionally stays on `newsletter_routes` only (rejects missing Content-Type, which would break GET routes elsewhere).
- Added doc comment to `request_validation_middleware` documenting all rejection rules.
- Added 7 tests: clean request, SQL injection in query, SQL injection in path, path traversal, oversized query string, within-limit body, over-limit body.

## Files changed
- `services/api/src/main.rs` — middleware wiring
- `services/api/src/security.rs` — doc comment + tests for #447, tests for #446 and #448
- `services/api/src/validation.rs` — doc comment + tests for #449