### PR TITLE
fix(#900): centralize all secrets in AWS Secrets Manager

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,179 @@
+# Secrets Management
+
+All application secrets are stored in **AWS Secrets Manager** and injected into
+the ECS task at startup via the `secrets` block in the task definition.  No
+secret values are stored in plaintext environment variables, Terraform state
+outputs, or version control.
+
+---
+
+## Secrets Inventory
+
+| Short name | Secrets Manager path (pattern) | ECS env var | Type | Rotation schedule |
+|---|---|---|---|---|
+| `database-url` | `predictiq/<env>/database-url` | `DATABASE_URL` | Connection string | Manual (coordinate with RDS password rotation) |
+| `redis-url` | `predictiq/<env>/redis-url` | `REDIS_URL` | Connection string | Manual |
+| `hmac-key` | `predictiq/<env>/hmac-key` | `HMAC_KEY` | 32+ byte random hex | **Every 90 days** |
+| `sendgrid-api-key` | `predictiq/<env>/sendgrid-api-key` | `SENDGRID_API_KEY` | SendGrid API key (`SG.*`) | **Every 180 days** |
+| `api-signing-key` | `predictiq/<env>/api-signing-key` | `API_SIGNING_KEY` | 32+ byte random hex | **Every 90 days** |
+
+`<env>` is one of `dev`, `staging`, or `prod`.
+
+### Full Secrets Manager ARN pattern
+
+```
+arn:aws:secretsmanager:<region>:<account-id>:secret:predictiq/<env>/<secret-name>-<suffix>
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Terraform (infrastructure/terraform/)              │
+│  ┌──────────────────────┐                          │
+│  │ modules/ecs/main.tf  │  creates/updates secrets │
+│  │                      │──────────────────────────┼──► AWS Secrets Manager
+│  │  ECS Task Definition │  references ARNs         │
+│  └──────────────────────┘                          │
+└─────────────────────────────────────────────────────┘
+                │  at task startup
+                ▼
+┌─────────────────────────────────────────────────────┐
+│  ECS Fargate Task                                   │
+│  ECS agent fetches secrets from Secrets Manager     │
+│  and injects them as environment variables          │
+│  (DATABASE_URL, REDIS_URL, HMAC_KEY, …)             │
+└─────────────────────────────────────────────────────┘
+```
+
+The ECS Task **Execution Role** (`predictiq-<env>-ecs-task-execution-role`) has
+`secretsmanager:GetSecretValue` permission scoped to only the five ARNs listed
+above — no wildcard permissions.
+
+---
+
+## Rotation Procedure
+
+### Automated helper
+
+Use `scripts/rotate-secret.sh` to rotate any secret and trigger an ECS
+rolling redeployment in one step:
+
+```bash
+# Rotate the HMAC key in production
+./scripts/rotate-secret.sh hmac-key "$(openssl rand -hex 32)" prod
+
+# Rotate the SendGrid API key (read from stdin to avoid shell history)
+echo "SG.newkey..." | ./scripts/rotate-secret.sh sendgrid-api-key - staging
+
+# Rotate the API signing key in dev
+./scripts/rotate-secret.sh api-signing-key "$(openssl rand -hex 32)" dev
+```
+
+The script:
+1. Validates the secret name against the known inventory.
+2. Prompts for confirmation in the `prod` environment.
+3. Calls `aws secretsmanager put-secret-value` to store the new value.
+4. Calls `aws ecs update-service --force-new-deployment` so running tasks
+   are replaced with new ones that pull the updated secret on startup.
+
+### Prerequisites
+
+- AWS CLI v2 with credentials that have:
+  - `secretsmanager:PutSecretValue` on the target secret ARN
+  - `ecs:UpdateService` on the target ECS service
+- `jq` installed
+
+### Manual rotation steps (if not using the script)
+
+1. **Generate** a new secret value:
+   ```bash
+   openssl rand -hex 32   # for HMAC_KEY / API_SIGNING_KEY
+   ```
+2. **Store** the new value in Secrets Manager:
+   ```bash
+   aws secretsmanager put-secret-value \
+     --secret-id "predictiq/prod/hmac-key" \
+     --secret-string "<new-value>"
+   ```
+3. **Redeploy** the ECS service to pick up the new secret:
+   ```bash
+   aws ecs update-service \
+     --cluster predictiq-prod \
+     --service predictiq-prod-api \
+     --force-new-deployment
+   ```
+4. **Verify** the new tasks are healthy before terminating old ones:
+   ```bash
+   aws ecs describe-services \
+     --cluster predictiq-prod \
+     --services predictiq-prod-api
+   ```
+
+---
+
+## Rotation Schedule
+
+| Secret | Frequency | Last rotated | Next rotation due |
+|---|---|---|---|
+| `hmac-key` | 90 days | See audit trail | — |
+| `api-signing-key` | 90 days | See audit trail | — |
+| `sendgrid-api-key` | 180 days | See audit trail | — |
+| `database-url` | On-demand | See audit trail | — |
+| `redis-url` | On-demand | See audit trail | — |
+
+Update "Last rotated" and "Next rotation due" after each rotation and commit
+the change to this file.
+
+---
+
+## Adding a New Secret
+
+1. Add a `variable "<name>"` block in `infrastructure/terraform/variables.tf`
+   with `sensitive = true`.
+2. Add `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version`
+   resources in `infrastructure/terraform/modules/ecs/main.tf`.
+3. Add the new ARN to the `secrets` block of `aws_ecs_task_definition.api`.
+4. Add the new ARN to the `Resource` list in
+   `aws_iam_role_policy.ecs_task_execution_secrets`.
+5. Pass the variable from the root module (`infrastructure/terraform/main.tf`)
+   to the ECS module.
+6. Update this inventory table.
+
+---
+
+## Auditing Secret Access
+
+All `GetSecretValue` calls are logged in AWS CloudTrail under
+`secretsmanager.amazonaws.com` events.  Use the following query in CloudTrail
+Insights or Athena to see recent accesses:
+
+```json
+{
+  "eventSource": "secretsmanager.amazonaws.com",
+  "eventName": "GetSecretValue",
+  "requestParameters.secretId": "predictiq/prod/*"
+}
+```
+
+---
+
+## Emergency Revocation
+
+To immediately revoke access to a secret (e.g. after a suspected compromise):
+
+1. Rotate the secret to a new value immediately:
+   ```bash
+   ./scripts/rotate-secret.sh <secret-name> "$(openssl rand -hex 32)" prod
+   ```
+2. If the ECS service must be stopped immediately, scale it to 0:
+   ```bash
+   aws ecs update-service \
+     --cluster predictiq-prod \
+     --service predictiq-prod-api \
+     --desired-count 0
+   ```
+3. Investigate CloudTrail logs for unauthorized `GetSecretValue` calls.
+4. Once the incident is resolved, restore desired count and redeploy.

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -71,6 +71,9 @@ module "ecs" {
   api_memory            = var.api_memory
   database_url          = module.rds.database_url
   redis_url             = module.redis.redis_url
+  hmac_key              = var.hmac_key
+  sendgrid_api_key      = var.sendgrid_api_key
+  api_signing_key       = var.api_signing_key
 }
 
 module "monitoring" {

--- a/infrastructure/terraform/modules/ecs/main.tf
+++ b/infrastructure/terraform/modules/ecs/main.tf
@@ -44,14 +44,34 @@ variable "redis_url" {
   sensitive = true
 }
 
+variable "hmac_key" {
+  description = "HMAC secret key used to sign API payloads"
+  type        = string
+  sensitive   = true
+}
+
+variable "sendgrid_api_key" {
+  description = "SendGrid API key for transactional email"
+  type        = string
+  sensitive   = true
+}
+
+variable "api_signing_key" {
+  description = "Private key used to sign API responses"
+  type        = string
+  sensitive   = true
+}
+
 locals {
   common_tags = {
-    Project   = "predictiq"
+    Project     = "predictiq"
     Environment = var.environment
-    Owner     = "infrastructure-team"
-    ManagedBy = "terraform"
+    Owner       = "infrastructure-team"
+    ManagedBy   = "terraform"
   }
 }
+
+# ── ECS Cluster ────────────────────────────────────────────────────────────────
 
 resource "aws_ecs_cluster" "main" {
   name = "predictiq-${var.environment}"
@@ -61,25 +81,21 @@ resource "aws_ecs_cluster" "main" {
     value = "enabled"
   }
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-cluster"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-cluster"
+  })
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/predictiq-${var.environment}"
   retention_in_days = var.environment == "prod" ? 30 : 7
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-logs"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-logs"
+  })
 }
