### PR TITLE
fix(migrations): correct newsletter table reference in migration 007

### DIFF
--- a/services/api/database/migrations/007_create_audit_logs.sql
+++ b/services/api/database/migrations/007_create_audit_logs.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     waitlist_entry_id UUID,
     content_id UUID,
     CONSTRAINT fk_audit_newsletter
-        FOREIGN KEY (newsletter_subscription_id) REFERENCES newsletter_subscriptions(id)
+        FOREIGN KEY (newsletter_subscription_id) REFERENCES newsletter_subscribers(id)
         ON DELETE SET NULL,
     CONSTRAINT fk_audit_contact
         FOREIGN KEY (contact_submission_id) REFERENCES contact_form_submissions(id)


### PR DESCRIPTION
## Summary
- Fixes the foreign key in `007_create_audit_logs.sql` to reference the correct table name `newsletter_subscribers` (was `newsletter_subscriptions`)
- The referenced table `newsletter_subscriptions` does not exist; migration 002 creates `newsletter_subscribers`
- Any fresh database setup (CI, staging, production blue-green) was failing at migration 007 with a relation-not-found error

## Test plan
- [ ] Apply migrations 001–006 to a clean Postgres instance
- [ ] Apply migration 007 — should succeed without foreign key errors
- [ ] Verify `audit_logs` table is created with the correct FK constraint pointing to `newsletter_subscribers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1037