### PR TITLE
fix: add ResolutionDeadlinePassed error code for bet deadline enforce…

### DIFF
--- a/contracts/predict-iq/src/errors.rs
+++ b/contracts/predict-iq/src/errors.rs
@@ -53,4 +53,5 @@ pub enum ErrorCode {
     GovernanceTokenNotSet = 146,
     MarketNotResolved = 147,
     InvalidDeadline = 148,
+    ResolutionDeadlinePassed = 149,
 }


### PR DESCRIPTION
…ment

Issue #688: modules/bets.rs uses ResolutionDeadlinePassed error code but it was missing from errors.rs. This error is returned when a bet is attempted after the market's resolution deadline, preventing betting after the oracle resolution window begins.

- Added ResolutionDeadlinePassed = 149 to ErrorCode enum
- Existing deadline check in place_bet() already enforces this at line 92-94
- Tests in bets_test.rs already cover this scenario (test_place_bet_rejected_one_second_after_resolution_deadline_while_still_active)

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above

## Related Issues

Closes #688 