+
+# ── ECS Task Definition ────────────────────────────────────────────────────────
 
 resource "aws_ecs_task_definition" "api" {
   family                   = "predictiq-${var.environment}-api"
@@ -108,6 +124,8 @@ resource "aws_ecs_task_definition" "api" {
           value = var.environment
         }
       ]
+      # All secrets are injected from AWS Secrets Manager — no plaintext
+      # environment variables for sensitive values.
       secrets = [
         {
           name      = "DATABASE_URL"
@@ -116,6 +134,18 @@ resource "aws_ecs_task_definition" "api" {
         {
           name      = "REDIS_URL"
           valueFrom = aws_secretsmanager_secret.redis_url.arn
+        },
+        {
+          name      = "HMAC_KEY"
+          valueFrom = aws_secretsmanager_secret.hmac_key.arn
+        },
+        {
+          name      = "SENDGRID_API_KEY"
+          valueFrom = aws_secretsmanager_secret.sendgrid_api_key.arn
+        },
+        {
+          name      = "API_SIGNING_KEY"
+          valueFrom = aws_secretsmanager_secret.api_signing_key.arn
         }
       ]
       logConfiguration = {
@@ -129,13 +159,12 @@ resource "aws_ecs_task_definition" "api" {
     }
   ])
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-api-task"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-api-task"
+  })
 }
+
+# ── Networking ─────────────────────────────────────────────────────────────────
 
 resource "aws_security_group" "alb" {
   name   = "predictiq-${var.environment}-alb-sg"
@@ -162,12 +191,9 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-alb-sg"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-alb-sg"
+  })
 }
 
 resource "aws_lb" "main" {
@@ -177,12 +203,9 @@ resource "aws_lb" "main" {
   security_groups    = [aws_security_group.alb.id]
   subnets            = var.public_subnet_ids
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-alb"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-alb"
+  })
 }
 
 resource "aws_lb_target_group" "api" {
@@ -201,12 +224,9 @@ resource "aws_lb_target_group" "api" {
     matcher             = "200"
   }
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-api-tg"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-api-tg"
+  })
 }
 
 resource "aws_lb_listener" "api" {
@@ -238,13 +258,12 @@ resource "aws_security_group" "ecs_tasks" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-ecs-tasks-sg"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-ecs-tasks-sg"
+  })
 }
+
+# ── ECS Service ────────────────────────────────────────────────────────────────
 
 resource "aws_ecs_service" "api" {
   name            = "predictiq-${var.environment}-api"
@@ -267,45 +286,101 @@ resource "aws_ecs_service" "api" {
 
   depends_on = [aws_lb_listener.api]
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-api-service"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-api-service"
+  })
 }
 
