### PR TITLE
feat(api): extend v1 sunset date and add API versioning docs

### DIFF
--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,96 @@
+# API Versioning
+
+## Current Versions
+
+| Version | Status     | Sunset Date      |
+|---------|------------|------------------|
+| v1      | Deprecated | 2026-12-31       |
+| v2      | Planned    | —                |
+
+## v1 Sunset Timeline
+
+- **Deprecated:** May 2026 — `Deprecation: true` and `Sunset` headers added to all v1 responses.
+- **Sunset:** 2026-12-31 — v1 endpoints will be removed.
+- **Action required:** Clients must migrate to v2 before 2026-12-31.
+
+The original sunset date was 2026-04-25. It has been extended to 2026-12-31 to allow clients additional migration time.
+
+Clients can detect deprecation by reading the response headers:
+
+```
+Deprecation: true
+Sunset: Sat, 31 Dec 2026 00:00:00 GMT
+Link: </api/v1>; rel="deprecation"; type="text/html"
+```
+
+## v2 Roadmap
+
+v2 is under active planning. The following breaking changes are planned:
+
+### Breaking Changes
+
+| Area | v1 Behaviour | v2 Behaviour |
+|------|-------------|--------------|
+| Error shape | Flat `{code, message}` | Flat `{code, message}` (unchanged) |
+| Pagination | `limit`/`offset` query params | Cursor-only (`cursor` param); `offset` removed |
+| API key header | `X-API-Key` | `Authorization: Bearer <token>` |
+| Versioning header | `API-Version` | `API-Version` (unchanged) |
+| Market list | Returns all fields | Returns summary fields; use `/markets/{id}` for full detail |
+
+### Non-Breaking Additions Planned for v2
+
+- Webhook subscription endpoints
+- Batch market resolution
+- User-level rate limit tiers
+
+## Client Migration Guide
+
+### 1. Detect deprecation headers
+
+Add header inspection to your HTTP client or middleware:
+
+```
+if response.headers["Deprecation"] == "true":
+    log.warn("v1 API is deprecated, migrate before " + response.headers["Sunset"])
+```
+
+### 2. Migrate pagination
+
+Replace `offset`-based pagination with cursor pagination:
+
+```
+# v1 (deprecated)
+GET /api/v1/markets?limit=20&offset=40
+
+# v2
+GET /api/v2/markets?limit=20&cursor=<opaque_cursor_from_previous_response>
+```
+
+### 3. Update the API key header
+
+```
+# v1 (deprecated)
+X-API-Key: your_key
+
+# v2
+Authorization: Bearer your_key
+```
+
+### 4. Switch the version path prefix
+
+Replace `/api/v1/` with `/api/v2/` in all request URLs once v2 is available.
+
+## Version Negotiation
+
+Clients may send an `API-Version` header to declare the target version. If omitted, the server defaults to the current stable version.
+
+```
+API-Version: v1
+```
+
+Unsupported versions are ignored and the server falls back to the default version.
+
+## References
+
+- `services/api/src/versioning.rs` — sunset header injection middleware
+- `API_SPEC.md` — full endpoint reference

--- a/services/api/src/versioning.rs
+++ b/services/api/src/versioning.rs
@@ -39,7 +39,7 @@ pub async fn versioning_middleware(mut req: Request, next: Next) -> Response {
 pub async fn v1_deprecation_middleware(req: Request, next: Next) -> Response {
     tracing::warn!(
         version = "v1",
-        sunset = "Sat, 25 Apr 2026 00:00:00 GMT",
+        sunset = "Sat, 31 Dec 2026 00:00:00 GMT",
         "Deprecated API version v1 called; clients must migrate before sunset"
     );
 
@@ -53,7 +53,7 @@ pub async fn v1_deprecation_middleware(req: Request, next: Next) -> Response {
     // Sunset date per RFC 8594: when v1 will be removed
     headers.insert(
         "Sunset",
-        HeaderValue::from_static("Sat, 25 Apr 2026 00:00:00 GMT"),
+        HeaderValue::from_static("Sat, 31 Dec 2026 00:00:00 GMT"),
     );
     headers.insert(
         header::LINK,


### PR DESCRIPTION
## Summary
- Extends the v1 API sunset date from `2026-04-25` (already past) to `2026-12-31` in `services/api/src/versioning.rs`, giving clients a valid future `Sunset` header while they complete migration
- Creates `docs/api-versioning.md` with: v1 sunset timeline, all planned v2 breaking changes (pagination cursor-only, API key header change, market list slimming), and a step-by-step client migration guide

## Test plan
- [ ] Check `Sunset` and `Deprecation` response headers on any `/api/v1/` endpoint — should read `Sat, 31 Dec 2026 00:00:00 GMT`
- [ ] Review `docs/api-versioning.md` for accuracy against current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #919