### PR TITLE
Fix dark mode preference persistence

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,12 +1,16 @@
+import type { ReactNode } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { darkModeInitScript } from '../lib/darkMode';
+import '../styles/accessibility.css';
 
 export const metadata = { title: 'PredictIQ' };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const { isDarkMode } = useDarkMode();
-
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: darkModeInitScript }} />
+      </head>
       <body>
         <ErrorBoundary section="main">
           {children}

--- a/frontend/src/lib/darkMode.ts
+++ b/frontend/src/lib/darkMode.ts
@@ -1,0 +1,63 @@
+export const DARK_MODE_STORAGE_KEY = 'darkMode';
+
+export interface DarkModePreference {
+  isDarkMode: boolean;
+  hasStoredPreference: boolean;
+}
+
+export function getDarkModePreference(): DarkModePreference {
+  if (typeof window === 'undefined') {
+    return {
+      isDarkMode: false,
+      hasStoredPreference: false,
+    };
+  }
+
+  try {
+    const stored = window.localStorage.getItem(DARK_MODE_STORAGE_KEY);
+
+    if (stored === 'true' || stored === 'false') {
+      return {
+        isDarkMode: stored === 'true',
+        hasStoredPreference: true,
+      };
+    }
+  } catch {
+    // Ignore storage access errors and fall back to system preference.
+  }
+
+  return {
+    isDarkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+    hasStoredPreference: false,
+  };
+}
+
+export function applyDarkModePreference({
+  isDarkMode,
+  hasStoredPreference,
+}: DarkModePreference) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.classList.toggle('dark-mode', isDarkMode);
+  document.documentElement.classList.toggle(
+    'light-mode',
+    !isDarkMode && hasStoredPreference,
+  );
+}
+
+export const darkModeInitScript = `
+(function () {
+  try {
+    var stored = localStorage.getItem('${DARK_MODE_STORAGE_KEY}');
+    var hasStoredPreference = stored === 'true' || stored === 'false';
+    var isDarkMode = hasStoredPreference
+      ? stored === 'true'
+      : window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    document.documentElement.classList.toggle('dark-mode', isDarkMode);
+    document.documentElement.classList.toggle('light-mode', !isDarkMode && hasStoredPreference);
+  } catch (error) {}
+})();
+`;

--- a/frontend/src/lib/hooks/__tests__/useDarkMode.test.ts
+++ b/frontend/src/lib/hooks/__tests__/useDarkMode.test.ts
@@ -1,21 +1,57 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { darkModeInitScript } from '../../darkMode';
 import { useDarkMode } from '../useDarkMode';
 
 describe('useDarkMode', () => {
+  const mockMatchMedia = (matches: boolean) => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  };
+
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.classList.remove('dark-mode');
+    document.documentElement.classList.remove('light-mode');
+    mockMatchMedia(false);
   });
 
