### PR TITLE
fix: enforce npm audit exit code in frontend CI (#637)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,10 +433,14 @@ jobs:
         working-directory: contracts/predict-iq
 
       - name: Scan Node.js dependencies
+        # Fails CI on high/critical npm vulnerabilities.
+        # Exception process: for known false positives, add an entry to
+        # frontend/.nsprc (npm audit ignore) with a justification comment
+        # and link to the tracking issue, then get security team approval
+        # before merging.
         run: |
           npm audit --audit-level=high
         working-directory: frontend
-        continue-on-error: true
 
   container-scanning:
     name: Container Image Scanning


### PR DESCRIPTION
## Summary
Removes `continue-on-error: true` from the `Scan Node.js dependencies` step in `.github/workflows/test.yml` so high/critical npm vulnerabilities now fail CI instead of being silently ignored.

## Changes
- Removed `continue-on-error: true` from the npm audit step
- Added inline comment documenting the exception process for known false positives (via `frontend/.nsprc` with justification + security team approval)

## Testing
CI will now exit non-zero when `npm audit --audit-level=high` finds high or critical vulnerabilities.

Closes #637