### PR TITLE
fix(#856 #857 #858): harden admin auth, webhook signatures, and CORS

### DIFF
--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -564,6 +564,140 @@ paths:
         "500":
           $ref: "#/components/responses/ApiError"
 
+  /api/blockchain/replay:
+    post:
+      tags: [blockchain]
+      operationId: blockchainReplay
+      summary: Replay blockchain events (admin)
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Replay result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/ApiError"
+        "500":
+          $ref: "#/components/responses/ApiError"
+
+  /api/v1/email/queue/dead-letter:
+    get:
+      tags: [email]
+      operationId: getEmailDeadLetterList
+      summary: List dead-letter email jobs (admin)
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Dead-letter job list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/ApiError"
+        "500":
+          $ref: "#/components/responses/ApiError"
+
+  /api/v1/email/queue/dead-letter/{job_id}/requeue:
+    post:
+      tags: [email]
+      operationId: requeueEmailDeadLetterJob
+      summary: Requeue a dead-letter email job (admin)
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Dead-letter job identifier
+      responses:
+        "200":
+          description: Requeue result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/ApiError"
+        "500":
+          $ref: "#/components/responses/ApiError"
+
+  /api/v1/audit/logs:
+    get:
+      tags: [audit]
+      operationId: getAuditLogs
+      summary: Retrieve audit log entries (admin)
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Audit log entries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/ApiError"
+        "500":
+          $ref: "#/components/responses/ApiError"
+
+  /api/v1/audit/statistics:
+    get:
+      tags: [audit]
+      operationId: getAuditStatistics
+      summary: Retrieve audit event statistics (admin)
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Audit statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/ApiError"
+        "500":
+          $ref: "#/components/responses/ApiError"
+
   /webhooks/sendgrid:
     post:
       tags: [webhooks]

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -501,6 +501,14 @@ impl Config {
             errors.push("HMAC_KEY: environment variable is not set or is empty".to_string());
         }
 
+        // Warn if no API keys are configured — admin endpoints will reject all requests.
+        if self.api_keys.is_empty() {
+            eprintln!(
+                "Warning: API_KEYS is not set. All admin endpoint requests will return 401. \
+                 Set API_KEYS to a comma-separated list of valid keys."
+            );
+        }
+
         if !errors.is_empty() {
             for error in &errors {
                 eprintln!("Configuration error: {}", error);

--- a/services/api/src/security.rs
+++ b/services/api/src/security.rs
@@ -301,7 +301,7 @@ impl ApiKeyAuth {
     }
 
     pub fn verify(&self, key: &str) -> bool {
-        self.valid_keys.is_empty() || self.valid_keys.iter().any(|k| k == key)
+        !self.valid_keys.is_empty() && self.valid_keys.iter().any(|k| k == key)
     }
 }
 


### PR DESCRIPTION
## Summary

- **#856 — Admin auth**: `ApiKeyAuth::verify` was fail-open: an empty `API_KEYS` env var let all requests through the middleware unchallenged. Changed the logic to fail-closed (`!is_empty() && any()`), so any deployment without `API_KEYS` configured now correctly returns `401` on all admin endpoints. Added a startup warning via `config.validate()` so operators are notified. Also added the 5 undocumented admin routes to `openapi.yaml` under the `ApiKeyAuth` security scheme (`/api/blockchain/replay`, `/api/v1/email/queue/dead-letter`, `/api/v1/email/queue/dead-letter/{job_id}/requeue`, `/api/v1/audit/logs`, `/api/v1/audit/statistics`).

- **#857 — SendGrid webhook signatures**: `sendgrid_webhook_middleware` already performs full HMAC-SHA256 verification against `SENDGRID_WEBHOOK_SECRET` plus a configurable timestamp replay window (`WEBHOOK_REPLAY_WINDOW_SECS`, default 300 s). No code changes required — confirming implementation is complete and closing the issue.

- **#858 — CORS allowlist**: CORS is already restricted via `CorsConfig` loaded from `CORS_ALLOWED_ORIGINS`, `CORS_ALLOWED_METHODS`, `CORS_ALLOWED_HEADERS`, and `CORS_ALLOW_CREDENTIALS` env vars with secure production defaults. `CORS_DEV_MODE=true` is required to opt in to permissive behaviour and logs a warning. No code changes required — confirming implementation is complete and closing the issue.

## Test plan

- [ ] Set `API_KEYS=` (empty) and confirm all `/admin/*` requests return `401 Unauthorized`.
- [ ] Set `API_KEYS=secret` and confirm requests with `X-API-Key: secret` succeed and requests without it return `401`.
- [ ] Confirm startup log shows warning when `API_KEYS` is not set.
- [ ] Confirm `POST /webhooks/sendgrid` with an invalid `X-Twilio-Email-Event-Webhook-Signature` returns `401`.
- [ ] Confirm CORS preflight with an origin not in `CORS_ALLOWED_ORIGINS` is blocked.

closes #856 
closes #857 
closes #858 

🤖 Generated with [Claude Code](https://claude.com/claude-code)