-  it('should initialize with light mode by default', () => {
+  it('should initialize with light mode by default', async () => {
     const { result } = renderHook(() => useDarkMode());
-    
-    // Wait for effect to run
-    expect(result.current.isLoaded).toBe(false);
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(localStorage.getItem('darkMode')).toBeNull();
   });
 
-  it('should toggle dark mode', () => {
+  it('should use system dark mode when no preference is stored', async () => {
+    mockMatchMedia(true);
+
     const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.isDarkMode).toBe(true);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(false);
+    expect(localStorage.getItem('darkMode')).toBeNull();
+  });
+
+  it('should toggle dark mode', async () => {
+    const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
     
     act(() => {
       result.current.toggleDarkMode();
@@ -24,8 +60,10 @@ describe('useDarkMode', () => {
     expect(result.current.isDarkMode).toBe(true);
   });
 
-  it('should persist dark mode preference to localStorage', () => {
+  it('should persist dark mode preference to localStorage', async () => {
     const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
     
     act(() => {
       result.current.toggleDarkMode();
@@ -34,17 +72,54 @@ describe('useDarkMode', () => {
     expect(localStorage.getItem('darkMode')).toBe('true');
   });
 
-  it('should load dark mode preference from localStorage', () => {
+  it('should load dark mode preference from localStorage', async () => {
     localStorage.setItem('darkMode', 'true');
     
     const { result } = renderHook(() => useDarkMode());
     
-    // Wait for effect
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
     expect(result.current.isDarkMode).toBe(true);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(false);
   });
 
-  it('should add dark-mode class to document element', () => {
+  it('should restore stored light preference over system dark mode', async () => {
+    mockMatchMedia(true);
+    localStorage.setItem('darkMode', 'false');
+
     const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(true);
+  });
+
+  it('should apply stored dark preference before React loads', () => {
+    localStorage.setItem('darkMode', 'true');
+
+    Function(darkModeInitScript)();
+
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(false);
+  });
+
+  it('should apply stored light preference before React loads', () => {
+    mockMatchMedia(true);
+    localStorage.setItem('darkMode', 'false');
+
+    Function(darkModeInitScript)();
+
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(true);
+  });
+
+  it('should add dark-mode class to document element', async () => {
+    const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
     
     act(() => {
       result.current.toggleDarkMode();
@@ -53,15 +128,19 @@ describe('useDarkMode', () => {
     expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
   });
 
-  it('should remove dark-mode class when toggling off', () => {
+  it('should remove dark-mode class when toggling off', async () => {
     localStorage.setItem('darkMode', 'true');
     
     const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
     
     act(() => {
       result.current.toggleDarkMode();
     });
     
     expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(true);
+    expect(localStorage.getItem('darkMode')).toBe('false');
   });
 });

--- a/frontend/src/lib/hooks/useDarkMode.ts
+++ b/frontend/src/lib/hooks/useDarkMode.ts
@@ -1,4 +1,14 @@
 import { useState, useEffect } from 'react';
+import {
+  DARK_MODE_STORAGE_KEY,
+  applyDarkModePreference,
+  getDarkModePreference,
+} from '../darkMode';
+
+const defaultPreference = {
+  isDarkMode: false,
+  hasStoredPreference: false,
+};
 
 /**
  * Hook for managing dark mode preference
@@ -6,44 +16,61 @@ import { useState, useEffect } from 'react';
  * Persists preference to localStorage
  */
 export function useDarkMode() {
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [preference, setPreference] = useState(defaultPreference);
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    // Load preference from localStorage or system preference
-    const stored = localStorage.getItem('darkMode');
-    
-    if (stored !== null) {
-      setIsDarkMode(stored === 'true');
-    } else {
-      // Check system preference
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setIsDarkMode(prefersDark);
-    }
-    
+    const initialPreference = getDarkModePreference();
+
+    setPreference(initialPreference);
+    applyDarkModePreference(initialPreference);
     setIsLoaded(true);
   }, []);
 
   useEffect(() => {
-    if (!isLoaded) return;
-
-    // Update localStorage
-    localStorage.setItem('darkMode', String(isDarkMode));
-
-    // Update document class
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark-mode');
-    } else {
-      document.documentElement.classList.remove('dark-mode');
+    if (preference.hasStoredPreference || typeof window === 'undefined') {
+      return;
     }
-  }, [isDarkMode, isLoaded]);
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      const nextPreference = {
+        isDarkMode: event.matches,
+        hasStoredPreference: false,
+      };
+
+      setPreference(nextPreference);
+      applyDarkModePreference(nextPreference);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [preference.hasStoredPreference]);
 
   const toggleDarkMode = () => {
-    setIsDarkMode(!isDarkMode);
+    setPreference((currentPreference) => {
+      const nextPreference = {
+        isDarkMode: !currentPreference.isDarkMode,
+        hasStoredPreference: true,
+      };
+
+      try {
+        localStorage.setItem(DARK_MODE_STORAGE_KEY, String(nextPreference.isDarkMode));
+      } catch {
+        // Keep the in-memory preference when storage is unavailable.
+      }
+
+      applyDarkModePreference(nextPreference);
+
+      return nextPreference;
+    });
   };
 
   return {
-    isDarkMode,
+    isDarkMode: preference.isDarkMode,
     toggleDarkMode,
     isLoaded,
   };

--- a/frontend/src/styles/accessibility.css
+++ b/frontend/src/styles/accessibility.css
@@ -428,6 +428,80 @@ html.dark-mode td {
   border-color: #4a4a4a;
 }
 
+/* Manual light mode class (overrides dark system preference) */
+html.light-mode,
+html.light-mode body {
+  background-color: #ffffff;
+  color: #222222;
+}
+
+html.light-mode a {
+  color: #0066cc;
+}
+
+html.light-mode a:hover {
+  color: #004499;
+}
+
+html.light-mode a:visited {
+  color: #551a8b;
+}
+
+html.light-mode button {
+  background-color: #0066cc;
+  border-color: #0066cc;
+  color: #ffffff;
+}
+
+html.light-mode button:hover {
+  background-color: #0052a3;
+  border-color: #0052a3;
+}
+
+html.light-mode input,
+html.light-mode textarea,
+html.light-mode select {
+  background-color: #ffffff;
+  color: #222222;
+  border-color: #666666;
+}
+
+html.light-mode input:focus,
+html.light-mode textarea:focus,
+html.light-mode select:focus {
+  border-color: #0066cc;
+  background-color: #ffffff;
+}
+
+html.light-mode .error-message {
+  color: #d32f2f;
+}
+
+html.light-mode input[aria-invalid="true"],
+html.light-mode textarea[aria-invalid="true"] {
+  border-color: #d32f2f;
+}
+
+html.light-mode h1,
+html.light-mode h2,
+html.light-mode h3,
+html.light-mode h4,
+html.light-mode h5,
+html.light-mode h6,
+html.light-mode label {
+  color: #222222;
+}
+
+html.light-mode th {
+  background-color: #f5f5f5;
+  border-color: #dddddd;
+  color: #222222;
+}
+
+html.light-mode td {
+  border-color: #dddddd;
+}
+
 /* Dark mode toggle button */
 .dark-mode-toggle {
   background: none;


### PR DESCRIPTION
## Summary
- persist explicit dark/light mode preference in localStorage only when the user toggles
- restore saved preference before React hydration with a root-level init script to prevent theme flash
- use prefers-color-scheme as the default when no stored preference exists
- add light-mode overrides so saved light preference beats a dark OS setting

Closes #653

## Tests
- NEXT_PUBLIC_API_URL=http://localhost:8000 npm test -- --runTestsByPath src/lib/hooks/__tests__/useDarkMode.test.ts

## Notes
- npm run build currently fails on existing Next 16 config issues: Turbopack rejects the custom webpack config, and explicit --webpack fails because the existing splitChunks config emits duplicate chunks/vendor.js.