### PR TITLE
feat: protect /metrics endpoint with auth and IP allowlist

### DIFF
--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -9,7 +9,7 @@ use predictiq_api::{
     idempotency, correlation, versioning, validation, rate_limit, audit_middleware,
     metrics::Metrics,
     newsletter::IpRateLimiter,
-    security::{self, ApiKeyAuth, IpWhitelist, RateLimiter},
+    security::{self, ApiKeyAuth, IpWhitelist, MetricsAuthConfig, RateLimiter},
     shutdown::{wait_for_signal, ShutdownCoordinator},
     tracing_config, compression,
     AppState,
@@ -177,7 +177,6 @@ async fn main() -> anyhow::Result<()> {
     // ── Routes ────────────────────────────────────────────────────────────────
     let public_routes = Router::new()
         .route("/health", get(handlers::health))
-        .route("/metrics", get(handlers::metrics))
         .route("/api/v1/blockchain/health", get(handlers::blockchain_health))
         .route("/api/v1/blockchain/markets/:market_id", get(handlers::blockchain_market_data))
         .route("/api/v1/blockchain/stats", get(handlers::blockchain_platform_stats))
@@ -197,6 +196,21 @@ async fn main() -> anyhow::Result<()> {
             (rate_limiter.clone(), security::TrustProxy(config_trust_proxy)),
             security::global_rate_limit_middleware,
         ))
+        .with_state(state.clone());
+
+    let metrics_auth_config = Arc::new(MetricsAuthConfig::new(
+        state.config.metrics_public,
+        state.config.metrics_allowlist_ips.clone(),
+        api_key_auth.clone(),
+    ));
+    let metrics_routes = Router::new()
+        .route("/metrics", get(handlers::metrics))
+        .layer(middleware::from_fn_with_state(
+            metrics_auth_config,
+            security::metrics_auth_middleware,
+        ))
+        .layer(middleware::from_fn(correlation::correlation_id_middleware))
+        .layer(TraceLayer::new_for_http())
         .with_state(state.clone());
 
     let newsletter_routes = Router::new()
@@ -294,6 +308,7 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .merge(public_routes)
+        .merge(metrics_routes)
         .merge(newsletter_routes)
         .merge(webhook_routes)
         .merge(admin_routes)

--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -668,6 +668,67 @@ mod tests {
 
         assert_eq!(extract_client_ip(&headers, None, false), "unknown");
     }
+
+    // ── metrics_auth_middleware ───────────────────────────────────────────────
+
+    fn metrics_app(config: Arc<MetricsAuthConfig>) -> axum::Router {
+        use axum::{routing::get, Router};
+        Router::new()
+            .route("/metrics", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(config, metrics_auth_middleware))
+    }
+
+    fn metrics_config(public: bool, allowlist: Vec<&str>, keys: Vec<&str>) -> Arc<MetricsAuthConfig> {
+        Arc::new(MetricsAuthConfig::new(
+            public,
+            allowlist.iter().filter_map(|s| s.parse().ok()).collect(),
+            Arc::new(ApiKeyAuth::new(keys.iter().map(|s| s.to_string()).collect())),
+        ))
+    }
+
+    async fn get_metrics(app: axum::Router, api_key: Option<&str>) -> StatusCode {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+        let mut builder = Request::builder().uri("/metrics");
+        if let Some(k) = api_key {
+            builder = builder.header("x-api-key", k);
+        }
+        app.oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn metrics_public_mode_allows_unauthenticated() {
+        let app = metrics_app(metrics_config(true, vec![], vec!["secret"]));
+        assert_eq!(get_metrics(app, None).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_requires_api_key_when_not_public() {
+        let app = metrics_app(metrics_config(false, vec![], vec!["secret"]));
+        assert_eq!(get_metrics(app, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn metrics_valid_api_key_grants_access() {
+        let app = metrics_app(metrics_config(false, vec![], vec!["secret"]));
+        assert_eq!(get_metrics(app, Some("secret")).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_wrong_api_key_rejected() {
+        let app = metrics_app(metrics_config(false, vec![], vec!["secret"]));
+        assert_eq!(get_metrics(app, Some("wrong")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn metrics_ip_not_in_allowlist_rejected() {
+        // allowlist contains only 10.0.0.1; request comes from 127.0.0.1 (no ConnectInfo)
+        let app = metrics_app(metrics_config(false, vec!["10.0.0.1"], vec!["secret"]));
+        assert_eq!(get_metrics(app, Some("secret")).await, StatusCode::FORBIDDEN);
+    }
 }
 
 /// Middleware to propagate trace context from incoming requests

--- a/services/api/tests/security_tests.rs
+++ b/services/api/tests/security_tests.rs
@@ -10,7 +10,7 @@ mod tests {
         Router,
     };
     use predictiq_api::security::{
-        ip_whitelist_middleware, sanitize, signing, IpWhitelist, RateLimitConfig, RateLimiter, TrustProxy,
+        ip_whitelist_middleware, sanitize, signing, ApiKeyAuth, IpWhitelist, MetricsAuthConfig, RateLimitConfig, RateLimiter, TrustProxy,
     };
     use tower::ServiceExt;
 
@@ -377,5 +377,59 @@ mod tests {
         assert!(sanitize::contains_sql_injection("Union Select id FROM t"));
         assert!(sanitize::contains_sql_injection("JAVASCRIPT:alert(1)"));
         assert!(sanitize::contains_sql_injection("ONERROR=x"));
+    }
+
+    // ── metrics_auth_middleware — HTTP-level tests ────────────────────────────
+
+    fn metrics_app(public: bool, allowlist: Vec<&str>, keys: Vec<&str>) -> Router {
+        use predictiq_api::security::metrics_auth_middleware;
+        let config = Arc::new(MetricsAuthConfig::new(
+            public,
+            allowlist.iter().filter_map(|s| s.parse().ok()).collect(),
+            Arc::new(ApiKeyAuth::new(keys.iter().map(|s| s.to_string()).collect())),
+        ));
+        Router::new()
+            .route("/metrics", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(config, metrics_auth_middleware))
+    }
+
+    async fn call_metrics(app: Router, api_key: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().uri("/metrics");
+        if let Some(k) = api_key {
+            builder = builder.header("x-api-key", k);
+        }
+        app.oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn metrics_public_mode_no_key_required() {
+        assert_eq!(call_metrics(metrics_app(true, vec![], vec!["s"]), None).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_no_key_returns_unauthorized() {
+        assert_eq!(call_metrics(metrics_app(false, vec![], vec!["s"]), None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn metrics_valid_key_returns_ok() {
+        assert_eq!(call_metrics(metrics_app(false, vec![], vec!["s"]), Some("s")).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_wrong_key_returns_unauthorized() {
+        assert_eq!(call_metrics(metrics_app(false, vec![], vec!["s"]), Some("bad")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn metrics_ip_not_in_allowlist_returns_forbidden() {
+        // allowlist = 10.0.0.1 only; request has no ConnectInfo → "unknown" → rejected
+        assert_eq!(
+            call_metrics(metrics_app(false, vec!["10.0.0.1"], vec!["s"]), Some("s")).await,
+            StatusCode::FORBIDDEN,
+        );
     }
 }


### PR DESCRIPTION
## Summary

Gates the `/metrics` Prometheus endpoint behind API key authentication and an optional IP allowlist, preventing public exposure of internal operational data.

## Changes

**`services/api/src/main.rs`**
- Removed `/metrics` from `public_routes`
- Added a dedicated `metrics_routes` router with `metrics_auth_middleware` wired from `MetricsAuthConfig` (built from existing config fields: `metrics_public`, `metrics_allowlist_ips`, `api_key_auth`)

**`services/api/src/security.rs`**
- `MetricsAuthConfig` and `metrics_auth_middleware` were already implemented; no changes needed
- Added unit tests covering all access-control branches

**`services/api/tests/security_tests.rs`**
- Added integration-level HTTP tests: public mode bypass, missing key → 401, valid key → 200, wrong key → 401, IP not in allowlist → 403

## Security Behaviour

| Scenario | Result |
|---|---|
| `METRICS_PUBLIC=true` | Open (no auth) — for trusted internal networks only |
| Valid `x-api-key` header, no allowlist | ✅ 200 |
| Missing or wrong `x-api-key` | ❌ 401 |
| IP not in `METRICS_ALLOWLIST_IPS` | ❌ 403 |
| IP in allowlist + valid key | ✅ 200 |

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `METRICS_PUBLIC` | `false` | Skip all auth (opt-in, internal clusters only) |
| `METRICS_ALLOWLIST_IPS` | *(empty)* | Comma-separated IP allowlist; empty = no IP restriction |
| `API_KEYS` | *(empty)* | Shared API key(s) checked via `x-api-key` header |

## Testing

All new tests are in `security.rs` (unit) and `tests/security_tests.rs` (integration).

Closes #456