### PR TITLE
fix: async newsletter emails, migration locking, webhook signature enforcement, DLQ metric

### DIFF
--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -320,7 +320,7 @@ pub async fn newsletter_subscribe(
     tracing::info!(request_id, email = %email, source = %source, ip = %ip, "newsletter subscription attempt");
 
     Ok((
-        StatusCode::OK,
+        StatusCode::ACCEPTED,
         Json(NewsletterResponse {
             success: true,
             message: "Please check your email to confirm your subscription.".to_string(),
@@ -974,6 +974,8 @@ pub async fn email_queue_stats(
         .get_stats()
         .await
         .map_err(into_api_error)?;
+
+    state.metrics.set_dlq_size(stats.dead_letter as i64);
 
     Ok((StatusCode::OK, Json(stats)))
 }

--- a/services/api/src/metrics.rs
+++ b/services/api/src/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use prometheus::{Encoder, HistogramVec, IntCounterVec, Registry, TextEncoder};
+use prometheus::{Encoder, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder};
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -13,6 +13,7 @@ pub struct Metrics {
     rpc_errors: IntCounterVec,
     rpc_fallbacks: IntCounterVec,
     db_timeouts: IntCounterVec,
+    email_dlq_size: IntGauge,
 }
 
 impl Metrics {
@@ -70,6 +71,12 @@ impl Metrics {
         )
         .context("db_timeouts metric")?;
 
+        let email_dlq_size = IntGauge::new(
+            "email_dlq_size",
+            "Number of email jobs currently in the dead-letter queue",
+        )
+        .context("email_dlq_size metric")?;
+
         registry.register(Box::new(cache_hits.clone()))?;
         registry.register(Box::new(cache_misses.clone()))?;
         registry.register(Box::new(invalidations.clone()))?;
@@ -77,6 +84,7 @@ impl Metrics {
         registry.register(Box::new(rpc_errors.clone()))?;
         registry.register(Box::new(rpc_fallbacks.clone()))?;
         registry.register(Box::new(db_timeouts.clone()))?;
+        registry.register(Box::new(email_dlq_size.clone()))?;
 
         Ok(Self {
             registry,
@@ -87,6 +95,7 @@ impl Metrics {
             rpc_errors,
             rpc_fallbacks,
             db_timeouts,
+            email_dlq_size,
         })
     }
 
@@ -124,6 +133,10 @@ impl Metrics {
 
     pub fn observe_db_timeout(&self, operation: &str) {
         self.db_timeouts.with_label_values(&[operation]).inc();
+    }
+
+    pub fn set_dlq_size(&self, n: i64) {
+        self.email_dlq_size.set(n);
     }
 
     pub fn observe_tx_eviction(&self, count: u64) {

--- a/services/api/src/migrations.rs
+++ b/services/api/src/migrations.rs
@@ -108,9 +108,49 @@ impl<'a> MigrationRunner<'a> {
     /// Ensure the tracking table exists, then apply every pending migration.
     /// Already-applied migrations are skipped. Returns the number of newly
     /// applied migrations.
+    ///
+    /// Uses a PostgreSQL session-level advisory lock to serialize concurrent
+    /// invocations (e.g. multiple instances starting simultaneously). If another
+    /// instance already holds the lock, this call aborts with an error so the
+    /// caller can surface it and halt startup cleanly.
     pub async fn run(&self) -> anyhow::Result<usize> {
         self.ensure_tracking_table().await?;
 
+        // Stable lock key — chosen to be unique to this codebase.
+        const MIGRATION_LOCK_KEY: i64 = 0x7072_6564_6963_7471_u64 as i64;
+
+        let mut lock_conn = self
+            .pool
+            .acquire()
+            .await
+            .context("acquire advisory lock connection")?;
+
+        let locked: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(MIGRATION_LOCK_KEY)
+            .fetch_one(&mut *lock_conn)
+            .await
+            .context("acquire migration advisory lock")?;
+
+        if !locked {
+            bail!(
+                "another instance holds the migration advisory lock — \
+                 aborting to prevent concurrent migration execution"
+            );
+        }
+
+        let result = self.run_inner().await;
+
+        // Always release the lock, even on failure, before the connection
+        // returns to the pool (session-level locks survive pool reuse).
+        let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
+            .bind(MIGRATION_LOCK_KEY)
+            .execute(&mut *lock_conn)
+            .await;
+
+        result
+    }
+
+    async fn run_inner(&self) -> anyhow::Result<usize> {
         let mut applied = 0usize;
 
         for migration in MIGRATIONS {

--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -468,7 +468,7 @@ pub async fn sendgrid_webhook_middleware(
 ) -> Result<Response, StatusCode> {
     let is_dev = std::env::var("ENVIRONMENT")
         .map(|e| e == "development")
-        .unwrap_or(true); // default to dev if not set
+        .unwrap_or(false); // default to non-dev so signature verification is enforced
 
     if config.secret.is_none() && !is_dev {
         return Err(StatusCode::UNAUTHORIZED);


### PR DESCRIPTION
## Summary

This PR resolves four backend reliability and security issues across the email and migration subsystems.

---

### fix(#677) — Newsletter confirmation email is now non-blocking

**File:** `services/api/src/handlers.rs`

The `newsletter_subscribe` handler was already enqueuing confirmation emails via `email/queue.rs`, but still returned `200 OK` — implying the operation had completed synchronously. Changed the response to `202 Accepted` so the status code accurately reflects that the email has been accepted for asynchronous processing, not sent inline. This also aligns the endpoint with REST semantics for async operations.

---

### fix(#676) — Migrations are now serialized with a PostgreSQL advisory lock

**File:** `services/api/src/migrations.rs`

In a horizontally scaled deployment, multiple instances starting simultaneously could each call `MigrationRunner::run()` concurrently, resulting in duplicate or conflicting migration attempts. 

`run()` now:
1. Acquires a session-level advisory lock via `pg_try_advisory_lock` on a stable key (`0x707265646963_7471`) before executing any migrations.
2. If the lock is already held by another instance, aborts immediately with a clear error — causing that instance's startup to fail rather than racing.
3. Always calls `pg_advisory_unlock` before the connection is returned to the pool (both on success and failure), preventing the lock from leaking across pool-reused connections.

The migration logic itself is extracted into a private `run_inner()` to keep the locking and execution concerns separate.

---

### fix(#679) — Webhook HMAC signature verification is now enforced by default

**File:** `services/api/src/security.rs`

`sendgrid_webhook_middleware` determined whether to run in development mode (bypassing signature verification) via:

```rust
.unwrap_or(true) // default to dev if not set
```

If the `ENVIRONMENT` environment variable was absent — which is common in staging or misconfigured production deployments — the middleware silently skipped HMAC verification, allowing any party to forge webhook events. Changed the default to `false` so that signature verification is enforced unless `ENVIRONMENT=development` is explicitly set.

---

### fix(#678) — DLQ size exposed as a Prometheus gauge

**Files:** `services/api/src/metrics.rs`, `services/api/src/handlers.rs`

The dead-letter queue (Redis key `email:dead_letter`) had no observability. Added an `email_dlq_size` `IntGauge` to the `Metrics` registry. The gauge is updated each time the `GET /api/v1/email/queue/stats` endpoint is called, reflecting the current DLQ cardinality from Redis.

The existing `list_dead_letter` (`GET /api/v1/email/dead-letter`) and `requeue_dead_letter` (`POST /api/v1/email/dead-letter/:id/requeue`) admin endpoints satisfy the inspect-and-replay acceptance criterion — no new endpoints were needed.

---

## Closes

Closes #677
Closes #676
Closes #679
Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)