-resource "aws_secretsmanager_secret" "database_url" {
-  name = "predictiq/${var.environment}/database-url"
+# ── AWS Secrets Manager — secrets inventory ────────────────────────────────────
+#
+# All application secrets are stored in Secrets Manager and injected into the
+# ECS task via the `secrets` block above.  No plaintext secrets are passed
+# through Terraform environment variables or ECS `environment` blocks.
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-database-url"
-    }
-  )
+resource "aws_secretsmanager_secret" "database_url" {
+  name        = "predictiq/${var.environment}/database-url"
+  description = "PostgreSQL connection string for the predictIQ API"
+
+  tags = merge(local.common_tags, {
+    Name            = "predictiq-${var.environment}-database-url"
+    SecretType      = "connection-string"
+    RotationEnabled = "false"
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "database_url" {
-  secret_id       = aws_secretsmanager_secret.database_url.id
-  secret_string   = var.database_url
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = var.database_url
 }
 
 resource "aws_secretsmanager_secret" "redis_url" {
-  name = "predictiq/${var.environment}/redis-url"
+  name        = "predictiq/${var.environment}/redis-url"
+  description = "Redis connection URL for the predictIQ API"
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-redis-url"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name            = "predictiq-${var.environment}-redis-url"
+    SecretType      = "connection-string"
+    RotationEnabled = "false"
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "redis_url" {
-  secret_id       = aws_secretsmanager_secret.redis_url.id
-  secret_string   = var.redis_url
+  secret_id     = aws_secretsmanager_secret.redis_url.id
+  secret_string = var.redis_url
 }
+
+resource "aws_secretsmanager_secret" "hmac_key" {
+  name        = "predictiq/${var.environment}/hmac-key"
+  description = "HMAC secret key used to sign API payloads and webhook signatures"
+
+  tags = merge(local.common_tags, {
+    Name            = "predictiq-${var.environment}-hmac-key"
+    SecretType      = "signing-key"
+    RotationEnabled = "true"
+    RotationSchedule = "90-days"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "hmac_key" {
+  secret_id     = aws_secretsmanager_secret.hmac_key.id
+  secret_string = var.hmac_key
+}
+
+resource "aws_secretsmanager_secret" "sendgrid_api_key" {
+  name        = "predictiq/${var.environment}/sendgrid-api-key"
+  description = "SendGrid API key for sending transactional email"
+
+  tags = merge(local.common_tags, {
+    Name            = "predictiq-${var.environment}-sendgrid-api-key"
+    SecretType      = "api-key"
+    RotationEnabled = "true"
+    RotationSchedule = "180-days"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "sendgrid_api_key" {
+  secret_id     = aws_secretsmanager_secret.sendgrid_api_key.id
+  secret_string = var.sendgrid_api_key
+}
+
+resource "aws_secretsmanager_secret" "api_signing_key" {
+  name        = "predictiq/${var.environment}/api-signing-key"
+  description = "Private key used to sign API responses"
+
+  tags = merge(local.common_tags, {
+    Name            = "predictiq-${var.environment}-api-signing-key"
+    SecretType      = "signing-key"
+    RotationEnabled = "true"
+    RotationSchedule = "90-days"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "api_signing_key" {
+  secret_id     = aws_secretsmanager_secret.api_signing_key.id
+  secret_string = var.api_signing_key
+}
+
+# ── IAM — ECS Task Execution Role ─────────────────────────────────────────────
 
 resource "aws_iam_role" "ecs_task_execution_role" {
   name = "predictiq-${var.environment}-ecs-task-execution-role"
@@ -323,12 +398,9 @@ resource "aws_iam_role" "ecs_task_execution_role" {
     ]
   })
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-ecs-task-execution-role"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-ecs-task-execution-role"
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
@@ -336,6 +408,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+# Grant the execution role access to all five Secrets Manager secrets.
 resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
   name = "predictiq-${var.environment}-ecs-task-execution-secrets"
   role = aws_iam_role.ecs_task_execution_role.id
@@ -350,12 +423,17 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
         ]
         Resource = [
           aws_secretsmanager_secret.database_url.arn,
-          aws_secretsmanager_secret.redis_url.arn
+          aws_secretsmanager_secret.redis_url.arn,
+          aws_secretsmanager_secret.hmac_key.arn,
+          aws_secretsmanager_secret.sendgrid_api_key.arn,
+          aws_secretsmanager_secret.api_signing_key.arn,
         ]
       }
     ]
   })
 }
+
+# ── IAM — ECS Task Role ────────────────────────────────────────────────────────
 
 resource "aws_iam_role" "ecs_task_role" {
   name = "predictiq-${var.environment}-ecs-task-role"
@@ -373,13 +451,12 @@ resource "aws_iam_role" "ecs_task_role" {
     ]
   })
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name = "predictiq-${var.environment}-ecs-task-role"
-    }
-  )
+  tags = merge(local.common_tags, {
+    Name = "predictiq-${var.environment}-ecs-task-role"
+  })
 }
+
+# ── Data sources / Outputs ─────────────────────────────────────────────────────
 
 data "aws_region" "current" {}
 
@@ -393,4 +470,17 @@ output "service_name" {
 
 output "alb_dns_name" {
   value = aws_lb.main.dns_name
+}
+
+# Expose secret ARNs so other modules or CI/CD pipelines can reference them.
+output "secret_arns" {
+  description = "Map of secret name → ARN for all Secrets Manager secrets managed by this module"
+  value = {
+    database_url     = aws_secretsmanager_secret.database_url.arn
+    redis_url        = aws_secretsmanager_secret.redis_url.arn
+    hmac_key         = aws_secretsmanager_secret.hmac_key.arn
+    sendgrid_api_key = aws_secretsmanager_secret.sendgrid_api_key.arn
+    api_signing_key  = aws_secretsmanager_secret.api_signing_key.arn
+  }
+  sensitive = true
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -181,3 +181,36 @@ variable "api_memory" {
     error_message = "API memory must be one of: 512, 1024, 2048, 3072, 4096, 5120, 6144, 7168, 8192."
   }
 }
+
+variable "hmac_key" {
+  description = "HMAC secret key used to sign API payloads and webhook signatures. Stored in AWS Secrets Manager."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.hmac_key) >= 32
+    error_message = "HMAC key must be at least 32 characters for adequate security."
+  }
+}
+
+variable "sendgrid_api_key" {
+  description = "SendGrid API key for transactional email. Stored in AWS Secrets Manager."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("^SG\\.", var.sendgrid_api_key))
+    error_message = "SendGrid API key must start with 'SG.'."
+  }
+}
+
+variable "api_signing_key" {
+  description = "Private key used to sign API responses. Stored in AWS Secrets Manager."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.api_signing_key) >= 32
+    error_message = "API signing key must be at least 32 characters."
+  }
+}

