### PR TITLE
fix(api): sanitize database constraint errors before sending to clients

### DIFF
--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -92,7 +92,8 @@ fn into_api_error(err: anyhow::Error) -> ApiError {
                 return ApiError::service_unavailable("database connection pool exhausted");
             }
             DbError::ConstraintViolation(msg) => {
-                return ApiError::conflict(msg.clone());
+                tracing::error!(db_constraint = %msg, "database constraint violation");
+                return ApiError::conflict("A record with this value already exists.");
             }
             DbError::Other(_) => {}
         }


### PR DESCRIPTION
## Summary

- Fixes information disclosure where raw `sqlx::Error` constraint messages (containing table/column names like `newsletter_subscribers_email_key`) were returned directly in 409 responses
- The full constraint message is now logged internally at `ERROR` level with the tracing correlation ID for operator visibility
- Clients receive a generic, safe message: `"A record with this value already exists."`
- Closes #914

## Changes

- `services/api/src/handlers.rs`: `into_api_error` — `DbError::ConstraintViolation` arm now logs internally and returns a sanitized conflict response

## Test plan
- [ ] Trigger a unique-constraint violation (e.g. subscribe with a duplicate email) and confirm the response body contains no table or column names
- [ ] Confirm the full constraint message still appears in server logs at ERROR level with the request correlation ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)