### PR TITLE
fix(db): migration checksum verification, idempotent rollbacks, markets soft-delete, VARCHAR constraints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -692,6 +692,57 @@ jobs:
             echo "✅ $f"
           done
 
+  # ── #906: verify rollback scripts are idempotent (run each twice) ────────────
+  rollback-idempotency:
+    name: Rollback Idempotency Check
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: predictiq_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/predictiq_test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply all forward migrations
+        run: |
+          for f in $(ls services/api/database/migrations/*.sql | sort); do
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+          done
+
+      - name: Run every rollback script twice and verify second run exits 0
+        run: |
+          FAILED=0
+          for f in $(ls services/api/database/migrations/rollbacks/*_down.sql | sort -r); do
+            echo "--- First run: $f ---"
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f" || { echo "❌ First run failed: $f"; FAILED=1; continue; }
+            echo "--- Second run (idempotency check): $f ---"
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+            RC=$?
+            if [ $RC -ne 0 ]; then
+              echo "❌ Second run of $f exited with code $RC (not idempotent)"
+              FAILED=1
+            else
+              echo "✅ $f is idempotent"
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo "One or more rollback scripts are not idempotent."
+            exit 1
+          fi
+          echo "All rollback scripts passed the idempotency check."
+
   # ── #741: API Criterion benchmarks ───────────────────────────────────────────
   api-criterion-benchmarks:
     name: API Criterion Benchmarks
@@ -853,6 +904,7 @@ jobs:
       - e2e-market-creation
       - documentation-sync
       - validate-migration-rollbacks
+      - rollback-idempotency
       - api-criterion-benchmarks
       - frontend-unit-coverage
     runs-on: ubuntu-latest

--- a/services/api/DATABASE.md
+++ b/services/api/DATABASE.md
@@ -35,9 +35,26 @@ This service uses PostgreSQL. Schema and seed scripts are in:
 | 010b | `010_create_audit_log.sql` | Append-only `audit_log` table (bigserial PK) |
 | 011 | `011_create_markets.sql` | `markets` table |
 | 012 | `012_add_performance_indexes.sql` | Composite indexes on `markets` and `content` (promoted from `sql/`) |
+| 013 | `013_add_email_queue_composite_index.sql` | Composite index for priority-ordered email queue scans |
+| 014 | `014_add_email_events_composite_index.sql` | Composite index for ordered email event lookups by job |
+| 015 | `015_add_newsletter_cleanup_index.sql` | Partial index for hourly unconfirmed-subscriber cleanup |
+| 016 | `016_add_markets_deadline_index.sql` | Partial index for deadline-based active market queries |
+| 017 | `017_add_soft_delete_markets.sql` | Adds `deleted_at` to `markets` + cleanup function |
+| 018 | `018_add_varchar_constraints.sql` | CHECK constraints on user-supplied TEXT columns |
 
 > **Note:** Two migration files share the `010_` prefix. Apply them in lexicographic
 > order (`010_add_soft_delete_newsletter.sql` before `010_create_audit_log.sql`).
+
+## Migration Immutability Guarantee
+
+Migration files are embedded at compile time and their SHA-256 checksums are
+stored in `schema_migrations` when first applied. At every startup the
+`MigrationRunner` compares the checksum of each embedded migration file against
+the stored value. If any mismatch is detected the service **refuses to start**
+and logs a `FATAL` error identifying the affected migration version and name.
+
+**Do not edit a migration file after it has been applied to any environment.**
+Instead, create a new migration that applies the desired change incrementally.
 
 ## Apply Migrations
 
@@ -78,6 +95,13 @@ exact changes made by their paired migration.
 | `010_add_soft_delete_newsletter.sql` | `rollbacks/010_add_soft_delete_newsletter_down.sql` |
 | `010_create_audit_log.sql` | `rollbacks/010_create_audit_log_down.sql` |
 | `011_create_markets.sql` | `rollbacks/011_create_markets_down.sql` |
+| `012_add_performance_indexes.sql` | `rollbacks/012_add_performance_indexes_down.sql` |
+| `013_add_email_queue_composite_index.sql` | `rollbacks/013_add_email_queue_composite_index_down.sql` |
+| `014_add_email_events_composite_index.sql` | `rollbacks/014_add_email_events_composite_index_down.sql` |
+| `015_add_newsletter_cleanup_index.sql` | `rollbacks/015_add_newsletter_cleanup_index_down.sql` |
+| `016_add_markets_deadline_index.sql` | `rollbacks/016_add_markets_deadline_index_down.sql` |
+| `017_add_soft_delete_markets.sql` | `rollbacks/017_add_soft_delete_markets_down.sql` |
+| `018_add_varchar_constraints.sql` | `rollbacks/018_add_varchar_constraints_down.sql` |
 
 ### Rolling back a single migration
 
@@ -109,7 +133,7 @@ done
 
 When rolling back multiple migrations, respect foreign-key dependencies:
 
-1. `011` → `010b` → `010a` → `009` → `008` → `007` → `006` → `005` → `004` → `003` → `002` → `001` → `000`
+1. `018` → `017` → `016` → `015` → `014` → `013` → `012` → `011` → `010b` → `010a` → `009` → `008` → `007` → `006` → `005` → `004` → `003` → `002` → `001` → `000`
 
 `analytics_events` (006) references `content_management` (005), and
 `audit_logs` (007) references several earlier tables — roll them back before
@@ -197,5 +221,5 @@ done
 
 - UUID primary keys via `gen_random_uuid()` (most tables); `audit_log` uses `BIGSERIAL`.
 - All tables include `created_at` / `updated_at` timestamps.
-- Soft deletes via `deleted_at` in `content_management`, `audit_logs`, and `newsletter_subscribers`.
+- Soft deletes via `deleted_at` in `content_management`, `audit_logs`, `newsletter_subscribers`, and `markets`. All query helpers filter `WHERE deleted_at IS NULL` by default. Rows soft-deleted for more than 30 days are eligible for hard-deletion via the `cleanup_soft_deleted_markets()` database function.
 - Indexes on high-frequency query fields (`email`, `status`, `created_at`).

--- a/services/api/database/SCHEMA.md
+++ b/services/api/database/SCHEMA.md
@@ -1,0 +1,130 @@
+# Database Schema Reference
+
+This document describes the column-level constraints enforced at the database
+layer for user-supplied string fields. All VARCHAR widths and CHECK constraint
+limits here correspond to the definitions in `database/migrations/`.
+
+## String Column Limits
+
+### `newsletter_subscribers`
+
+| Column | Type | Limit |
+|--------|------|-------|
+| `email` | `VARCHAR(255)` | 255 chars — covers the RFC 5321 maximum |
+| `source` | `VARCHAR(100)` | 100 chars |
+| `confirmation_token` | `VARCHAR(255)` | 255 chars |
+
+### `contact_form_submissions`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `name` | `VARCHAR(120)` | 120 chars |
+| `email` | `VARCHAR(255)` | 255 chars |
+| `subject` | `VARCHAR(200)` | 200 chars |
+| `message` | `TEXT + CHECK` | 10 000 chars (`chk_contact_message_length`) |
+| `status` | `VARCHAR(50)` | 50 chars |
+
+### `waitlist_entries`
+
+| Column | Type | Limit |
+|--------|------|-------|
+| `email` | `VARCHAR(255)` | 255 chars |
+| `status` | `VARCHAR(50)` | 50 chars |
+| `source` | `VARCHAR(100)` | 100 chars |
+
+### `content_management`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `slug` | `VARCHAR(180)` | 180 chars |
+| `title` | `VARCHAR(220)` | 220 chars |
+| `body` | `TEXT + CHECK` | 500 000 chars (`chk_content_body_length`) |
+| `author_email` | `VARCHAR(255)` | 255 chars |
+| `status` | `VARCHAR(50)` | 50 chars |
+
+### `markets`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `title` | `TEXT + CHECK` | 500 chars (`chk_markets_title_length`) |
+| `status` | `TEXT + CHECK(IN)` | enumerated: `active`, `resolved`, `cancelled` |
+
+### `email_jobs`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `job_type` | `VARCHAR(50)` | 50 chars |
+| `recipient_email` | `VARCHAR(255)` | 255 chars |
+| `template_name` | `VARCHAR(100)` | 100 chars |
+| `status` | `VARCHAR(50)` | 50 chars |
+| `error_message` | `TEXT + CHECK` | 4 000 chars (`chk_email_jobs_error_message_length`) |
+
+### `email_events`
+
+| Column | Type | Limit |
+|--------|------|-------|
+| `message_id` | `VARCHAR(255)` | 255 chars |
+| `event_type` | `VARCHAR(50)` | 50 chars |
+| `recipient_email` | `VARCHAR(255)` | 255 chars |
+
+### `email_suppressions`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `email` | `VARCHAR(255)` | 255 chars |
+| `suppression_type` | `VARCHAR(50)` | 50 chars |
+| `reason` | `TEXT + CHECK` | 1 000 chars (`chk_email_suppressions_reason_length`) |
+| `bounce_type` | `VARCHAR(50)` | 50 chars |
+
+### `email_template_variants`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `template_name` | `VARCHAR(100)` | 100 chars |
+| `variant_name` | `VARCHAR(50)` | 50 chars |
+| `subject_line` | `TEXT + CHECK` | 998 chars (`chk_email_subject_line_length`) — RFC 5322 line limit |
+
+### `analytics_events`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `event_name` | `VARCHAR(120)` | 120 chars |
+| `event_category` | `VARCHAR(80)` | 80 chars |
+| `session_id` | `VARCHAR(120)` | 120 chars |
+| `page_url` | `TEXT + CHECK` | 2 048 chars (`chk_analytics_page_url_length`) |
+| `referrer` | `TEXT + CHECK` | 2 048 chars (`chk_analytics_referrer_length`) |
+| `user_agent` | `TEXT + CHECK` | 512 chars (`chk_analytics_user_agent_length`) |
+
+### `audit_logs`
+
+| Column | Type / Constraint | Limit |
+|--------|-------------------|-------|
+| `action` | `VARCHAR(120)` | 120 chars |
+| `entity_type` | `VARCHAR(80)` | 80 chars |
+| `actor_email` | `VARCHAR(255)` | 255 chars |
+| `reason` | `TEXT + CHECK` | 2 000 chars (`chk_audit_logs_reason_length`) |
+
+## Soft-Delete Columns
+
+The following tables support soft-delete via a `deleted_at TIMESTAMPTZ` column.
+All query helpers filter `WHERE deleted_at IS NULL` by default.
+
+| Table | Soft-delete added by |
+|-------|----------------------|
+| `newsletter_subscribers` | `010_add_soft_delete_newsletter.sql` |
+| `content_management` | `005_create_content_management.sql` |
+| `audit_logs` | `007_create_audit_logs.sql` |
+| `markets` | `017_add_soft_delete_markets.sql` |
+
+Rows with `deleted_at < NOW() - INTERVAL '30 days'` are eligible for permanent
+removal via the `cleanup_soft_deleted_markets()` database function (markets) or
+the equivalent application-level cleanup job (newsletter subscribers).
+
+## Conventions
+
+- UUID primary keys use `gen_random_uuid()` (requires the `pgcrypto` extension,
+  enabled by migration `001`). The `audit_log` table is the sole exception and
+  uses `BIGSERIAL`.
+- All tables carry `created_at` and `updated_at` timestamp columns.
+- Foreign keys that reference parent rows use `ON DELETE SET NULL` or
+  `ON DELETE CASCADE` as noted in the migration that defines them.

--- a/services/api/database/migrations/017_add_soft_delete_markets.sql
+++ b/services/api/database/migrations/017_add_soft_delete_markets.sql
@@ -1,0 +1,30 @@
+-- Add soft-delete support to the markets table.
+--
+-- Existing rows are backfilled with deleted_at = NULL (the column default),
+-- so no data migration is required beyond adding the column.
+--
+-- Query helpers must filter WHERE deleted_at IS NULL to exclude soft-deleted
+-- markets from all normal reads. A scheduled cleanup function is also created
+-- to hard-delete rows that have been soft-deleted for more than 30 days.
+
+ALTER TABLE markets
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_markets_deleted_at
+    ON markets (deleted_at)
+    WHERE deleted_at IS NOT NULL;
+
+-- Cleanup function: hard-delete markets soft-deleted more than 30 days ago.
+-- Call this from a scheduled job (e.g. pg_cron or application background task).
+CREATE OR REPLACE FUNCTION cleanup_soft_deleted_markets() RETURNS INTEGER
+    LANGUAGE plpgsql AS $$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    DELETE FROM markets
+    WHERE deleted_at IS NOT NULL
+      AND deleted_at < NOW() - INTERVAL '30 days';
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;

--- a/services/api/database/migrations/018_add_varchar_constraints.sql
+++ b/services/api/database/migrations/018_add_varchar_constraints.sql
@@ -1,0 +1,57 @@
+-- Add CHECK-based length constraints to user-supplied TEXT columns that lack
+-- a database-level length guard. Validation was previously enforced only in
+-- application code; these constraints protect against direct INSERT/UPDATE
+-- bypassing the application layer.
+--
+-- Limits are chosen to be generous enough for real-world content while
+-- still preventing runaway storage from malformed or malicious inputs.
+
+-- markets.title: free-form market title supplied by operators
+ALTER TABLE markets
+    ADD CONSTRAINT IF NOT EXISTS chk_markets_title_length
+        CHECK (char_length(title) <= 500);
+
+-- contact_form_submissions.message: user-supplied contact message body
+ALTER TABLE contact_form_submissions
+    ADD CONSTRAINT IF NOT EXISTS chk_contact_message_length
+        CHECK (char_length(message) <= 10000);
+
+-- analytics_events.page_url: URL of the page where the event occurred
+ALTER TABLE analytics_events
+    ADD CONSTRAINT IF NOT EXISTS chk_analytics_page_url_length
+        CHECK (char_length(page_url) <= 2048);
+
+-- analytics_events.referrer: HTTP Referer header value
+ALTER TABLE analytics_events
+    ADD CONSTRAINT IF NOT EXISTS chk_analytics_referrer_length
+        CHECK (char_length(referrer) <= 2048);
+
+-- analytics_events.user_agent: User-Agent header string
+ALTER TABLE analytics_events
+    ADD CONSTRAINT IF NOT EXISTS chk_analytics_user_agent_length
+        CHECK (char_length(user_agent) <= 512);
+
+-- email_jobs.error_message: internal error detail from the mailer
+ALTER TABLE email_jobs
+    ADD CONSTRAINT IF NOT EXISTS chk_email_jobs_error_message_length
+        CHECK (char_length(error_message) <= 4000);
+
+-- email_suppressions.reason: human-readable suppression reason
+ALTER TABLE email_suppressions
+    ADD CONSTRAINT IF NOT EXISTS chk_email_suppressions_reason_length
+        CHECK (char_length(reason) <= 1000);
+
+-- email_template_variants.subject_line: rendered email subject
+ALTER TABLE email_template_variants
+    ADD CONSTRAINT IF NOT EXISTS chk_email_subject_line_length
+        CHECK (char_length(subject_line) <= 998);
+
+-- audit_logs.reason: free-text audit rationale entered by an operator
+ALTER TABLE audit_logs
+    ADD CONSTRAINT IF NOT EXISTS chk_audit_logs_reason_length
+        CHECK (char_length(reason) <= 2000);
+
+-- content_management.body: CMS page body (allow large content)
+ALTER TABLE content_management
+    ADD CONSTRAINT IF NOT EXISTS chk_content_body_length
+        CHECK (char_length(body) <= 500000);

--- a/services/api/database/migrations/rollbacks/012_add_performance_indexes_down.sql
+++ b/services/api/database/migrations/rollbacks/012_add_performance_indexes_down.sql
@@ -1,0 +1,6 @@
+-- Rollback for 012_add_performance_indexes.sql
+-- Drops the two composite/compound performance indexes added for markets and content.
+-- CONCURRENTLY is not valid inside a transaction block, so these use plain DROP INDEX IF EXISTS.
+
+DROP INDEX IF EXISTS idx_markets_status_volume_ends_at;
+DROP INDEX IF EXISTS idx_content_published_at;

--- a/services/api/database/migrations/rollbacks/013_add_email_queue_composite_index_down.sql
+++ b/services/api/database/migrations/rollbacks/013_add_email_queue_composite_index_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 013_add_email_queue_composite_index.sql
+-- Drops the composite index for priority-ordered email queue worker scans.
+
+DROP INDEX IF EXISTS idx_email_jobs_status_priority_scheduled;

--- a/services/api/database/migrations/rollbacks/014_add_email_events_composite_index_down.sql
+++ b/services/api/database/migrations/rollbacks/014_add_email_events_composite_index_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 014_add_email_events_composite_index.sql
+-- Drops the composite index for ordered email event lookups by job.
+
+DROP INDEX IF EXISTS idx_email_events_job_timestamp;

--- a/services/api/database/migrations/rollbacks/015_add_newsletter_cleanup_index_down.sql
+++ b/services/api/database/migrations/rollbacks/015_add_newsletter_cleanup_index_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 015_add_newsletter_cleanup_index.sql
+-- Drops the partial index used by the hourly unconfirmed-subscriber cleanup job.
+
+DROP INDEX IF EXISTS idx_newsletter_subscribers_cleanup;

--- a/services/api/database/migrations/rollbacks/016_add_markets_deadline_index_down.sql
+++ b/services/api/database/migrations/rollbacks/016_add_markets_deadline_index_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 016_add_markets_deadline_index.sql
+-- Drops the partial index used by background jobs that auto-close overdue active markets.
+
+DROP INDEX IF EXISTS idx_markets_active_ends_at;

--- a/services/api/database/migrations/rollbacks/017_add_soft_delete_markets_down.sql
+++ b/services/api/database/migrations/rollbacks/017_add_soft_delete_markets_down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 017_add_soft_delete_markets.sql
+-- Drops the cleanup function, the partial index, and the deleted_at column.
+-- Any rows with a non-NULL deleted_at value will have that data discarded.
+
+DROP FUNCTION IF EXISTS cleanup_soft_deleted_markets();
+DROP INDEX IF EXISTS idx_markets_deleted_at;
+ALTER TABLE markets DROP COLUMN IF EXISTS deleted_at;

--- a/services/api/database/migrations/rollbacks/018_add_varchar_constraints_down.sql
+++ b/services/api/database/migrations/rollbacks/018_add_varchar_constraints_down.sql
@@ -1,0 +1,13 @@
+-- Rollback for 018_add_varchar_constraints.sql
+-- Drops all CHECK constraints added for column-level length validation.
+
+ALTER TABLE markets DROP CONSTRAINT IF EXISTS chk_markets_title_length;
+ALTER TABLE contact_form_submissions DROP CONSTRAINT IF EXISTS chk_contact_message_length;
+ALTER TABLE analytics_events DROP CONSTRAINT IF EXISTS chk_analytics_page_url_length;
+ALTER TABLE analytics_events DROP CONSTRAINT IF EXISTS chk_analytics_referrer_length;
+ALTER TABLE analytics_events DROP CONSTRAINT IF EXISTS chk_analytics_user_agent_length;
+ALTER TABLE email_jobs DROP CONSTRAINT IF EXISTS chk_email_jobs_error_message_length;
+ALTER TABLE email_suppressions DROP CONSTRAINT IF EXISTS chk_email_suppressions_reason_length;
+ALTER TABLE email_template_variants DROP CONSTRAINT IF EXISTS chk_email_subject_line_length;
+ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS chk_audit_logs_reason_length;
+ALTER TABLE content_management DROP CONSTRAINT IF EXISTS chk_content_body_length;

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -203,7 +203,8 @@ impl Database {
                         COUNT(*) FILTER (WHERE status = 'active')::BIGINT AS active_markets, \
                         COUNT(*) FILTER (WHERE status = 'resolved')::BIGINT AS resolved_markets, \
                         COALESCE(SUM(total_volume), 0)::DOUBLE PRECISION AS total_volume \
-                    FROM markets",
+                    FROM markets \
+                    WHERE deleted_at IS NULL",
                 )
                 .fetch_one(&self.pool)).await.map_err(anyhow::Error::from)?;
 
@@ -235,7 +236,7 @@ impl Database {
                 let rows = self.with_timeout("featured_markets", sqlx::query(
                     "SELECT id, title, total_volume, ends_at \
                     FROM markets \
-                    WHERE status = 'active' \
+                    WHERE status = 'active' AND deleted_at IS NULL \
                     ORDER BY total_volume DESC, ends_at ASC \
                     LIMIT $1",
                 )
@@ -698,6 +699,40 @@ impl Database {
         Ok(analytics)
     }
 
+    /// Soft-delete a market by setting `deleted_at = NOW()`.
+    /// Returns `true` if the market existed and was not already deleted.
+    pub async fn soft_delete_market(&self, market_id: i64) -> anyhow::Result<bool> {
+        let rows = self
+            .with_timeout(
+                "soft_delete_market",
+                sqlx::query(
+                    "UPDATE markets \
+                     SET deleted_at = NOW() \
+                     WHERE id = $1 AND deleted_at IS NULL",
+                )
+                .bind(market_id)
+                .execute(&self.pool),
+            )
+            .await
+            .map_err(anyhow::Error::from)?
+            .rows_affected();
+        Ok(rows > 0)
+    }
+
+    /// Hard-delete markets that have been soft-deleted for more than 30 days
+    /// by invoking the `cleanup_soft_deleted_markets` database function.
+    /// Returns the number of rows permanently removed.
+    pub async fn cleanup_soft_deleted_markets(&self) -> anyhow::Result<i32> {
+        let count: i32 = self
+            .with_timeout(
+                "cleanup_soft_deleted_markets",
+                sqlx::query_scalar("SELECT cleanup_soft_deleted_markets()").fetch_one(&self.pool),
+            )
+            .await
+            .map_err(anyhow::Error::from)?;
+        Ok(count)
+    }
+
     /// Resolve a market by persisting the winning outcome to the database.
     ///
     /// Returns an error if the market does not exist or is not in `active` status.
@@ -708,7 +743,7 @@ impl Database {
                 sqlx::query(
                     "UPDATE markets \
                      SET status = 'resolved', outcome_index = $1, resolved_at = NOW() \
-                     WHERE id = $2 AND status = 'active'",
+                     WHERE id = $2 AND status = 'active' AND deleted_at IS NULL",
                 )
                 .bind(outcome_index as i32)
                 .bind(market_id)

--- a/services/api/src/migrations.rs
+++ b/services/api/src/migrations.rs
@@ -92,6 +92,16 @@ const MIGRATIONS: &[Migration] = &[
         name: "011_create_markets",
         sql: include_str!("../database/migrations/011_create_markets.sql"),
     },
+    Migration {
+        version: "017",
+        name: "017_add_soft_delete_markets",
+        sql: include_str!("../database/migrations/017_add_soft_delete_markets.sql"),
+    },
+    Migration {
+        version: "018",
+        name: "018_add_varchar_constraints",
+        sql: include_str!("../database/migrations/018_add_varchar_constraints.sql"),
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -151,6 +161,8 @@ impl<'a> MigrationRunner<'a> {
     }
 
     async fn run_inner(&self) -> anyhow::Result<usize> {
+        self.verify_checksums().await?;
+
         let mut applied = 0usize;
 
         for migration in MIGRATIONS {
@@ -168,6 +180,58 @@ impl<'a> MigrationRunner<'a> {
 
         info!(applied, "migration run complete");
         Ok(applied)
+    }
+
+    /// Compare the SHA-256 of each embedded migration against the stored
+    /// checksum in `schema_migrations`. Bail with a FATAL error on any mismatch
+    /// so a manually edited migration file is caught before it can run.
+    async fn verify_checksums(&self) -> anyhow::Result<()> {
+        let applied = sqlx::query_as::<_, AppliedMigration>(
+            "SELECT version, name, applied_at, checksum
+             FROM schema_migrations
+             ORDER BY version ASC",
+        )
+        .fetch_all(self.pool)
+        .await
+        .context("failed to query schema_migrations for checksum verification")?;
+
+        for record in &applied {
+            let Some(migration) = MIGRATIONS.iter().find(|m| m.version == record.version) else {
+                // Migration applied in a previous version of the binary; skip.
+                warn!(
+                    version = %record.version,
+                    "applied migration not found in current binary — skipping checksum check"
+                );
+                continue;
+            };
+
+            let expected = hex::encode(Sha256::digest(migration.sql.as_bytes()));
+            if expected != record.checksum {
+                tracing::error!(
+                    version = %record.version,
+                    name = %record.name,
+                    stored_checksum = %record.checksum,
+                    computed_checksum = %expected,
+                    "FATAL: migration checksum mismatch — the embedded SQL differs from what \
+                     was applied. The migration file must not be modified after being applied."
+                );
+                bail!(
+                    "migration checksum mismatch for version {} ({}): \
+                     stored={}, computed={}",
+                    record.version,
+                    record.name,
+                    record.checksum,
+                    expected
+                );
+            }
+
+            info!(
+                version = %record.version,
+                "checksum verified"
+            );
+        }
+
+        Ok(())
     }
 
     /// Return the list of applied migrations from the tracking table.


### PR DESCRIPTION
## Summary

- **#905** — `migrations.rs`: verify SHA-256 checksum of each already-applied migration against the stored value in `schema_migrations` at startup. Refuses to start and logs a FATAL error identifying the affected version if a mismatch is detected. Documents the immutability guarantee in `DATABASE.md`.
- **#906** — Add missing `_down.sql` rollback scripts for migrations 012–016 so every forward migration has an idempotent rollback. Add a new `rollback-idempotency` CI job that applies every rollback script **twice in sequence** and asserts the second run exits 0.
- **#907** — Add `deleted_at TIMESTAMPTZ` to `markets` via migration 017. Add `cleanup_soft_deleted_markets()` database function for 30-day hard-delete of soft-deleted rows. Update all markets query helpers in `db.rs` (`featured_markets_cached`, `statistics_cached`, `resolve_market`) to filter `WHERE deleted_at IS NULL`. Add `soft_delete_market()` and `cleanup_soft_deleted_markets()` methods to `Database`.
- **#908** — Migration 018 adds `CHECK`-based length constraints to user-supplied `TEXT` columns across all tables. Creates `database/SCHEMA.md` documenting all column limits and soft-delete conventions.

## Files changed

| File | Change |
|------|--------|
| `src/migrations.rs` | Add `verify_checksums()` called at the top of `run_inner()` |
| `src/db.rs` | Add `deleted_at IS NULL` guards on markets queries; add `soft_delete_market`, `cleanup_soft_deleted_markets` |
| `database/migrations/017_add_soft_delete_markets.sql` | New — soft-delete column + cleanup function |
| `database/migrations/018_add_varchar_constraints.sql` | New — CHECK length constraints on TEXT columns |
| `database/migrations/rollbacks/012–018_*_down.sql` | New — idempotent rollback scripts for all missing migrations |
| `database/SCHEMA.md` | New — column limits and soft-delete documentation |
| `DATABASE.md` | Updated migration table, rollback table, dependency order, immutability guarantee |
| `.github/workflows/test.yml` | New `rollback-idempotency` job; added to `all-tests-passed` gate |

Closes #905
Closes #906
Closes #907
Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)