--- a/scripts/rotate-secret.sh
+++ b/scripts/rotate-secret.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# rotate-secret.sh — rotate a named AWS Secrets Manager secret and trigger an
+# ECS service redeployment so running tasks pick up the new value.
+#
+# Usage:
+#   ./scripts/rotate-secret.sh <secret-name> <new-value> [environment]
+#
+# Arguments:
+#   secret-name   Short name of the secret, e.g. "hmac-key", "sendgrid-api-key",
+#                 "api-signing-key", "database-url", "redis-url".
+#                 The full Secrets Manager path is constructed as:
+#                   predictiq/<environment>/<secret-name>
+#   new-value     The new secret value to store.  Pass "-" to read from stdin
+#                 (recommended for large values to avoid shell history leakage).
+#   environment   Deployment environment: dev | staging | prod  (default: prod)
+#
+# Prerequisites:
+#   - AWS CLI v2 installed and configured with credentials that have:
+#       secretsmanager:PutSecretValue on the target secret
+#       ecs:UpdateService on the target ECS service
+#   - jq installed for JSON parsing
+#
+# Examples:
+#   Rotate the HMAC key in production:
+#     ./scripts/rotate-secret.sh hmac-key "$(openssl rand -hex 32)" prod
+#
+#   Rotate the SendGrid API key, reading value from stdin:
+#     echo "SG.newkey..." | ./scripts/rotate-secret.sh sendgrid-api-key - staging
+#
+# Exit codes:
+#   0  Secret rotated and ECS service update triggered successfully.
+#   1  Missing required argument or dependency.
+#   2  AWS CLI call failed.
+
+set -euo pipefail
+
+# ── colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+# ── dependency checks ─────────────────────────────────────────────────────────
+command -v aws  >/dev/null 2>&1 || die "aws CLI is not installed or not in PATH"
+command -v jq   >/dev/null 2>&1 || die "jq is not installed or not in PATH"
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <secret-name> <new-value|-> [environment]"
+  echo "  secret-name:  hmac-key | sendgrid-api-key | api-signing-key | database-url | redis-url"
+  echo "  new-value:    new secret string, or '-' to read from stdin"
+  echo "  environment:  dev | staging | prod  (default: prod)"
+  exit 1
+fi
+
+SECRET_SHORT_NAME="$1"
+NEW_VALUE_ARG="$2"
+ENVIRONMENT="${3:-prod}"
+
+# Validate environment
+if [[ ! "$ENVIRONMENT" =~ ^(dev|staging|prod)$ ]]; then
+  die "environment must be one of: dev, staging, prod"
+fi
+
+# Validate secret name against the known inventory
+VALID_NAMES=("hmac-key" "sendgrid-api-key" "api-signing-key" "database-url" "redis-url")
+VALID=false
+for name in "${VALID_NAMES[@]}"; do
+  [[ "$SECRET_SHORT_NAME" == "$name" ]] && VALID=true && break
+done
+$VALID || die "Unknown secret name '${SECRET_SHORT_NAME}'. Valid names: ${VALID_NAMES[*]}"
+
+# Read value from stdin if requested
+if [[ "$NEW_VALUE_ARG" == "-" ]]; then
+  info "Reading new secret value from stdin..."
+  NEW_VALUE="$(cat)"
+else
+  NEW_VALUE="$NEW_VALUE_ARG"
+fi
+
+[[ -z "$NEW_VALUE" ]] && die "New secret value must not be empty"
+
+# ── resolve names ─────────────────────────────────────────────────────────────
+SECRET_PATH="predictiq/${ENVIRONMENT}/${SECRET_SHORT_NAME}"
+ECS_CLUSTER="predictiq-${ENVIRONMENT}"
+ECS_SERVICE="predictiq-${ENVIRONMENT}-api"
+
+info "Rotating secret: ${SECRET_PATH}"
+info "Environment:     ${ENVIRONMENT}"
+info "ECS service:     ${ECS_CLUSTER}/${ECS_SERVICE}"
+
+# ── confirm in production ─────────────────────────────────────────────────────
+if [[ "$ENVIRONMENT" == "prod" ]]; then
+  warn "You are about to rotate a production secret."
+  warn "This will trigger a rolling ECS redeployment."
+  read -r -p "Type 'yes' to continue: " CONFIRM
+  [[ "$CONFIRM" == "yes" ]] || { info "Aborted."; exit 0; }
+fi
+
+# ── update the secret ─────────────────────────────────────────────────────────
+info "Updating secret value in AWS Secrets Manager..."
+aws secretsmanager put-secret-value \
+  --secret-id "${SECRET_PATH}" \
+  --secret-string "${NEW_VALUE}" \
+  --output json \
+  | jq -r '"  Secret version ID: \(.VersionId)"' \
+  || die "Failed to update secret '${SECRET_PATH}'"
+
+info "Secret updated successfully."
+
+# ── trigger ECS service update ────────────────────────────────────────────────
+# A force-new-deployment causes ECS to start new tasks that will pull the
+# updated secret from Secrets Manager on startup.
+info "Triggering ECS service redeployment to pick up the new secret..."
+aws ecs update-service \
+  --cluster "${ECS_CLUSTER}" \
+  --service "${ECS_SERVICE}" \
+  --force-new-deployment \
+  --output json \
+  | jq -r '"  ECS deployment ID: \(.service.deployments[0].id)"' \
+  || die "Failed to trigger ECS redeployment for ${ECS_CLUSTER}/${ECS_SERVICE}"
+
+info "ECS service update triggered. New tasks will start with the rotated secret."
+info "Monitor progress with:"
+info "  aws ecs describe-services --cluster ${ECS_CLUSTER} --services ${ECS_SERVICE}"
+echo
+info "Rotation complete for secret: ${SECRET_PATH}"


