### PR TITLE
 fix(api): resolve compilation errors and complete backend hardening refactor

### DIFF
--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tower = { version = "0.5", features = ["util"] }
@@ -47,11 +47,12 @@ hex = "0.4"
 base64 = "0.22"
 subtle = "2.5"
 ipnet = "2"
+fastrand = "2.4.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-testcontainers = { version = "0.23", features = ["tokio"] }
-testcontainers-modules = { version = "0.11", features = ["redis", "tokio"] }
+testcontainers = { version = "0.23" }
+testcontainers-modules = { version = "0.11", features = ["redis", "postgres"] }
 
 [[bench]]
 name = "api_key_auth"

--- a/services/api/src/audit.rs
+++ b/services/api/src/audit.rs
@@ -1,7 +1,6 @@
 use std::net::IpAddr;
 
-pub mod client_ip;
-pub use client_ip::{extract_client_ip, trusted_cidrs_from_env};
+pub use crate::client_ip::{extract_client_ip, trusted_cidrs_from_env};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/services/api/src/audit_middleware.rs
+++ b/services/api/src/audit_middleware.rs
@@ -1,5 +1,4 @@
-pub mod body_redact;
-pub use body_redact::{body_logging_enabled, redact_sensitive, truncate_body};
+pub use crate::body_redact::{body_logging_enabled, redact_sensitive, truncate_body};
 
 use std::sync::Arc;
 

--- a/services/api/src/blockchain.rs
+++ b/services/api/src/blockchain.rs
@@ -793,7 +793,7 @@ impl BlockchainClient {
                 total_events = all_events.len(),
                 "fetch_events_since paginated"
             );
-            self.metrics.observe_invalidation("events_pagination_pages", pages);
+            self.metrics.observe_invalidation("events_pagination_pages", pages as usize);
         }
 
         Ok(all_events)

--- a/services/api/src/cache/mod.rs
+++ b/services/api/src/cache/mod.rs
@@ -7,11 +7,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use redis::redis_module::RedisResult;
-
-
 use anyhow::Context;
-use deadpool_redis::{Config as PoolConfig, Pool, Runtime};
+use deadpool_redis::{Config as PoolConfig, Pool};
 use redis::AsyncCommands;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -245,8 +242,9 @@ impl RedisCache {
         }
 
         // Deterministically hash the tag so the metadata key is stable.
+        use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        std::hash::Hash::hash(&tag, &mut hasher);
+        tag.cache_keys().join("|").hash(&mut hasher);
         let tag_hash = format!("{:x}", hasher.finish());
 
         let zset_key = self.tag_cfg.tag_key(&tag_hash);
@@ -293,18 +291,19 @@ impl RedisCache {
             "#,
         );
 
-        let mut over_evicted: i64 = 0;
+        let script = std::sync::Arc::new(script);
         self.exec(|mut conn| {
             let zset_key = zset_key.clone();
             let seq_key = seq_key.clone();
             let keys = tag_keys.clone();
+            let script = script.clone();
             async move {
                 let mut argv: Vec<String> = Vec::with_capacity(2 + keys.len());
                 argv.push(tag_ttl_secs.to_string());
                 argv.push(cap.to_string());
                 argv.extend(keys);
 
-                over_evicted = script
+                let _: i64 = script
                     .key(&zset_key)
                     .key(&seq_key)
                     .arg(tag_ttl_secs)
@@ -316,7 +315,6 @@ impl RedisCache {
         })
         .await?;
 
-        // Note: we don't need the evicted count for correctness.
         Ok(())
     }
 
@@ -399,11 +397,14 @@ impl RedisCache {
         T: DeserializeOwned,
     {
         let key = key.to_owned();
-        self.exec(|mut conn| async move {
-            let val: Option<String> = conn.get(&key).await?;
-            match val {
-                Some(raw) => Ok(Some(serde_json::from_str(&raw)?)),
-                None => Ok(None),
+        self.exec(|mut conn| {
+            let key = key.clone();
+            async move {
+                let val: Option<String> = conn.get(&key).await?;
+                match val {
+                    Some(raw) => Ok(Some(serde_json::from_str(&raw)?)),
+                    None => Ok(None),
+                }
             }
         })
         .await
@@ -429,9 +430,12 @@ impl RedisCache {
 
     pub async fn del(&self, key: &str) -> anyhow::Result<()> {
         let key = key.to_owned();
-        self.exec(|mut conn| async move {
-            let _: usize = conn.del(&key).await?;
-            Ok(())
+        self.exec(|mut conn| {
+            let key = key.clone();
+            async move {
+                let _: usize = conn.del(&key).await?;
+                Ok(())
+            }
         })
         .await
     }
@@ -460,23 +464,25 @@ impl RedisCache {
         let pattern = pattern.to_owned();
 
         loop {
-            let pattern_clone = pattern.clone();
             let (next_cursor, batch_deleted) = self
-                .exec(|mut conn| async move {
-                    let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                        .arg(cursor)
-                        .arg("MATCH")
-                        .arg(&pattern_clone)
-                        .arg("COUNT")
-                        .arg(100u64)
-                        .query_async(&mut conn)
-                        .await?;
-                    let deleted = if keys.is_empty() {
-                        0
-                    } else {
-                        conn.del(keys).await?
-                    };
-                    Ok((next_cursor, deleted))
+                .exec(|mut conn| {
+                    let pattern_clone = pattern.clone();
+                    async move {
+                        let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                            .arg(cursor)
+                            .arg("MATCH")
+                            .arg(&pattern_clone)
+                            .arg("COUNT")
+                            .arg(100u64)
+                            .query_async(&mut conn)
+                            .await?;
+                        let deleted = if keys.is_empty() {
+                            0
+                        } else {
+                            conn.del(keys).await?
+                        };
+                        Ok((next_cursor, deleted))
+                    }
                 })
                 .await?;
 

--- a/services/api/src/compression.rs
+++ b/services/api/src/compression.rs
@@ -1,48 +1,25 @@
-use tower_http::compression::predicate::{NotForContentType, Predicate};
+use axum::http::{header, Extensions, HeaderMap, StatusCode, Version};
 use tower_http::compression::CompressionLayer;
 
-fn should_compress_text_based(content_type: Option<&str>) -> bool {
-    let Some(ct) = content_type else {
-        // If we can't determine content type, avoid wasting CPU.
-        return false;
-    };
+type CompressFn = fn(StatusCode, Version, &HeaderMap, &Extensions) -> bool;
 
-    // Remove common parameters like `charset=utf-8`.
+fn should_compress(
+    _: StatusCode,
+    _: Version,
+    headers: &HeaderMap,
+    _: &Extensions,
+) -> bool {
+    let ct = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
     let ct = ct.split(';').next().unwrap_or(ct).trim();
-
-    // Only compress text-ish payloads.
-    // Note: application/json is explicitly included.
     ct == "application/json" || ct.starts_with("text/")
 }
 
-pub fn compression_layer() -> CompressionLayer {
-    // Exclude already-compressed/binary formats to avoid CPU waste.
-    // (This primarily protects against cases where `content_type` might be
-    // missing/incorrect while still keeping the middleware safe.)
-    let not_for_binary = NotForContentType::new(vec![
-        "application/zip",
-        "application/gzip",
-        "application/x-gzip",
-        "application/x-zip-compressed",
-        "application/pdf",
-        "image/jpeg",
-        "image/png",
-        "image/webp",
-        "image/gif",
-        "image/svg+xml",
-        "audio/mpeg",
-        "audio/mp4",
-        "video/mp4",
-        "application/octet-stream",
-        "application/x-bzip2",
-        "application/x-7z-compressed",
-    ]);
-
+pub fn compression_layer() -> CompressionLayer<CompressFn> {
     CompressionLayer::new()
         .gzip(true)
         .br(true)
-        // Only apply compression to text-based responses.
-        .compress_when(Predicate::from_fn(should_compress_text_based))
-        .filter(not_for_binary)
+        .compress_when(should_compress as CompressFn)
 }
-

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -66,7 +66,7 @@ impl CorsConfig {
                     .filter(|s| !s.is_empty())
                     .collect()
             })
-            .unwrap_or_else(|| {
+            .unwrap_or_else(|_| {
                 ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
                     .iter()
                     .map(|s| s.to_string())
@@ -80,7 +80,7 @@ impl CorsConfig {
                     .filter(|s| !s.is_empty())
                     .collect()
             })
-            .unwrap_or_else(|| {
+            .unwrap_or_else(|_| {
                 ["content-type", "authorization"]
                     .iter()
                     .map(|s| s.to_string())

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -124,7 +124,7 @@ impl Database {
     /// Snapshot pool size/idle into Prometheus gauges.
     /// Call this just before rendering `/metrics` so the values are current.
     pub fn record_pool_metrics(&self) {
-        self.metrics.record_pool_metrics(self.pool.size(), self.pool.num_idle());
+        self.metrics.observe_pool_connections("primary", self.pool.size() as i64, self.pool.num_idle() as i64);
     }
 
     pub async fn new(
@@ -759,7 +759,6 @@ impl Database {
         .fetch_one(&self.pool)).await.unwrap_or(0);
         Ok(count > 0)
     }
-}
 }
 
 #[cfg(test)]

--- a/services/api/src/email/service.rs
+++ b/services/api/src/email/service.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use redis::AsyncCommands as _;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::time::Duration;
@@ -139,7 +138,7 @@ impl EmailService {
         // --- idempotency check ---
         if let (Some(cache), Some(key)) = (&self.cache, idem_key) {
             let redis_key = format!("email:idem:{key}");
-            let mut conn = cache.manager.clone();
+            let mut conn = cache.get_connection().await.context("idempotency Redis connection failed")?;
 
             // Try SET NX — only succeeds for the first send.
             let acquired: Option<String> = redis::cmd("SET")

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -1,4 +1,3 @@
-use crate::content_type::require_json_content_type;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -565,7 +564,7 @@ pub async fn statistics(State(state): State<Arc<AppState>>) -> Result<impl IntoR
     } else {
         state.metrics.observe_miss("api", endpoint);
     }
-    state.metrics.observe_request(endpoint, start.elapsed());
+    state.metrics.observe_request(endpoint, "200", start.elapsed());
 
     Ok((StatusCode::OK, Json(payload)))
 }
@@ -633,7 +632,7 @@ pub async fn featured_markets(
     } else {
         state.metrics.observe_miss("api", endpoint);
     }
-    state.metrics.observe_request(endpoint, start.elapsed());
+    state.metrics.observe_request(endpoint, "200", start.elapsed());
 
     Ok((StatusCode::OK, Json(paginated)))
 }
@@ -647,13 +646,13 @@ pub async fn content(
     let cursor = query.cursor();
     let endpoint = "content";
 
-    let cache_key = keys::api_content(limit);
+    let cache_key = keys::api_content(limit.into());
     let ttl = Duration::from_secs(60 * 60);
 
     let (payload, hit) = state
         .cache
         .get_or_set_json(&cache_key, ttl, || async {
-            let data = state.db.content_cached(limit).await?;
+            let data = state.db.content_cached(limit.into()).await?;
             Ok(data)
         })
         .await
@@ -683,7 +682,7 @@ pub async fn content(
     } else {
         state.metrics.observe_miss("api", endpoint);
     }
-    state.metrics.observe_request(endpoint, start.elapsed());
+    state.metrics.observe_request(endpoint, "200", start.elapsed());
 
     Ok((StatusCode::OK, Json(paginated)))
 }
@@ -811,11 +810,11 @@ pub async fn blockchain_user_bets(
 
     let page_data = state
         .blockchain
-        .user_bets_page(&user, page, page_size)
+        .user_bets_page(&user, page, page_size.into())
         .await
         .map_err(into_api_error)?;
 
-    let has_more = (page + 1) * page_size < page_data.total;
+    let has_more = (page + 1) * (page_size as i64) < page_data.total;
     let next_cursor = if has_more {
         Some((page + 1).to_string())
     } else {
@@ -883,13 +882,13 @@ pub async fn warm_critical_caches(state: Arc<AppState>) -> anyhow::Result<()> {
 
     let (mut succeeded, mut failed) = (0usize, 0usize);
 
-    warm!("db.statistics",             state.db.statistics_cached().map(|r| r.map(|_| ())),                                                                                      succeeded, failed);
-    warm!("db.featured_markets",       state.db.featured_markets_cached(state.config.featured_limit).map(|r| r.map(|_| ())),                                                     succeeded, failed);
-    warm!("blockchain.health",         state.blockchain.health_check_cached().map(|r| r.map(|_| ())),                                                                             succeeded, failed);
-    warm!("blockchain.platform_stats", state.blockchain.platform_statistics_cached().map(|r| r.map(|_| ())),                                                                     succeeded, failed);
-    warm!("api.statistics",            statistics(State(state.clone())).map(|r| r.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}"))),                                             succeeded, failed);
-    warm!("api.featured_markets",      featured_markets(State(state.clone()), Query(PaginationQuery::default())).map(|r| r.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}"))),   succeeded, failed);
-    warm!("api.content",               content(State(state.clone()), Query(PaginationQuery::default())).map(|r| r.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}"))),             succeeded, failed);
+    warm!("db.statistics",             state.db.statistics_cached(),                                                                                                                succeeded, failed);
+    warm!("db.featured_markets",       state.db.featured_markets_cached(state.config.featured_limit),                                                                               succeeded, failed);
+    warm!("blockchain.health",         state.blockchain.health_check_cached(),                                                                                                       succeeded, failed);
+    warm!("blockchain.platform_stats", state.blockchain.platform_statistics_cached(),                                                                                               succeeded, failed);
+    warm!("api.statistics",            async { statistics(State(state.clone())).await.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}")) },                                          succeeded, failed);
+    warm!("api.featured_markets",      async { featured_markets(State(state.clone()), Query(PaginationQuery::default())).await.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}")) }, succeeded, failed);
+    warm!("api.content",               async { content(State(state.clone()), Query(PaginationQuery::default())).await.map(|_| ()).map_err(|e| anyhow::anyhow!("{e:?}")) },          succeeded, failed);
 
     tracing::info!(succeeded, failed, total = succeeded + failed, "cache warming complete");
     Ok(())

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod audit;
 pub mod audit_middleware;
+pub mod body_redact;
+pub mod client_ip;
+pub mod content_type;
 #[cfg(test)]
 mod resolve_market_tests;
 pub mod blockchain;

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
     )?;
 
     // Validate required configuration before proceeding
-    config.validate()?;
+    config.validate().map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let metrics = Metrics::new()?;
     let cache = RedisCache::new(&config.redis_url).await?;

--- a/services/api/src/migrations.rs
+++ b/services/api/src/migrations.rs
@@ -15,7 +15,7 @@
 use anyhow::{bail, Context};
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use tracing::{info, warn};
+use tracing::info;
 
 /// A single migration file embedded at compile time.
 #[derive(Debug, Clone)]

--- a/services/api/src/pagination.rs
+++ b/services/api/src/pagination.rs
@@ -77,6 +77,38 @@ pub fn validate_pagination(params: PaginationParams) -> Result<ValidatedPaginati
 
 pub struct ValidatedPaginationQuery(pub ValidatedPagination);
 
+/// Query parameters accepted by paginated API handlers.
+#[derive(Debug, Deserialize, Default)]
+pub struct PaginationQuery {
+    pub limit: Option<u32>,
+    pub cursor: Option<String>,
+}
+
+impl PaginationQuery {
+    pub fn limit(&self) -> u32 {
+        self.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_PAGE_LIMIT)
+    }
+
+    pub fn cursor(&self) -> Option<String> {
+        self.cursor.clone()
+    }
+}
+
+/// A single page of results returned by paginated endpoints.
+#[derive(Debug, Serialize)]
+pub struct PaginatedResponse<T: Serialize> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+    pub limit: u32,
+    pub has_more: bool,
+}
+
+impl<T: Serialize> PaginatedResponse<T> {
+    pub fn new(items: Vec<T>, next_cursor: Option<String>, limit: u32, has_more: bool) -> Self {
+        Self { items, next_cursor, limit, has_more }
+    }
+}
+
 #[axum::async_trait]
 impl<S> axum::extract::FromRequestParts<S> for ValidatedPaginationQuery
 where

--- a/services/api/src/rate_limit.rs
+++ b/services/api/src/rate_limit.rs
@@ -19,7 +19,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use deadpool_redis::{Pool as RedisPool, redis::AsyncCommands};
+use deadpool_redis::Pool as RedisPool;
 use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::sync::Arc;
@@ -150,6 +150,57 @@ pub async fn rate_limit_middleware(
                 .into_response()
         }
     }
+}
+
+pub async fn newsletter_rate_limit_middleware(
+    State(state): State<std::sync::Arc<crate::AppState>>,
+    headers: HeaderMap,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let client_key = client_key_from_headers(&headers);
+    if !state
+        .newsletter_rate_limiter
+        .allow(&client_key, 10, std::time::Duration::from_secs(3600))
+        .await
+    {
+        let body = RateLimitError {
+            error:       "rate_limit_exceeded",
+            message:     "Too many newsletter requests. Please try again later.".to_string(),
+            retry_after: 3600,
+        };
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("Retry-After", "3600".to_string())],
+            Json(body),
+        )
+            .into_response();
+    }
+    next.run(req).await
+}
+
+pub async fn admin_rate_limit_middleware(
+    State(limiter): State<std::sync::Arc<crate::security::RateLimiter>>,
+    headers: HeaderMap,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let client_key = client_key_from_headers(&headers);
+    let config = crate::security::RateLimitConfig::new(50, std::time::Duration::from_secs(60));
+    if !limiter.check(&client_key, &config).await {
+        let body = RateLimitError {
+            error:       "rate_limit_exceeded",
+            message:     "Too many admin requests. Please try again later.".to_string(),
+            retry_after: 60,
+        };
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("Retry-After", "60".to_string())],
+            Json(body),
+        )
+            .into_response();
+    }
+    next.run(req).await
 }
 
 fn client_key_from_headers(headers: &HeaderMap) -> String {

--- a/services/api/src/validation.rs
+++ b/services/api/src/validation.rs
@@ -8,10 +8,52 @@
 //!
 //! This is a defence-in-depth layer; the frontend MUST also escape output.
 
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::Serialize;
+
+const MAX_REQUEST_BODY_BYTES: u64 = 1 * 1024 * 1024; // 1 MB
+
+#[derive(Serialize)]
+struct RequestTooLargeError {
+    error:      &'static str,
+    message:    String,
+    max_bytes:  u64,
+}
+
+pub async fn content_type_validation_middleware(req: Request<Body>, next: Next) -> Response {
+    crate::content_type::require_json_content_type(req, next).await
+}
+
+pub async fn request_size_validation_middleware(req: Request<Body>, next: Next) -> Response {
+    if let Some(content_length) = req
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        if content_length > MAX_REQUEST_BODY_BYTES {
+            let body = RequestTooLargeError {
+                error:     "request_too_large",
+                message:   format!(
+                    "Request body exceeds the {MAX_REQUEST_BODY_BYTES}-byte limit."
+                ),
+                max_bytes: MAX_REQUEST_BODY_BYTES,
+            };
+            return (StatusCode::PAYLOAD_TOO_LARGE, Json(body)).into_response();
+        }
+    }
+    next.run(req).await
+}
+
+pub async fn request_validation_middleware(req: Request<Body>, next: Next) -> Response {
+    request_size_validation_middleware(req, next).await
+}
 
 #[derive(Debug, Serialize)]
 pub struct ValidationError {


### PR DESCRIPTION


Summary
Extracted body_redact, client_ip, and content_type from submodules into top-level modules; updated re-exports in audit and audit_middleware
Added PaginationQuery (with limit()/cursor() + Default) and PaginatedResponse<T> to pagination.rs to satisfy handler usage
Rewrote compression.rs to use the correct tower-http predicate API — replaced Predicate::from_fn (non-existent) and NotForContentType::new(Vec) (wrong type) with a typed function pointer predicate
Fixed cache/mod.rs: moved clone() calls inside async closure captures to satisfy lifetime requirements; replaced mutable over_evicted binding with in-place discard; fixed hash computation to use stable string representation
Fixed handlers.rs: added missing status_code arg to three observe_request calls; fixed seven warm! macro invocations that called .map() on unawaited futures
Added newsletter_rate_limit_middleware and admin_rate_limit_middleware to rate_limit.rs
Added content_type_validation_middleware, request_size_validation_middleware, and request_validation_middleware to validation.rs
Fixed email/service.rs: replaced removed cache.manager field access with cache.get_connection().await
Fixed config.rs: corrected unwrap_or_else closures to accept the error argument (|_|)
Fixed main.rs: converted Box<dyn Error> from config.validate() to anyhow::Error
Added fastrand and derive (sqlx) to Cargo.toml; switched testcontainers features to postgres
Test plan
 cargo check --manifest-path services/api/Cargo.toml passes with zero errors
 Existing unit tests pass (cargo test --manifest-path services/api/Cargo.toml)
 Rate limiting middleware rejects requests above threshold with 429 Too Many Requests
 Content-Type validation rejects non-JSON bodies on POST/PUT/PATCH with 415
 Request size validation rejects bodies over 1 MB with 413
 Cache warm-up endpoint completes without panicking
 
 
 closes #970
 
 closes #974
 
 closes #979
 
 
 closes #975