### PR TITLE
Add cargo audit for services/api (#638)

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -25,20 +25,39 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
 
-      - name: Audit Rust dependencies
+      - name: Audit contracts/predict-iq dependencies
         run: cargo audit --deny warnings
+        working-directory: contracts/predict-iq
         continue-on-error: true
 
-      - name: Audit Rust dependencies (fail on critical)
+      - name: Audit contracts/predict-iq (fail on critical)
         run: |
           output=$(cargo audit --json)
           critical=$(echo "$output" | jq '[.vulnerabilities[] | select(.advisory.severity == "critical")] | length')
           if [ "$critical" -gt 0 ]; then
-            echo "❌ Found $critical critical vulnerabilities"
+            echo "❌ Found $critical critical vulnerabilities in contracts/predict-iq"
             echo "$output" | jq '.vulnerabilities[] | select(.advisory.severity == "critical")'
             exit 1
           fi
-          echo "✅ No critical vulnerabilities found"
+          echo "✅ No critical vulnerabilities found in contracts/predict-iq"
+        working-directory: contracts/predict-iq
+
+      - name: Audit services/api dependencies
+        run: cargo audit --deny warnings
+        working-directory: services/api
+        continue-on-error: true
+
+      - name: Audit services/api (fail on critical)
+        run: |
+          output=$(cargo audit --json)
+          critical=$(echo "$output" | jq '[.vulnerabilities[] | select(.advisory.severity == "critical")] | length')
+          if [ "$critical" -gt 0 ]; then
+            echo "❌ Found $critical critical vulnerabilities in services/api"
+            echo "$output" | jq '.vulnerabilities[] | select(.advisory.severity == "critical")'
+            exit 1
+          fi
+          echo "✅ No critical vulnerabilities found in services/api"
+        working-directory: services/api
 
   scan-npm:
     name: Scan NPM Dependencies


### PR DESCRIPTION
Closes #638

Add explicit `cargo audit` steps for `services/api` in `dependency-scan.yml`. The root workspace only covers `contracts/*`, so the API crate's dependencies (axum, sqlx, redis, reqwest) were never audited.

**Changes:**
- Split the single generic audit step into two targeted pairs, one for `contracts/predict-iq` and one for `services/api`, using `working-directory`
- Critical vulnerabilities in either crate fail the `scan-rust` job and block merges to main