### PR DESCRIPTION
## Summary

Closes #900

`HMAC_KEY`, `SENDGRID_API_KEY`, and `API_SIGNING_KEY` were not in AWS Secrets Manager — only `DATABASE_URL` and `REDIS_URL` had been migrated. The three missing secrets were loaded from plaintext environment variables, making rotation, auditing, and revocation difficult and increasing blast radius of any leak.

## Changes

### `infrastructure/terraform/modules/ecs/main.tf`

- Added `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version` resources for the three missing secrets:
  - `predictiq/<env>/hmac-key` (tagged: rotation 90 days)
  - `predictiq/<env>/sendgrid-api-key` (tagged: rotation 180 days)
  - `predictiq/<env>/api-signing-key` (tagged: rotation 90 days)
- Added all five secret ARNs to the ECS task definition `secrets` block so the ECS agent injects them as environment variables at task startup — no plaintext `environment` blocks for sensitive values
- Expanded `aws_iam_role_policy.ecs_task_execution_secrets` `Resource` list to include the three new ARNs (least-privilege; no wildcards)
- Added `secret_arns` output map (sensitive) so CI/CD pipelines can reference ARNs without re-querying
- Added new input variables: `hmac_key`, `sendgrid_api_key`, `api_signing_key` (all `sensitive = true`)

