### PR TITLE
fix: use wc -c for portable WASM size check

### DIFF
--- a/.github/workflows/contract-deployment.yml
+++ b/.github/workflows/contract-deployment.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Verify WASM size
         run: |
-          size=$(stat -f%z target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm 2>/dev/null || stat -c%s target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm)
+          size=$(wc -c < target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm)
           echo "Optimized WASM size: $size bytes"
           max_size=65536
           if [ $size -gt $max_size ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,7 +592,7 @@ jobs:
 
       - name: Check WASM size
         run: |
-          size=$(stat -f%z target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm 2>/dev/null || stat -c%s target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm)
+          size=$(wc -c < target/wasm32-unknown-unknown/release/predict_iq_optimized.wasm)
           echo "Optimized WASM size: $size bytes"
           max_size=65536  # 64KB limit
           if [ $size -gt $max_size ]; then


### PR DESCRIPTION
## Summary
Fixes #639

Replaced `stat -f%z ... 2>/dev/null || stat -c%s ...` with `wc -c <` in the WASM size check step.

## Changes
- `.github/workflows/test.yml`
- `.github/workflows/contract-deployment.yml`

`wc -c` is portable across Linux and macOS and produces no error output on success.