### PR TITLE
fix: security and process hardening (#732 #733 #734 #735)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS
+# Each line maps a path pattern to one or more GitHub teams or users.
+# The last matching rule takes precedence.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything not matched below
+* @solutions-plug/maintainers
+
+# Smart contract code — requires smart contract team review
+/contracts/ @solutions-plug/smart-contract-team
+
+# Security module — requires security team review
+/services/api/src/security.rs @solutions-plug/security-team
+
+# CI/CD workflows — requires DevOps review
+/.github/workflows/ @solutions-plug/devops
+
+# Infrastructure / Terraform — requires DevOps review
+/infrastructure/ @solutions-plug/devops

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -34,18 +34,23 @@ regex = '''redis://[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+@[a-zA-Z0-9.-]+:[0-9]+'''
 tags = ["redis", "connection"]
 
 [allowlist]
-description = "Allowlist for false positives"
+description = "Allowlist for known false positives — each entry is intentional and scoped as narrowly as possible"
+
 paths = [
-  '''^\.env\.example$''',
-  '''^.*\.md$''',
-  '''^.*test.*\.rs$''',
-  '''^.*_test\.ts$''',
+  # .env.example documents required variables with empty or clearly fake values; never contains real secrets
+  '''^services/api/\.env\.example$''',
+  # frontend .env.example follows the same convention
+  '''^frontend/\.env\.example$''',
 ]
 
 regexes = [
+  # Generic placeholder domain used in code examples and templates — not a real host
   '''example\.com''',
+  # Loopback addresses are not secrets; they appear in default config and tests
   '''localhost''',
   '''127\.0\.0\.1''',
+  # Canonical Stellar placeholder public key (all X's) used in documentation
   '''GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX''',
+  # Canonical Stellar placeholder secret key (all X's) used in documentation
   '''SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX''',
 ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to PredictIQ
+
+## Branch Protection Rules
+
+The `main` branch is protected. The following rules are enforced:
+
+- **Pull request required** — direct pushes to `main` are not allowed; all changes must go through a PR.
+- **CI must pass** — all status checks in `.github/workflows/` must succeed before a PR can be merged.
+- **At least 1 approval required** — a PR must receive at least one approving review from a team member.
+- **No force pushes** — `git push --force` to `main` is disabled.
+- **No branch deletion** — `main` cannot be deleted.
+
+These rules are configured in the repository settings under **Settings → Branches → Branch protection rules**.
+
+## Code Ownership
+
+Sensitive paths have designated reviewers defined in [`.github/CODEOWNERS`](.github/CODEOWNERS). GitHub automatically requests a review from the relevant owner when a PR touches those paths.
+
+## Development Workflow
+
+1. Create a feature branch from `main`: `git checkout -b feat/your-feature`
+2. Make your changes and commit with a descriptive message.
+3. Open a pull request against `main`.
+4. Ensure all CI checks pass and at least one reviewer approves.
+5. Merge using **Squash and merge** to keep the history clean.
+
+## Secrets and Environment Variables
+
+- Never commit real secrets or credentials.
+- Copy `services/api/.env.example` to `services/api/.env` and fill in real values locally. The `.env` file is gitignored.
+- All placeholder values in `.env.example` are intentionally empty or clearly fake.
+- Gitleaks runs on every push to detect accidental secret commits (see `.gitleaks.toml`).

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -3,7 +3,7 @@ API_BIND_ADDR=0.0.0.0:8080
 BASE_URL=http://localhost:8080
 
 # Database
-DATABASE_URL=postgres://postgres:postgres@localhost/predictiq
+DATABASE_URL=postgres://<user>:<password>@<host>/<dbname>
 
 # PostgreSQL connection pool (sqlx); same values as built-in defaults
 DB_POOL_MIN_CONNECTIONS=5
@@ -35,8 +35,8 @@ PREDICTIQ_CONTRACT_ID=predictiq_contract
 # CONTRACT_KEY_HEALTH_CHECK=platform:stats   # defaults to CONTRACT_KEY_PLATFORM_STATS
 
 # Email Service (SendGrid)
-SENDGRID_API_KEY=SG.your_sendgrid_api_key_here
-FROM_EMAIL=noreply@predictiq.com
+SENDGRID_API_KEY=
+FROM_EMAIL=noreply@example.com
 
 # Optional Configuration
 RUST_LOG=info


### PR DESCRIPTION
## Summary

This PR resolves four related security and process issues in a single batch.

---

### #732 — Clean up `.env.example` placeholder values

`services/api/.env.example` contained values that resembled real secrets (`SG.your_sendgrid_api_key_here`, `postgres://postgres:postgres@...`). These have been replaced with clearly empty or generic equivalents so developers cannot accidentally copy them into production.

**Changes:**
- `SENDGRID_API_KEY` → blank (empty value)
- `FROM_EMAIL` → `noreply@example.com`
- `DATABASE_URL` → angle-bracket template `postgres://<user>:<password>@<host>/<dbname>`

---

### #733 — Tighten `.gitleaks.toml` allowlist

The previous allowlist used broad path globs (`^.*\.md$`, `^.*test.*\.rs$`) that could suppress detection of real secrets committed inside any Markdown or test file. Each entry is now scoped as narrowly as possible and annotated with a justification comment.

**Changes:**
- Removed blanket `.md` and test-file path allowances
- Pinned exact paths for the two `.env.example` files
- Added inline comments explaining every regex and path entry

---

### #734 — Create `CONTRIBUTING.md` with branch protection rules

No documentation existed for how `main` is protected or how contributors should work. `CONTRIBUTING.md` now covers:

- Branch protection rules (PR required, CI must pass, 1+ approval, no force push, no deletion)
- Code ownership via CODEOWNERS
- Development workflow (branch → PR → review → squash merge)
- Secrets handling guidance

---

### #735 — Create `.github/CODEOWNERS`

Changes to sensitive paths now automatically request review from the appropriate team.

| Path | Owner |
|------|-------|
| `/contracts/` | `@solutions-plug/smart-contract-team` |
| `/services/api/src/security.rs` | `@solutions-plug/security-team` |
| `/.github/workflows/` | `@solutions-plug/devops` |
| `/infrastructure/` | `@solutions-plug/devops` |
| `*` (default) | `@solutions-plug/maintainers` |

---

Closes #732
Closes #733
Closes #734
Closes #735