### PR TITLE
fix: db timeouts, Stellar passphrase validation, pool metrics, RPC retry backoff

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -25,6 +25,10 @@ REDIS_URL=redis://127.0.0.1:6379
 BLOCKCHAIN_NETWORK=testnet
 BLOCKCHAIN_RPC_URL=https://soroban-testnet.stellar.org
 PREDICTIQ_CONTRACT_ID=predictiq_contract
+# Network passphrase validated against the RPC node at startup.
+# Defaults to the canonical passphrase for BLOCKCHAIN_NETWORK (testnet or mainnet).
+# Set explicitly when using a custom network or to guard against misconfiguration.
+# STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # Contract storage key schema (v1 defaults shown).
 # Override these when a network uses different key naming conventions.

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -12,6 +12,11 @@ DB_POOL_ACQUIRE_TIMEOUT_SECS=5
 # Optional — seconds; leave unset to use sqlx defaults for idle / lifetime
 # DB_POOL_IDLE_TIMEOUT_SECS=600
 # DB_POOL_MAX_LIFETIME_SECS=1800
+# PostgreSQL session-level timeouts set on every connection (milliseconds).
+# statement_timeout aborts queries that exceed the limit; lock_timeout aborts
+# lock waits that exceed the limit. Both default to 30s/10s respectively.
+DB_STATEMENT_TIMEOUT_MS=30000
+DB_LOCK_TIMEOUT_MS=10000
 
 # Redis
 REDIS_URL=redis://127.0.0.1:6379

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -37,6 +37,28 @@ cargo test -p predictiq-api -- --nocapture
 | `DB_POOL_IDLE_TIMEOUT_SECS` | _(sqlx default)_ | Seconds before idle connections are reaped |
 | `DB_POOL_MAX_LIFETIME_SECS` | _(sqlx default)_ | Max lifetime of a connection |
 | `DB_QUERY_TIMEOUT_SECS` | `30` | Per-query execution timeout |
+| `DB_STATEMENT_TIMEOUT_MS` | `30000` | PostgreSQL `statement_timeout` per connection (ms) |
+| `DB_LOCK_TIMEOUT_MS` | `10000` | PostgreSQL `lock_timeout` per connection (ms) |
+
+### Recommended production pool settings
+
+| Scenario | `MIN` | `MAX` | `ACQUIRE_TIMEOUT` | `IDLE_TIMEOUT` | `MAX_LIFETIME` |
+|---|---|---|---|---|---|
+| Low traffic / staging | `2` | `10` | `5s` | `300s` | `1800s` |
+| Standard production | `5` | `25` | `5s` | `600s` | `1800s` |
+| High-throughput production | `10` | `50` | `10s` | `600s` | `3600s` |
+
+Rule of thumb: `MAX` ≤ PostgreSQL `max_connections` minus connections reserved for migrations, pg_bouncer, and maintenance sessions.
+
+### Pool metrics
+
+The following Prometheus gauges are exported on `/metrics` and updated on each scrape:
+
+| Metric | Description |
+|---|---|
+| `db_pool_size` | Total connections in the pool (idle + active) |
+| `db_pool_idle` | Idle connections waiting for work |
+| `db_pool_active` | Connections currently executing a query |
 | `BLOCKCHAIN_RPC_URL` | testnet default | Soroban RPC endpoint |
 | `PREDICTIQ_CONTRACT_ID` | `predictiq_contract` | On-chain contract ID |
 | `API_KEYS` | _(none)_ | Comma-separated admin API keys |

--- a/services/api/src/blockchain.rs
+++ b/services/api/src/blockchain.rs
@@ -33,6 +33,7 @@ pub struct BlockchainClient {
     cache: RedisCache,
     metrics: Metrics,
     monitor: Arc<MonitoringState>,
+    expected_passphrase: String,
 }
 
 /// TTL for watched transaction hashes. Entries older than this are evicted
@@ -218,7 +219,48 @@ impl BlockchainClient {
             cache,
             metrics,
             monitor: Arc::new(MonitoringState::default()),
+            expected_passphrase: config.network_passphrase.clone(),
         })
