### PR TITLE
Backend: resolve write flow, SCAN invalidation, cache tags, RPC error propagation

### DIFF
--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -55,4 +55,9 @@ testcontainers-modules = { version = "0.11", features = ["redis", "tokio"] }
 [[bench]]
 name = "api_key_auth"
 harness = false
+
+[[bench]]
+name = "invalidation_tags"
+harness = false
+
 [workspace]

--- a/services/api/benches/invalidation_tags.rs
+++ b/services/api/benches/invalidation_tags.rs
@@ -1,0 +1,43 @@
+/// Benchmark: tag-based invalidation key derivation overhead.
+///
+/// Measures the cost of `InvalidationTag::cache_keys()` (pure CPU, no I/O)
+/// to confirm that the tag abstraction adds negligible overhead compared to
+/// building the key list manually inline.
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use predictiq_api::cache::InvalidationTag;
+
+fn bench_tag_cache_keys(c: &mut Criterion) {
+    let mut group = c.benchmark_group("invalidation_tag");
+
+    // Tag-based: derive keys from a MarketResolved tag.
+    group.bench_function("market_resolved_tag_keys", |b| {
+        let tag = InvalidationTag::MarketResolved {
+            market_id: black_box(42),
+            network: black_box("testnet".to_string()),
+            featured_limit: black_box(10),
+        };
+        b.iter(|| black_box(tag.cache_keys()))
+    });
+
+    // Baseline: build the same key list manually (what the handler did before).
+    group.bench_function("market_resolved_manual_keys", |b| {
+        b.iter(|| {
+            let market_id: i64 = black_box(42);
+            let network: &str = black_box("testnet");
+            let featured_limit: i64 = black_box(10);
+            black_box(vec![
+                format!("chain:v1:market:{market_id}"),
+                format!("chain:v1:oracle:{network}:market:{market_id}"),
+                "api:v1:statistics".to_string(),
+                "api:v1:featured_markets".to_string(),
+                "dbq:v1:statistics".to_string(),
+                format!("dbq:v1:featured_markets:limit:{featured_limit}"),
+            ])
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_tag_cache_keys);
+criterion_main!(benches);

--- a/services/api/database/migrations/011_create_markets.sql
+++ b/services/api/database/migrations/011_create_markets.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS markets (
+    id            BIGSERIAL PRIMARY KEY,
+    title         TEXT        NOT NULL,
+    status        TEXT        NOT NULL DEFAULT 'active'
+                              CHECK (status IN ('active', 'resolved', 'cancelled')),
+    outcome_index INTEGER,
+    total_volume  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    ends_at       TIMESTAMPTZ NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at   TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS markets_status_idx ON markets (status);

--- a/services/api/src/blockchain.rs
+++ b/services/api/src/blockchain.rs
@@ -40,6 +40,20 @@ struct MonitoringState {
     watched_txs: RwLock<HashSet<String>>,
 }
 
+/// Indicates whether a response was sourced from a live RPC call or a stale
+/// cache entry served after an RPC failure.
+///
+/// Consumers and alerting rules can use this field to distinguish real zeros
+/// from error-masked defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataSource {
+    /// Data was fetched live from the RPC node.
+    Live,
+    /// The RPC call failed; this is a stale cached value served as a fallback.
+    StaleFallback,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainMarketData {
     pub market_id: i64,
@@ -48,6 +62,7 @@ pub struct ChainMarketData {
     pub onchain_volume: String,
     pub resolved_outcome: Option<u32>,
     pub ledger: u32,
+    pub source: DataSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +72,7 @@ pub struct PlatformStatistics {
     pub resolved_markets: u64,
     pub total_volume: String,
     pub ledger: u32,
+    pub source: DataSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,15 +91,17 @@ pub struct UserBetsPage {
     pub page_size: i64,
     pub total: i64,
     pub items: Vec<UserBet>,
+    pub source: DataSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OracleResult {
     pub market_id: i64,
-    pub source: Option<String>,
+    pub source_name: Option<String>,
     pub outcome: Option<u32>,
     pub confidence_bps: Option<u64>,
     pub ledger: u32,
+    pub source: DataSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -92,6 +110,7 @@ pub struct TransactionStatus {
     pub status: String,
     pub ledger: Option<u32>,
     pub error: Option<String>,
+    pub source: DataSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -277,8 +296,8 @@ impl BlockchainClient {
             .cache
             .get_or_set_json(&key, ttl, || async move {
                 let ledger = self.latest_ledger().await.unwrap_or(0);
-                let data: Value = self
-                    .rpc_call(
+                match self
+                    .rpc_call::<Value>(
                         "getContractData",
                         json!({
                             "contractId": self.contract_id,
@@ -286,36 +305,30 @@ impl BlockchainClient {
                         }),
                     )
                     .await
-                    .unwrap_or_else(|_| {
-                        json!({
-                            "title": null,
-                            "status": null,
-                            "onchain_volume": "0",
-                            "resolved_outcome": null
-                        })
-                    });
-
-                Ok(ChainMarketData {
-                    market_id,
-                    title: data
-                        .get("title")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned),
-                    status: data
-                        .get("status")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned),
-                    onchain_volume: data
-                        .get("onchain_volume")
-                        .and_then(Value::as_str)
-                        .unwrap_or("0")
-                        .to_string(),
-                    resolved_outcome: data
-                        .get("resolved_outcome")
-                        .and_then(Value::as_u64)
-                        .map(|v| v as u32),
-                    ledger,
-                })
+                {
+                    Ok(data) => Ok(ChainMarketData {
+                        market_id,
+                        title: data.get("title").and_then(Value::as_str).map(ToOwned::to_owned),
+                        status: data.get("status").and_then(Value::as_str).map(ToOwned::to_owned),
+                        onchain_volume: data
+                            .get("onchain_volume")
+                            .and_then(Value::as_str)
+                            .unwrap_or("0")
+                            .to_string(),
+                        resolved_outcome: data
+                            .get("resolved_outcome")
+                            .and_then(Value::as_u64)
+                            .map(|v| v as u32),
+                        ledger,
+                        source: DataSource::Live,
+                    }),
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getContractData");
+                        self.metrics.observe_rpc_fallback(endpoint);
+                        tracing::warn!(market_id, error = %e, "market_data RPC failed");
+                        Err(e)
+                    }
+                }
             })
             .await?;
 
@@ -337,8 +350,8 @@ impl BlockchainClient {
             .cache
             .get_or_set_json(&key, ttl, || async move {
                 let ledger = self.latest_ledger().await.unwrap_or(0);
-                let data: Value = self
-                    .rpc_call(
+                match self
+                    .rpc_call::<Value>(
                         "getContractData",
                         json!({
                             "contractId": self.contract_id,
@@ -346,35 +359,26 @@ impl BlockchainClient {
                         }),
                     )
                     .await
-                    .unwrap_or_else(|_| {
-                        json!({
-                            "total_markets": 0,
-                            "active_markets": 0,
-                            "resolved_markets": 0,
-                            "total_volume": "0"
-                        })
-                    });
-
-                Ok(PlatformStatistics {
-                    total_markets: data
-                        .get("total_markets")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0),
-                    active_markets: data
-                        .get("active_markets")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0),
-                    resolved_markets: data
-                        .get("resolved_markets")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0),
-                    total_volume: data
-                        .get("total_volume")
-                        .and_then(Value::as_str)
-                        .unwrap_or("0")
-                        .to_string(),
-                    ledger,
-                })
+                {
+                    Ok(data) => Ok(PlatformStatistics {
+                        total_markets: data.get("total_markets").and_then(Value::as_u64).unwrap_or(0),
+                        active_markets: data.get("active_markets").and_then(Value::as_u64).unwrap_or(0),
+                        resolved_markets: data.get("resolved_markets").and_then(Value::as_u64).unwrap_or(0),
+                        total_volume: data
+                            .get("total_volume")
+                            .and_then(Value::as_str)
+                            .unwrap_or("0")
+                            .to_string(),
+                        ledger,
+                        source: DataSource::Live,
+                    }),
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getContractData");
+                        self.metrics.observe_rpc_fallback(endpoint);
+                        tracing::warn!(error = %e, "platform_statistics RPC failed");
+                        Err(e)
+                    }
+                }
             })
             .await?;
 
@@ -405,8 +409,8 @@ impl BlockchainClient {
             .cache
             .get_or_set_json(&key, ttl, || async move {
                 let ledger = self.latest_ledger().await.unwrap_or(0);
-                let data: Value = self
-                    .rpc_call(
+                match self
+                    .rpc_call::<Value>(
                         "getContractData",
                         json!({
                             "contractId": self.contract_id,
@@ -416,52 +420,43 @@ impl BlockchainClient {
                         }),
                     )
                     .await
-                    .unwrap_or_else(|_| json!({"bets": [], "total": 0}));
-
-                let bets = data
-                    .get("bets")
-                    .and_then(Value::as_array)
-                    .cloned()
-                    .unwrap_or_default();
-
-                // The RPC may return a total count; fall back to the slice length
-                // so we never over-report.
-                let total = data
-                    .get("total")
-                    .and_then(Value::as_i64)
-                    .unwrap_or(bets.len() as i64);
-
-                let items = bets
-                    .into_iter()
-                    .map(|entry| UserBet {
-                        market_id: entry
-                            .get("market_id")
+                {
+                    Ok(data) => {
+                        let bets = data
+                            .get("bets")
+                            .and_then(Value::as_array)
+                            .cloned()
+                            .unwrap_or_default();
+                        let total = data
+                            .get("total")
                             .and_then(Value::as_i64)
-                            .unwrap_or_default(),
-                        outcome: entry
-                            .get("outcome")
-                            .and_then(Value::as_u64)
-                            .unwrap_or_default() as u32,
-                        amount: entry
-                            .get("amount")
-                            .and_then(Value::as_str)
-                            .unwrap_or("0")
-                            .to_string(),
-                        token: entry
-                            .get("token")
-                            .and_then(Value::as_str)
-                            .map(ToOwned::to_owned),
-                        ledger,
-                    })
-                    .collect::<Vec<_>>();
-
-                Ok(UserBetsPage {
-                    user: user.to_string(),
-                    page,
-                    page_size,
-                    total,
-                    items,
-                })
+                            .unwrap_or(bets.len() as i64);
+                        let items = bets
+                            .into_iter()
+                            .map(|entry| UserBet {
+                                market_id: entry.get("market_id").and_then(Value::as_i64).unwrap_or_default(),
+                                outcome: entry.get("outcome").and_then(Value::as_u64).unwrap_or_default() as u32,
+                                amount: entry.get("amount").and_then(Value::as_str).unwrap_or("0").to_string(),
+                                token: entry.get("token").and_then(Value::as_str).map(ToOwned::to_owned),
+                                ledger,
+                            })
+                            .collect::<Vec<_>>();
+                        Ok(UserBetsPage {
+                            user: user.to_string(),
+                            page,
+                            page_size,
+                            total,
+                            items,
+                            source: DataSource::Live,
+                        })
+                    }
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getContractData");
+                        self.metrics.observe_rpc_fallback(endpoint);
+                        tracing::warn!(user, error = %e, "user_bets RPC failed");
+                        Err(e)
+                    }
+                }
             })
             .await?;
 
@@ -483,8 +478,8 @@ impl BlockchainClient {
             .cache
             .get_or_set_json(&key, ttl, || async move {
                 let ledger = self.latest_ledger().await.unwrap_or(0);
-                let data: Value = self
-                    .rpc_call(
+                match self
+                    .rpc_call::<Value>(
                         "getContractData",
                         json!({
                             "contractId": self.contract_id,
@@ -492,21 +487,22 @@ impl BlockchainClient {
                         }),
                     )
                     .await
-                    .unwrap_or_else(|_| json!({}));
-
-                Ok(OracleResult {
-                    market_id,
-                    source: data
-                        .get("source")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned),
-                    outcome: data
-                        .get("outcome")
-                        .and_then(Value::as_u64)
-                        .map(|v| v as u32),
-                    confidence_bps: data.get("confidence_bps").and_then(Value::as_u64),
-                    ledger,
-                })
+                {
+                    Ok(data) => Ok(OracleResult {
+                        market_id,
+                        source_name: data.get("source").and_then(Value::as_str).map(ToOwned::to_owned),
+                        outcome: data.get("outcome").and_then(Value::as_u64).map(|v| v as u32),
+                        confidence_bps: data.get("confidence_bps").and_then(Value::as_u64),
+                        ledger,
+                        source: DataSource::Live,
+                    }),
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getContractData");
+                        self.metrics.observe_rpc_fallback(endpoint);
+                        tracing::warn!(market_id, error = %e, "oracle_result RPC failed");
+                        Err(e)
+                    }
+                }
             })
             .await?;
 
@@ -536,21 +532,24 @@ impl BlockchainClient {
                     error_result_xdr: Option<String>,
                 }
 
-                let tx = self
+                match self
                     .rpc_call::<TxResponse>("getTransaction", json!({ "hash": hash }))
                     .await
-                    .unwrap_or(TxResponse {
-                        status: "NOT_FOUND".to_string(),
-                        ledger: None,
-                        error_result_xdr: None,
-                    });
-
-                Ok(TransactionStatus {
-                    hash: hash.to_string(),
-                    status: tx.status,
-                    ledger: tx.ledger,
-                    error: tx.error_result_xdr,
-                })
+                {
+                    Ok(tx) => Ok(TransactionStatus {
+                        hash: hash.to_string(),
+                        status: tx.status,
+                        ledger: tx.ledger,
+                        error: tx.error_result_xdr,
+                        source: DataSource::Live,
+                    }),
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getTransaction");
+                        self.metrics.observe_rpc_fallback(endpoint);
+                        tracing::warn!(hash, error = %e, "transaction_status RPC failed");
+                        Err(e)
+                    }
+                }
             })
             .await?;
 
@@ -571,8 +570,12 @@ impl BlockchainClient {
         let (value, hit) = self
             .cache
             .get_or_set_json(&key, ttl, || async move {
-                let latest = self.latest_ledger().await.unwrap_or(0);
-                let contract_reachable = self
+                let latest = self.latest_ledger().await.unwrap_or_else(|e| {
+                    self.metrics.observe_rpc_error("getLatestLedger");
+                    tracing::warn!(error = %e, "health_check: getLatestLedger failed");
+                    0
+                });
+                let contract_reachable = match self
                     .rpc_call::<Value>(
                         "getContractData",
                         json!({
@@ -581,7 +584,14 @@ impl BlockchainClient {
                         }),
                     )
                     .await
-                    .is_ok();
+                {
+                    Ok(_) => true,
+                    Err(e) => {
+                        self.metrics.observe_rpc_error("getContractData");
+                        tracing::warn!(error = %e, "health_check: contract probe failed");
+                        false
+                    }
+                };
 
                 let checked_at_unix = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -643,7 +653,11 @@ impl BlockchainClient {
             let result = self
                 .rpc_call::<EventsResponse>("getEvents", params)
                 .await
-                .unwrap_or(EventsResponse { events: vec![], latest_ledger: None });
+                .map_err(|e| {
+                    self.metrics.observe_rpc_error("getEvents");
+                    tracing::warn!(from_ledger, error = %e, "getEvents RPC failed");
+                    e
+                })?;
 
             let batch_len = result.events.len();
             let last_id = result.events.last()
@@ -693,7 +707,11 @@ impl BlockchainClient {
     }
 
     async fn sync_once(&self, cursor_ledger: u32) -> anyhow::Result<u32> {
-        let latest = self.latest_ledger().await.unwrap_or(cursor_ledger);
+        let latest = self.latest_ledger().await.unwrap_or_else(|e| {
+            self.metrics.observe_rpc_error("getLatestLedger");
+            tracing::warn!(error = %e, "sync_once: getLatestLedger failed, holding cursor");
+            cursor_ledger
+        });
         self.handle_reorg_if_detected(latest).await?;
 
         let confirmed_tip = latest.saturating_sub(self.confirmation_ledger_lag);
@@ -896,5 +914,36 @@ impl BlockchainClient {
             WorkerHandle::new("blockchain-sync", sync_handle),
             WorkerHandle::new("blockchain-tx-monitor", mon_handle),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DataSource;
+
+    /// DataSource::Live and StaleFallback must be distinguishable by callers.
+    #[test]
+    fn data_source_variants_are_distinct() {
+        assert_ne!(DataSource::Live, DataSource::StaleFallback);
+    }
+
+    /// DataSource serialises to the expected snake_case strings so API
+    /// consumers and alerting rules can pattern-match on the field value.
+    #[test]
+    fn data_source_serialises_to_snake_case() {
+        let live = serde_json::to_value(DataSource::Live).unwrap();
+        let stale = serde_json::to_value(DataSource::StaleFallback).unwrap();
+        assert_eq!(live, serde_json::json!("live"));
+        assert_eq!(stale, serde_json::json!("stale_fallback"));
+    }
+
+    /// DataSource round-trips through JSON without loss.
+    #[test]
+    fn data_source_round_trips() {
+        for variant in [DataSource::Live, DataSource::StaleFallback] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: DataSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
     }
 }

--- a/services/api/src/cache/mod.rs
+++ b/services/api/src/cache/mod.rs
@@ -395,10 +395,27 @@ impl RedisCache {
         let start = std::time::Instant::now();
         let value = fetcher().await?;
         // Best-effort write — don't fail the request if cache write fails.
-        if let Err(e) = self.set_json(key, &value, ttl).await {
-            tracing::warn!(key, error = %e, "cache write failed");
+        if let Err(e) = self.set_json(entry_key, &value, ttl).await {
+            tracing::warn!(entry_key, error = %e, "cache write failed");
         }
         Ok((value, false))
+    }
+
+    /// Invalidate all cache keys associated with `tag`.
+    ///
+    /// Keys are derived from the tag at call time — no Redis set membership
+    /// lookup is required, keeping the blast radius deterministic and bounded.
+    /// Returns the number of keys deleted (keys that were already absent count
+    /// as 0 from Redis DEL but are still included in the returned count for
+    /// observability purposes).
+    pub async fn invalidate_tag(&self, tag: &InvalidationTag) -> anyhow::Result<usize> {
+        let tag_keys = tag.cache_keys();
+        let mut deleted = 0usize;
+        for key in &tag_keys {
+            self.del(key).await?;
+            deleted += 1;
+        }
+        Ok(deleted)
     }
 }
 
@@ -536,6 +553,87 @@ mod tests {
         assert_eq!(deleted, 0);
     }
 
+    // ── InvalidationTag tests ────────────────────────────────────────────────
+
+    /// Verifies that MarketResolved tag produces exactly the expected 6 keys.
+    #[test]
+    fn market_resolved_tag_produces_correct_keys() {
+        use super::InvalidationTag;
+        let tag = InvalidationTag::MarketResolved {
+            market_id: 7,
+            network: "testnet".to_string(),
+            featured_limit: 10,
+        };
+        let keys = tag.cache_keys();
+        assert_eq!(keys.len(), 6, "MarketResolved must cover exactly 6 keys");
+        assert!(keys.contains(&"chain:v1:market:7".to_string()));
+        assert!(keys.contains(&"chain:v1:oracle:testnet:market:7".to_string()));
+        assert!(keys.contains(&"api:v1:statistics".to_string()));
+        assert!(keys.contains(&"api:v1:featured_markets".to_string()));
+        assert!(keys.contains(&"dbq:v1:statistics".to_string()));
+        assert!(keys.contains(&"dbq:v1:featured_markets:limit:10".to_string()));
+    }
+
+    /// Verifies that different market IDs produce distinct key sets (no cross-contamination).
+    #[test]
+    fn market_resolved_tag_keys_are_market_id_scoped() {
+        use super::InvalidationTag;
+        let keys_a = InvalidationTag::MarketResolved {
+            market_id: 1,
+            network: "mainnet".to_string(),
+            featured_limit: 5,
+        }
+        .cache_keys();
+        let keys_b = InvalidationTag::MarketResolved {
+            market_id: 2,
+            network: "mainnet".to_string(),
+            featured_limit: 5,
+        }
+        .cache_keys();
+
+        // Per-market keys must differ.
+        assert_ne!(
+            keys_a.iter().find(|k| k.contains("chain:v1:market:")),
+            keys_b.iter().find(|k| k.contains("chain:v1:market:")),
+        );
+        // Aggregate keys are shared (both markets affect statistics).
+        assert_eq!(
+            keys_a.iter().find(|k| k.as_str() == "api:v1:statistics"),
+            keys_b.iter().find(|k| k.as_str() == "api:v1:statistics"),
+        );
+    }
+
+    /// Integration: invalidate_tag deletes exactly the keys in the tag and leaves others.
+    #[tokio::test]
+    async fn invalidate_tag_deletes_tag_keys_only() {
+        use super::InvalidationTag;
+        let (cache, _c) = start_cache().await;
+
+        let tag = InvalidationTag::MarketResolved {
+            market_id: 99,
+            network: "testnet".to_string(),
+            featured_limit: 10,
+        };
+
+        // Populate all tag keys plus one unrelated key.
+        for key in tag.cache_keys() {
+            cache.set_json(&key, &1u32, Duration::from_secs(60)).await.unwrap();
+        }
+        cache.set_json("unrelated:key", &42u32, Duration::from_secs(60)).await.unwrap();
+
+        let deleted = cache.invalidate_tag(&tag).await.unwrap();
+        assert_eq!(deleted, 6, "must report 6 deletions");
+
+        // All tag keys must be gone.
+        for key in tag.cache_keys() {
+            let v: Option<u32> = cache.get_json(&key).await.unwrap();
+            assert!(v.is_none(), "{key} must be absent after invalidate_tag");
+        }
+        // Unrelated key must survive.
+        let survivor: Option<u32> = cache.get_json("unrelated:key").await.unwrap();
+        assert_eq!(survivor, Some(42));
+    }
+
     #[tokio::test]
     async fn circuit_breaker_degrades_gracefully() {
         use super::{CircuitState, RedisCacheConfig};
@@ -568,6 +666,65 @@ mod tests {
             .unwrap();
         assert_eq!(val, 7);
         assert!(!hit);
+    }
+}
+
+// ── Invalidation tags ────────────────────────────────────────────────────────
+//
+// # Key and tag strategy
+//
+// Every cache key belongs to exactly one *invalidation tag*. A tag groups the
+// minimal set of keys that must be evicted together when a specific write
+// occurs. This keeps the blast radius deterministic: callers declare *what
+// changed* (the tag) rather than *which keys to delete* (the key list).
+//
+// ## Tag → key mapping
+//
+// | Tag                          | Keys invalidated                                                  |
+// |------------------------------|-------------------------------------------------------------------|
+// | `MarketResolved(id, net, lim)` | chain_market(id), chain_oracle_result(net,id),                  |
+// |                              | api_statistics, api_featured_markets,                             |
+// |                              | dbq_statistics, dbq_featured_markets(lim)                         |
+//
+// ## Rules
+// - Tags are defined here; handlers import and use them.
+// - A tag must never include keys from unrelated domains (e.g. resolving a
+//   market must not evict content or user-bet keys).
+// - When a new write path is added, add a corresponding tag here first.
+
+/// Describes a write event and the exact cache keys it invalidates.
+///
+/// Use [`RedisCache::invalidate_tag`] to apply a tag.
+#[derive(Debug, Clone)]
+pub enum InvalidationTag {
+    /// A market was resolved.
+    ///
+    /// Invalidates the per-market chain entry, the oracle result, and the
+    /// aggregate statistics / featured-markets lists.
+    MarketResolved {
+        market_id: i64,
+        network: String,
+        featured_limit: i64,
+    },
+}
+
+impl InvalidationTag {
+    /// Returns the exact set of cache keys this tag covers.
+    pub fn cache_keys(&self) -> Vec<String> {
+        match self {
+            InvalidationTag::MarketResolved {
+                market_id,
+                network,
+                featured_limit,
+            } => vec![
+                keys::chain_market(*market_id),
+                keys::chain_oracle_result(network, *market_id),
+                keys::api_statistics(),
+                keys::api_featured_markets(),
+                keys::dbq_statistics(),
+                keys::dbq_featured_markets(*featured_limit),
+            ],
+        }
     }
 }
 

--- a/services/api/src/cache/mod.rs
+++ b/services/api/src/cache/mod.rs
@@ -286,32 +286,50 @@ impl RedisCache {
         .await
     }
 
+    /// Delete all keys matching `pattern` using non-blocking cursor-based SCAN.
+    ///
+    /// Each SCAN+DEL batch acquires and releases its own pool connection so no
+    /// single connection is held for the full duration of a large-keyspace scan.
+    /// The circuit breaker is checked once before the loop; individual batch
+    /// errors are propagated immediately.
     pub async fn del_by_pattern(&self, pattern: &str) -> anyhow::Result<usize> {
+        if !self.cb.allow() {
+            anyhow::bail!("Redis circuit breaker is open");
+        }
+
+        let mut cursor: u64 = 0;
+        let mut total_deleted: usize = 0;
         let pattern = pattern.to_owned();
-        self.exec(|mut conn| async move {
-            let mut cursor: u64 = 0;
-            let mut total_deleted: usize = 0;
-            loop {
-                let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                    .arg(cursor)
-                    .arg("MATCH")
-                    .arg(&pattern)
-                    .arg("COUNT")
-                    .arg(100u64)
-                    .query_async(&mut conn)
-                    .await?;
-                if !keys.is_empty() {
-                    let deleted: usize = conn.del(keys).await?;
-                    total_deleted += deleted;
-                }
-                cursor = next_cursor;
-                if cursor == 0 {
-                    break;
-                }
+
+        loop {
+            let pattern_clone = pattern.clone();
+            let (next_cursor, batch_deleted) = self
+                .exec(|mut conn| async move {
+                    let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                        .arg(cursor)
+                        .arg("MATCH")
+                        .arg(&pattern_clone)
+                        .arg("COUNT")
+                        .arg(100u64)
+                        .query_async(&mut conn)
+                        .await?;
+                    let deleted = if keys.is_empty() {
+                        0
+                    } else {
+                        conn.del(keys).await?
+                    };
+                    Ok((next_cursor, deleted))
+                })
+                .await?;
+
+            total_deleted += batch_deleted;
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
             }
-            Ok(total_deleted)
-        })
-        .await
+        }
+
+        Ok(total_deleted)
     }
 
     /// Fetch-or-set with stampede protection.
@@ -477,6 +495,45 @@ mod tests {
         }
         let other: Option<u32> = cache.get_json("other:item:0").await.unwrap();
         assert_eq!(other, Some(100));
+    }
+
+    /// Verifies that del_by_pattern correctly handles a keyspace larger than a
+    /// single SCAN page (COUNT 100), exercising the cursor-batching loop.
+    #[tokio::test]
+    async fn del_by_pattern_large_keyspace_uses_cursor_batching() {
+        let (cache, _c) = start_cache().await;
+        let n = 250u32; // exceeds the COUNT 100 hint, forcing multiple SCAN rounds
+        for i in 0..n {
+            cache
+                .set_json(&format!("large:item:{i}"), &i, Duration::from_secs(60))
+                .await
+                .unwrap();
+        }
+        // One key outside the pattern must survive.
+        cache
+            .set_json("large:other:0", &999u32, Duration::from_secs(60))
+            .await
+            .unwrap();
+
+        let deleted = cache.del_by_pattern("large:item:*").await.unwrap();
+        assert_eq!(deleted, n as usize, "all {n} matching keys must be deleted");
+
+        // Spot-check a few keys are gone.
+        for i in [0u32, 99, 100, 249] {
+            let v: Option<u32> = cache.get_json(&format!("large:item:{i}")).await.unwrap();
+            assert!(v.is_none(), "large:item:{i} must be gone after del_by_pattern");
+        }
+        // Non-matching key must be untouched.
+        let survivor: Option<u32> = cache.get_json("large:other:0").await.unwrap();
+        assert_eq!(survivor, Some(999), "non-matching key must survive");
+    }
+
+    /// Verifies that del_by_pattern returns 0 and does not error when no keys match.
+    #[tokio::test]
+    async fn del_by_pattern_no_matches_returns_zero() {
+        let (cache, _c) = start_cache().await;
+        let deleted = cache.del_by_pattern("nonexistent:*").await.unwrap();
+        assert_eq!(deleted, 0);
     }
 
     #[tokio::test]

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -630,8 +630,30 @@ impl Database {
         Ok(analytics)
     }
 
-    /// Stub: resolve a market outcome. Full implementation requires a markets table.
-    pub async fn resolve_market(&self, _market_id: i64, _outcome_index: u32) -> anyhow::Result<()> {
+    /// Resolve a market by persisting the winning outcome to the database.
+    ///
+    /// Returns an error if the market does not exist or is not in `active` status.
+    pub async fn resolve_market(&self, market_id: i64, outcome_index: u32) -> anyhow::Result<()> {
+        let rows_affected = self
+            .with_timeout(
+                "resolve_market",
+                sqlx::query(
+                    "UPDATE markets \
+                     SET status = 'resolved', outcome_index = $1, resolved_at = NOW() \
+                     WHERE id = $2 AND status = 'active'",
+                )
+                .bind(outcome_index as i32)
+                .bind(market_id)
+                .execute(&self.pool),
+            )
+            .await
+            .map_err(anyhow::Error::from)?
+            .rows_affected();
+
+        if rows_affected == 0 {
+            anyhow::bail!("market {market_id} not found or not in active status");
+        }
+
         Ok(())
     }
 

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::ValidateEmail;
 
-use crate::{blockchain::HealthStatus, cache::keys, db::DbError, email::webhook::sendgrid_webhook_handler, pagination::{PaginatedResponse, PaginationQuery}, AppState};
+use crate::{blockchain::HealthStatus, cache::{keys, InvalidationTag}, db::DbError, email::webhook::sendgrid_webhook_handler, pagination::{PaginatedResponse, PaginationQuery}, AppState};
 
 #[derive(Debug, Serialize)]
 pub struct ApiError {
@@ -730,25 +730,13 @@ pub async fn resolve_market(
         .await
         .map_err(map_err)?;
 
-    // 2. Invalidate only the keys affected by this market's resolution.
-    //    Broad prefix wildcards (api:v1:* / dbq:v1:*) are intentionally avoided
-    //    to keep the blast radius small.
-    let network = state.config.network_name();
-    let featured_limit = state.config.featured_limit;
-    let keys_to_del = [
-        keys::chain_market(market_id),
-        keys::chain_oracle_result(network, market_id),
-        keys::api_statistics(),
-        keys::api_featured_markets(),
-        keys::dbq_statistics(),
-        keys::dbq_featured_markets(featured_limit),
-    ];
-
-    let mut invalidated = 0usize;
-    for key in &keys_to_del {
-        state.cache.del(key).await.map_err(map_err)?;
-        invalidated += 1;
-    }
+    // 2. Invalidate only the keys affected by this market's resolution via tag.
+    let tag = InvalidationTag::MarketResolved {
+        market_id,
+        network: state.config.network_name().to_owned(),
+        featured_limit: state.config.featured_limit,
+    };
+    let invalidated = state.cache.invalidate_tag(&tag).await.map_err(map_err)?;
 
     state
         .metrics

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod audit;
 pub mod audit_middleware;
+#[cfg(test)]
+mod resolve_market_tests;
 pub mod blockchain;
 pub mod cache;
 pub mod compression;

--- a/services/api/src/migrations.rs
+++ b/services/api/src/migrations.rs
@@ -87,6 +87,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "008_create_email_tracking",
         sql: include_str!("../database/migrations/008_create_email_tracking.sql"),
     },
+    Migration {
+        version: "011",
+        name: "011_create_markets",
+        sql: include_str!("../database/migrations/011_create_markets.sql"),
+    },
 ];
 
 // ---------------------------------------------------------------------------

--- a/services/api/src/resolve_market_tests.rs
+++ b/services/api/src/resolve_market_tests.rs
@@ -1,0 +1,174 @@
+#[cfg(test)]
+mod resolve_market_tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    use crate::handlers::{resolve_market, InvalidationResult};
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// Build a minimal router wired to `resolve_market` for handler-level tests.
+    fn app(state: Arc<crate::AppState>) -> Router {
+        Router::new()
+            .route("/admin/markets/:market_id/resolve", post(resolve_market))
+            .with_state(state)
+    }
+
+    async fn post_resolve(
+        router: Router,
+        market_id: i64,
+        outcome_index: u32,
+    ) -> axum::response::Response {
+        let body = serde_json::to_vec(&json!({ "outcome_index": outcome_index })).unwrap();
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/admin/markets/{market_id}/resolve"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    // ---------------------------------------------------------------------------
+    // Unit tests — no real DB/Redis required
+    // ---------------------------------------------------------------------------
+
+    /// Verifies that a successful DB write returns 200 and a non-zero
+    /// `invalidated_keys` count.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL + Redis
+    async fn test_resolve_market_success_returns_200_and_invalidation_count() {
+        let state = build_test_state().await;
+        // Insert a test market first so the UPDATE finds a row.
+        sqlx::query(
+            "INSERT INTO markets (id, title, status, total_volume, ends_at) \
+             VALUES (9001, 'Test Market', 'active', 0, NOW() + INTERVAL '1 day')",
+        )
+        .execute(state.db.pool())
+        .await
+        .unwrap();
+
+        let response = post_resolve(app(Arc::clone(&state)), 9001, 0).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body: InvalidationResult =
+            serde_json::from_slice(&axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert!(body.invalidated_keys > 0);
+
+        // Cleanup
+        sqlx::query("DELETE FROM markets WHERE id = 9001")
+            .execute(state.db.pool())
+            .await
+            .unwrap();
+    }
+
+    /// Verifies that resolving a non-existent market returns 500.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL + Redis
+    async fn test_resolve_market_not_found_returns_500() {
+        let state = build_test_state().await;
+        let response = post_resolve(app(Arc::clone(&state)), 999_999_999, 0).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    /// Verifies that resolving an already-resolved market returns 500.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL + Redis
+    async fn test_resolve_market_already_resolved_returns_500() {
+        let state = build_test_state().await;
+        sqlx::query(
+            "INSERT INTO markets (id, title, status, outcome_index, total_volume, ends_at, resolved_at) \
+             VALUES (9002, 'Resolved Market', 'resolved', 1, 0, NOW() - INTERVAL '1 day', NOW())",
+        )
+        .execute(state.db.pool())
+        .await
+        .unwrap();
+
+        let response = post_resolve(app(Arc::clone(&state)), 9002, 0).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Cleanup
+        sqlx::query("DELETE FROM markets WHERE id = 9002")
+            .execute(state.db.pool())
+            .await
+            .unwrap();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Pure-logic unit tests (no I/O)
+    // ---------------------------------------------------------------------------
+
+    /// Verifies that `ResolveMarketRequest` deserialises correctly.
+    #[test]
+    fn test_resolve_market_request_deserialises() {
+        let json = r#"{"outcome_index": 2}"#;
+        let req: crate::handlers::ResolveMarketRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.outcome_index, 2);
+    }
+
+    /// Verifies that `InvalidationResult` serialises correctly.
+    #[test]
+    fn test_invalidation_result_serialises() {
+        let result = InvalidationResult { invalidated_keys: 6 };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["invalidated_keys"], 6);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helper — builds AppState from env (used by #[ignore] integration tests)
+    // ---------------------------------------------------------------------------
+
+    #[cfg(test)]
+    async fn build_test_state() -> Arc<crate::AppState> {
+        use crate::{
+            audit::AuditLogger,
+            blockchain::BlockchainClient,
+            cache::RedisCache,
+            config::Config,
+            db::Database,
+            email::{queue::EmailQueue, service::EmailService, webhook::WebhookHandler},
+            metrics::Metrics,
+            newsletter::IpRateLimiter,
+        };
+
+        let config = Config::from_env();
+        let metrics = Metrics::new().expect("metrics");
+        let cache = RedisCache::new(&config.redis_url).await.expect("redis");
+        let db = Database::new(&config.database_url, cache.clone(), metrics.clone(), &config.db_pool)
+            .await
+            .expect("db");
+        let blockchain = BlockchainClient::new(&config, cache.clone(), metrics.clone())
+            .expect("blockchain");
+        let email_service = EmailService::new(config.clone()).expect("email_service");
+        let email_queue = EmailQueue::new(cache.clone(), db.clone());
+        let webhook_handler = WebhookHandler::new(db.clone());
+        let audit_logger = AuditLogger::new(db.pool());
+
+        Arc::new(crate::AppState {
+            config,
+            cache: cache.clone(),
+            db,
+            blockchain,
+            metrics,
+            newsletter_rate_limiter: IpRateLimiter::new(cache),
+            email_service,
+            email_queue,
+            webhook_handler,
+            audit_logger,
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Closes #457
Closes #458
Closes #459
Closes #460

---

### #457 — Implement real market resolve write flow
- Replaced `db::resolve_market` stub with a real `UPDATE markets SET status='resolved'` query guarded on `status='active'`; returns error when `rows_affected == 0`
- Added migration `011_create_markets.sql` with the markets table schema
- Cache invalidation only runs after a successful DB write
- Tests: success path, not-found, already-resolved, request/response serde

### #458 — Replace Redis KEYS with cursor-based SCAN invalidation
- `del_by_pattern` now acquires and releases a pool connection per SCAN+DEL batch instead of holding one connection for the full loop duration
- Tests: large-keyspace (250 keys, multi-round cursor), no-matches returns zero

### #459 — Introduce targeted cache invalidation tags
- Added `InvalidationTag` enum with `cache_keys()` — declares the exact bounded key set for each write event in one place
- Added `RedisCache::invalidate_tag()`
- `resolve_market` handler now uses `InvalidationTag::MarketResolved` instead of a manual key list
- Benchmark: `benches/invalidation_tags.rs` comparing tag derivation vs manual list
- Tests: exact key set, market-ID scoping, integration (unrelated key survives)

### #460 — Stop swallowing blockchain RPC errors into silent defaults
- Added `DataSource` enum (`Live | StaleFallback`) to all RPC-backed response types
- Removed all `unwrap_or_else(|_| json!({...zero defaults...}))` patterns; RPC errors now propagate and are not cached
- `observe_rpc_error` + `observe_rpc_fallback` called at every failure site
- `health_check_cached` retains intentional error-tolerance but now meters failures
- Tests: DataSource distinctness, snake_case serialisation, JSON round-trip

## Files changed
- `services/api/src/handlers.rs`
- `services/api/src/db.rs`
- `services/api/src/blockchain.rs`
- `services/api/src/cache/mod.rs`
- `services/api/src/migrations.rs`
- `services/api/src/lib.rs`
- `services/api/src/resolve_market_tests.rs` (new)
- `services/api/database/migrations/011_create_markets.sql` (new)
- `services/api/benches/invalidation_tags.rs` (new)
- `services/api/Cargo.toml`