### PR TITLE
feat(api): add SendGrid connectivity probe to /health endpoint

### DIFF
--- a/services/api/src/email/service.rs
+++ b/services/api/src/email/service.rs
@@ -113,6 +113,31 @@ impl EmailService {
         })
     }
 
+    /// Probe SendGrid API reachability. Returns Ok if the API key is valid and
+    /// SendGrid is reachable; returns Err on timeout, network failure, or a
+    /// non-2xx response. Uses a 3-second timeout to keep health checks fast.
+    pub async fn probe_sendgrid(&self) -> Result<()> {
+        let api_key = self
+            .config
+            .sendgrid_api_key
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("SENDGRID_API_KEY not configured"))?;
+        let fut = self
+            .client
+            .get("https://api.sendgrid.com/v3/user/email")
+            .bearer_auth(api_key)
+            .send();
+        let resp = tokio::time::timeout(Duration::from_secs(3), fut)
+            .await
+            .map_err(|_| anyhow::anyhow!("SendGrid probe timed out after 3s"))?
+            .map_err(|e| anyhow::anyhow!("SendGrid probe request failed: {e}"))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            anyhow::bail!("SendGrid probe returned non-2xx status {}", resp.status())
+        }
+    }
+
     /// Send an email using SendGrid
     pub async fn send_email(
         &self,

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -160,6 +160,16 @@ pub async fn health(State(state): State<Arc<AppState>>, headers: HeaderMap) -> i
         health_status["workers"]["email_queue_processing"] = processing_count.into();
     }
 
+    let sendgrid_status = match state.email_service.probe_sendgrid().await {
+        Ok(()) => "ok",
+        Err(e) => {
+            tracing::warn!(error = %e, "SendGrid connectivity probe failed");
+            health_status["status"] = "degraded".into();
+            "degraded"
+        }
+    };
+    health_status["sendgrid"] = serde_json::json!({ "status": sendgrid_status });
+
     (StatusCode::OK, Json(health_status))
 }
 


### PR DESCRIPTION
## Summary

- Adds a `probe_sendgrid()` method to `EmailService` that calls `GET /v3/user/email` with a **3-second timeout** to detect an invalid API key or SendGrid outage before email sends start failing silently
- Wires the probe into the `/health` handler: sets `status: degraded` and adds `sendgrid.status: degraded` to the response when the probe fails; `sendgrid.status: ok` when healthy
- Closes #921

## Changes

- `services/api/src/email/service.rs`: new `pub async fn probe_sendgrid()` method using the existing `reqwest::Client` + `tokio::time::timeout`
- `services/api/src/handlers.rs`: health handler calls `probe_sendgrid()` and surfaces the result in the JSON response

## Test plan
- [ ] With a valid `SENDGRID_API_KEY`, call `GET /health` and confirm `sendgrid.status` is `"ok"` and overall status is `"ok"`
- [ ] With an invalid/missing key, confirm `sendgrid.status` is `"degraded"` and overall status is `"degraded"`
- [ ] Confirm the probe times out within ~3 seconds when SendGrid is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)