### `infrastructure/terraform/main.tf`

- Passed the three new variables from the root module to the ECS module

### `infrastructure/terraform/variables.tf`

- Added variable declarations for `hmac_key`, `sendgrid_api_key`, `api_signing_key` with:
  - `sensitive = true`
  - Validation rules (min length ≥ 32 for key types; `SG.` prefix check for SendGrid)

### `scripts/rotate-secret.sh` *(new)*

Bash helper to rotate a named secret and trigger an ECS rolling redeployment:

```bash
# Rotate HMAC key in production
./scripts/rotate-secret.sh hmac-key "$(openssl rand -hex 32)" prod

# Rotate SendGrid key, reading from stdin (avoids shell history)
echo "SG.newkey..." | ./scripts/rotate-secret.sh sendgrid-api-key - staging
```

- Validates secret name against the known inventory
- Prompts for confirmation before mutating production
- Supports reading the new value from stdin (`-`) to avoid shell history leakage
- Calls `aws secretsmanager put-secret-value` then `aws ecs update-service --force-new-deployment`
- Prints deployment ID and monitoring command

### `docs/secrets.md` *(new)*

Full secrets inventory documenting:
- All 5 secrets with their Secrets Manager paths, ECS env var names, types, and rotation schedules
- Architecture diagram (Terraform → Secrets Manager → ECS)
- Manual and automated (`rotate-secret.sh`) rotation procedures
- How to add a new secret end-to-end
- CloudTrail audit query for `GetSecretValue` events
- Emergency revocation procedure

## Security properties

| Property | Before | After |
|---|---|---|
| Secrets in version control / tfvars | HMAC_KEY, SENDGRID_API_KEY, API_SIGNING_KEY at risk | All secrets sensitive; never in plaintext output |
| Blast radius of a single env var leak | Full secret value exposed | Only current value; rotation revokes immediately |
| IAM permissions for secret access | Only DATABASE_URL + REDIS_URL ARNs | All 5 ARNs, still no wildcards |
| Rotation tooling | None | `rotate-secret.sh` + documented schedule |

## Acceptance criteria

- [x] AWS Secrets Manager as canonical secrets store for all 5 secrets
- [x] Terraform ECS task definitions reference Secrets Manager ARNs rather than plaintext env vars
- [x] `scripts/rotate-secret.sh` helper rotates a named secret and triggers ECS service update
- [x] `docs/secrets.md` documents secrets inventory and rotation schedule