+    }
+
+    /// Query the RPC node for its network passphrase and verify it matches
+    /// the configured `STELLAR_NETWORK_PASSPHRASE`. Startup must call this and
+    /// fail fast if the passphrase does not match, preventing silently signed
+    /// transactions for the wrong network.
+    ///
+    /// When `STELLAR_NETWORK_PASSPHRASE` is unset (empty string, e.g. for a
+    /// custom network without a known passphrase), validation is skipped.
+    pub async fn validate_network_passphrase(&self) -> anyhow::Result<()> {
+        if self.expected_passphrase.is_empty() {
+            tracing::info!("STELLAR_NETWORK_PASSPHRASE not set; skipping passphrase validation");
+            return Ok(());
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct NetworkResult {
+            passphrase: String,
+        }
+
+        let result: NetworkResult = self
+            .rpc_call("getNetwork", serde_json::json!({}))
+            .await
+            .context("failed to query RPC network info for passphrase validation")?;
+
+        if result.passphrase != self.expected_passphrase {
+            anyhow::bail!(
+                "Stellar network passphrase mismatch — \
+                 RPC returned {:?} but STELLAR_NETWORK_PASSPHRASE is {:?}. \
+                 Check BLOCKCHAIN_NETWORK and STELLAR_NETWORK_PASSPHRASE.",
+                result.passphrase,
+                self.expected_passphrase,
+            );
+        }
+
+        tracing::info!(
+            passphrase = %result.passphrase,
+            "Stellar network passphrase validated"
+        );
+        Ok(())
     }
 
     async fn rpc_call<T: for<'de> Deserialize<'de>>(

--- a/services/api/src/blockchain.rs
+++ b/services/api/src/blockchain.rs
@@ -171,6 +171,18 @@ struct RpcError {
     message: String,
 }
 
+/// Standard JSON-RPC error codes that indicate a client-side mistake and
+/// should never be retried (retrying will produce the same error).
+fn is_non_retryable_rpc_error(code: i64) -> bool {
+    matches!(
+        code,
+        -32700  // Parse error
+        | -32600  // Invalid request
+        | -32601  // Method not found
+        | -32602  // Invalid params
+    )
+}
+
 impl BlockchainClient {
     pub fn new(config: &Config, cache: RedisCache, metrics: Metrics) -> anyhow::Result<Self> {
         let http = Client::builder()
@@ -284,37 +296,73 @@ impl BlockchainClient {
 
             match response {
                 Ok(resp) => {
-                    let parsed = resp
-                        .error_for_status()
-                        .context("rpc status error")?
-                        .json::<RpcEnvelope<T>>()
-                        .await
-                        .context("rpc parse error")?;
+                    let status = resp.status();
 
-                    if let Some(err) = parsed.error {
+                    // 4xx (except 429 Too Many Requests) are non-retryable client errors.
+                    if status.is_client_error() && status != reqwest::StatusCode::TOO_MANY_REQUESTS {
+                        return Err(anyhow!(
+                            "rpc {} non-retryable client error: {}",
+                            method, status
+                        ));
+                    }
+
+                    if !status.is_success() {
+                        // 5xx / 429 are transient — retry with backoff.
                         if attempt >= self.retry_attempts {
                             return Err(anyhow!(
-                                "rpc {} failed: {} ({})",
-                                method,
-                                err.message,
-                                err.code
+                                "rpc {} http error after {} attempt(s): {}",
+                                method, attempt, status
                             ));
                         }
-                    } else if let Some(result) = parsed.result {
-                        return Ok(result);
-                    } else if attempt >= self.retry_attempts {
-                        return Err(anyhow!("rpc {} returned empty result", method));
+                        tracing::warn!(
+                            method, attempt, %status,
+                            "rpc http error, retrying"
+                        );
+                    } else {
+                        let parsed = resp
+                            .json::<RpcEnvelope<T>>()
+                            .await
+                            .context("rpc parse error")?;
+
+                        if let Some(err) = parsed.error {
+                            if is_non_retryable_rpc_error(err.code) {
+                                return Err(anyhow!(
+                                    "rpc {} non-retryable error: {} ({})",
+                                    method, err.message, err.code
+                                ));
+                            }
+                            if attempt >= self.retry_attempts {
+                                return Err(anyhow!(
+                                    "rpc {} failed: {} ({})",
+                                    method, err.message, err.code
+                                ));
+                            }
+                            tracing::warn!(
+                                method, attempt, code = err.code,
+                                message = %err.message, "rpc error, retrying"
+                            );
+                        } else if let Some(result) = parsed.result {
+                            return Ok(result);
+                        } else if attempt >= self.retry_attempts {
+                            return Err(anyhow!("rpc {} returned empty result", method));
+                        } else {
+                            tracing::warn!(method, attempt, "rpc empty result, retrying");
+                        }
                     }
                 }
                 Err(err) => {
                     if attempt >= self.retry_attempts {
                         return Err(anyhow!("rpc {} transport failed: {err}", method));
                     }
+                    tracing::warn!(method, attempt, error = %err, "rpc transport error, retrying");
                 }
             }
 
-            let backoff = self.retry_base_delay_ms * u64::from(attempt);
-            sleep(Duration::from_millis(backoff)).await;
+            // Exponential backoff: base_delay * 2^(attempt-1), capped at 60 s.
+            let backoff_ms = (self.retry_base_delay_ms * (1u64 << (attempt - 1).min(10)))
+                .min(60_000);
+            tracing::warn!(method, attempt, backoff_ms, "rpc retry scheduled");
+            sleep(Duration::from_millis(backoff_ms)).await;
         }
     }
 

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -215,6 +215,10 @@ pub struct Config {
     /// Contract storage key schema.  See [`ContractKeySchema`] for per-field
     /// documentation and startup validation.
     pub contract_key_schema: ContractKeySchema,
+    /// Expected Stellar network passphrase. Validated against the RPC node at
+    /// startup. Configured via `STELLAR_NETWORK_PASSPHRASE`; defaults to the
+    /// canonical passphrase for the configured `BLOCKCHAIN_NETWORK`.
+    pub network_passphrase: String,
 }
 
 impl Config {
@@ -282,6 +286,15 @@ impl Config {
         let trusted_proxy_cidrs = env::var("TRUSTED_PROXY_CIDRS")
             .map(|v| v.split(',').filter_map(|s| s.trim().parse().ok()).collect())
             .unwrap_or_else(|_| vec![]);
+
+        let network_passphrase = env::var("STELLAR_NETWORK_PASSPHRASE")
+            .unwrap_or_else(|_| match &blockchain_network {
+                BlockchainNetwork::Testnet => "Test SDF Network ; September 2015".to_string(),
+                BlockchainNetwork::Mainnet => {
+                    "Public Global Stellar Network ; September 2015".to_string()
+                }
+                BlockchainNetwork::Custom => String::new(),
+            });
 
         Self {
             bind_addr,
@@ -422,6 +435,7 @@ impl Config {
             unsubscribe_signing_secret: env::var("UNSUBSCRIBE_SIGNING_SECRET").ok(),
             cors: CorsConfig::from_env(),
             contract_key_schema: ContractKeySchema::from_env(),
+            network_passphrase,
         }
     }
 

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -142,6 +142,13 @@ pub struct DbPoolConfig {
     /// Per-query execution timeout. Queries that exceed this are cancelled and
     /// return an error. Configured via `DB_QUERY_TIMEOUT_SECS` (default: 30).
     pub query_timeout: Duration,
+    /// PostgreSQL `statement_timeout` set on every connection via `after_connect`.
+    /// Prevents runaway queries from holding connections indefinitely.
+    /// Configured via `DB_STATEMENT_TIMEOUT_MS` (default: 30000 ms).
+    pub statement_timeout_ms: u64,
+    /// PostgreSQL `lock_timeout` set on every connection via `after_connect`.
+    /// Prevents lock-contention hangs. Configured via `DB_LOCK_TIMEOUT_MS` (default: 10000 ms).
+    pub lock_timeout_ms: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -295,6 +302,14 @@ impl Config {
                         .unwrap_or(30)
                         .max(1),
                 ),
+                statement_timeout_ms: env::var("DB_STATEMENT_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(30_000),
+                lock_timeout_ms: env::var("DB_LOCK_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(10_000),
             },
             blockchain_rpc_url,
             blockchain_network,

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -98,6 +98,12 @@ impl Database {
         self.pool.clone()
     }
 
+    /// Snapshot pool size/idle into Prometheus gauges.
+    /// Call this just before rendering `/metrics` so the values are current.
+    pub fn record_pool_metrics(&self) {
+        self.metrics.record_pool_metrics(self.pool.size(), self.pool.num_idle());
+    }
+
     pub async fn new(
         database_url: &str,
         cache: RedisCache,

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -104,10 +104,24 @@ impl Database {
         metrics: Metrics,
         pool_config: &crate::config::DbPoolConfig,
     ) -> anyhow::Result<Self> {
+        let stmt_timeout_ms = pool_config.statement_timeout_ms;
+        let lock_timeout_ms = pool_config.lock_timeout_ms;
+
         let mut builder = PgPoolOptions::new()
             .max_connections(pool_config.max_connections)
             .min_connections(pool_config.min_connections)
-            .acquire_timeout(pool_config.acquire_timeout);
+            .acquire_timeout(pool_config.acquire_timeout)
+            .after_connect(move |conn, _meta| {
+                Box::pin(async move {
+                    sqlx::query(&format!("SET statement_timeout = {stmt_timeout_ms}"))
+                        .execute(&mut *conn)
+                        .await?;
+                    sqlx::query(&format!("SET lock_timeout = {lock_timeout_ms}"))
+                        .execute(&mut *conn)
+                        .await?;
+                    Ok(())
+                })
+            });
 
         if let Some(idle) = pool_config.idle_timeout {
             builder = builder.idle_timeout(idle);

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -735,6 +735,7 @@ pub async fn resolve_market(
 }
 
 pub async fn metrics(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, ApiError> {
+    state.db.record_pool_metrics();
     let body = state.metrics.render().map_err(into_api_error)?;
     Ok((
         StatusCode::OK,

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -95,6 +95,7 @@ async fn main() -> anyhow::Result<()> {
     let cache = RedisCache::new(&config.redis_url).await?;
     let db = Database::new(&config.database_url, cache.clone(), metrics.clone(), &config.db_pool).await?;
     let blockchain = BlockchainClient::new(&config, cache.clone(), metrics.clone())?;
+    blockchain.validate_network_passphrase().await?;
 
     let email_service = EmailService::new(config.clone())?;
     let email_queue = EmailQueue::new(cache.clone(), db.clone());

--- a/services/api/src/metrics.rs
+++ b/services/api/src/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use prometheus::{Encoder, HistogramVec, IntCounterVec, Registry, TextEncoder};
+use prometheus::{Encoder, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder};
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -13,6 +13,9 @@ pub struct Metrics {
     rpc_errors: IntCounterVec,
     rpc_fallbacks: IntCounterVec,
     db_timeouts: IntCounterVec,
+    db_pool_size: IntGauge,
+    db_pool_idle: IntGauge,
+    db_pool_active: IntGauge,
 }
 
 impl Metrics {
@@ -70,6 +73,24 @@ impl Metrics {
         )
         .context("db_timeouts metric")?;
 
+        let db_pool_size = IntGauge::new(
+            "db_pool_size",
+            "Total number of connections in the PostgreSQL pool (idle + active)",
+        )
+        .context("db_pool_size metric")?;
+
+        let db_pool_idle = IntGauge::new(
+            "db_pool_idle",
+            "Number of idle connections in the PostgreSQL pool",
+        )
+        .context("db_pool_idle metric")?;
+
+        let db_pool_active = IntGauge::new(
+            "db_pool_active",
+            "Number of active (in-use) connections in the PostgreSQL pool",
+        )
+        .context("db_pool_active metric")?;
+
         registry.register(Box::new(cache_hits.clone()))?;
         registry.register(Box::new(cache_misses.clone()))?;
         registry.register(Box::new(invalidations.clone()))?;
@@ -77,6 +98,9 @@ impl Metrics {
         registry.register(Box::new(rpc_errors.clone()))?;
         registry.register(Box::new(rpc_fallbacks.clone()))?;
         registry.register(Box::new(db_timeouts.clone()))?;
+        registry.register(Box::new(db_pool_size.clone()))?;
+        registry.register(Box::new(db_pool_idle.clone()))?;
+        registry.register(Box::new(db_pool_active.clone()))?;
 
         Ok(Self {
             registry,
@@ -87,6 +111,9 @@ impl Metrics {
             rpc_errors,
             rpc_fallbacks,
             db_timeouts,
+            db_pool_size,
+            db_pool_idle,
+            db_pool_active,
         })
     }
 
@@ -124,6 +151,14 @@ impl Metrics {
 
     pub fn observe_db_timeout(&self, operation: &str) {
         self.db_timeouts.with_label_values(&[operation]).inc();
+    }
+
+    pub fn record_pool_metrics(&self, size: u32, idle: usize) {
+        let idle = idle as i64;
+        let size = size as i64;
+        self.db_pool_size.set(size);
+        self.db_pool_idle.set(idle);
+        self.db_pool_active.set((size - idle).max(0));
     }
 
     pub fn observe_tx_eviction(&self, count: u64) {


### PR DESCRIPTION
## Summary

Resolves four backend reliability and security issues across `services/api/src/db.rs` and `services/api/src/blockchain.rs`.

---

### fix(#674) — Set `statement_timeout` and `lock_timeout` on all PostgreSQL connections

**Problem:** `db.rs` configured the SQLx pool but never set session-level timeouts. A slow or runaway query could hold a connection indefinitely and exhaust the pool.

**Changes:**
- Added `statement_timeout_ms` and `lock_timeout_ms` to `DbPoolConfig` in `config.rs`
- Applied both via `PgPoolOptions::after_connect` on every new connection in `db.rs`
- `DB_STATEMENT_TIMEOUT_MS` (default: 30 000 ms) and `DB_LOCK_TIMEOUT_MS` (default: 10 000 ms) configurable via env
- Both vars documented in `services/api/.env.example`

---

### fix(#673) — Validate Stellar network passphrase against the RPC node at startup

**Problem:** `blockchain.rs` used a Stellar network passphrase from config without verifying it against the actual RPC node. A misconfiguration (e.g. testnet passphrase pointed at mainnet) caused silent transaction rejection or incorrect signing.

**Changes:**
- Added `network_passphrase: String` to `Config` in `config.rs`, defaulting to the canonical testnet/mainnet passphrase for the configured `BLOCKCHAIN_NETWORK`; overridable via `STELLAR_NETWORK_PASSPHRASE`
- Added `expected_passphrase` field to `BlockchainClient`
- Added `BlockchainClient::validate_network_passphrase()` async method — calls `getNetwork` RPC and bails with a clear error if the returned passphrase does not match
- Called at startup in `main.rs` immediately after `BlockchainClient::new()`; any mismatch aborts startup
- `STELLAR_NETWORK_PASSPHRASE` documented in `services/api/.env.example`

---

### feat(#675) — Expose connection pool metrics via the `/metrics` Prometheus endpoint

**Problem:** `db.rs` created the pool with configurable settings but exposed no pool-level metrics, making it impossible to observe pool pressure in production.

**Changes:**
- Added `db_pool_size`, `db_pool_idle`, and `db_pool_active` `IntGauge` Prometheus metrics to `metrics.rs`
- Added `Metrics::record_pool_metrics(size, idle)` method
- Added `Database::record_pool_metrics()` — reads live counters from the SQLx pool and updates the gauges
- Called in the `/metrics` handler in `handlers.rs` just before rendering, so scraped values are always current
- Added recommended production pool values table and pool metrics table to `services/api/README.md`

---

### fix(#672) — Retry failed Stellar RPC calls with exponential backoff

**Problem:** `blockchain.rs` retried all RPC failures with linear backoff. Non-retryable errors (e.g. invalid params) were still retried. HTTP 4xx/5xx paths bypassed retry logic entirely due to `error_for_status()?`. Retry attempts were not recorded in tracing spans.

**Changes:**
- Changed backoff from linear (`base × attempt`) to true exponential (`base × 2^(attempt−1)`, capped at 60 s)
- Added `is_non_retryable_rpc_error(code)` — immediately returns error for JSON-RPC standard client error codes (`−32600` invalid request, `−32601` method not found, `−32602` invalid params, `−32700` parse error)
- Fixed HTTP error handling: non-429 4xx responses are non-retryable; 5xx and 429 responses are retried with backoff
- Added `tracing::warn!` on every retry recording `method`, `attempt`, and `backoff_ms` in the span

---

## Files changed

| File | What changed |
|---|---|
| `services/api/src/config.rs` | `DbPoolConfig`: added `statement_timeout_ms`, `lock_timeout_ms`; `Config`: added `network_passphrase` |
| `services/api/src/db.rs` | `Database::new`: added `after_connect` timeout hook; added `Database::record_pool_metrics()` |
| `services/api/src/blockchain.rs` | Added `expected_passphrase` field; `validate_network_passphrase()`; `is_non_retryable_rpc_error()`; exponential backoff + tracing in `rpc_call` |
| `services/api/src/main.rs` | Call `blockchain.validate_network_passphrase().await?` at startup |
| `services/api/src/metrics.rs` | Added `db_pool_size`, `db_pool_idle`, `db_pool_active` gauges and `record_pool_metrics()` |
| `services/api/src/handlers.rs` | Snapshot pool metrics before rendering `/metrics` |
| `services/api/.env.example` | Documented `DB_STATEMENT_TIMEOUT_MS`, `DB_LOCK_TIMEOUT_MS`, `STELLAR_NETWORK_PASSPHRASE` |
| `services/api/README.md` | Added recommended pool settings table and pool metrics reference table |

Closes #672
Closes #673
Closes #674
Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)