### PR TITLE
perf(db): add missing composite indexes for analytics, email, newsletter, and audit tables

### DIFF
--- a/services/api/database/migrations/017_add_analytics_events_market_id.sql
+++ b/services/api/database/migrations/017_add_analytics_events_market_id.sql
@@ -1,0 +1,12 @@
+-- Composite index for market-scoped time-series analytics queries.
+--
+-- Queries that filter analytics_events by market and sort by time perform
+-- full table scans because the table has no market_id column or composite
+-- index. This migration adds the nullable market_id foreign key and the
+-- covering index so market-scoped event lookups resolve in a single index scan.
+
+ALTER TABLE analytics_events
+    ADD COLUMN IF NOT EXISTS market_id BIGINT REFERENCES markets(id) ON DELETE SET NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_analytics_events_market_time
+    ON analytics_events (market_id, occurred_at DESC);

--- a/services/api/database/migrations/018_add_email_tracking_email_status_index.sql
+++ b/services/api/database/migrations/018_add_email_tracking_email_status_index.sql
@@ -1,0 +1,18 @@
+-- Composite and partial indexes for failed/bounced email lookups.
+--
+-- Queries that fetch all events for a given recipient address (e.g. to decide
+-- whether to suppress future sends) scan the full email_events table today
+-- because the existing idx_email_events_recipient covers only the equality
+-- predicate, and the planner must then filter on event_type separately.
+--
+-- The composite index covers both columns so recipient+type lookups resolve in
+-- one scan. The partial index is scoped to bounce and dropped events only,
+-- keeping it small while accelerating the most latency-sensitive suppression
+-- queries.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_tracking_email_status
+    ON email_events (recipient_email, event_type);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_tracking_email_status_failed
+    ON email_events (recipient_email, event_type)
+    WHERE event_type IN ('bounce', 'dropped');

--- a/services/api/database/migrations/019_add_newsletter_confirmed_at_index.sql
+++ b/services/api/database/migrations/019_add_newsletter_confirmed_at_index.sql
@@ -1,0 +1,11 @@
+-- Partial index for subscriber growth analytics and cleanup queries.
+--
+-- Queries that bucket confirmed subscribers by confirmation date perform full
+-- table scans because no index covers confirmed_at. The partial index is
+-- scoped to non-NULL confirmed_at rows (i.e. confirmed subscribers only),
+-- keeping it small and excluding unconfirmed rows that are never included in
+-- growth reports or retention cleanup.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_newsletter_confirmed_at
+    ON newsletter_subscribers (confirmed_at)
+    WHERE confirmed_at IS NOT NULL;

--- a/services/api/database/migrations/020_add_audit_log_actor_time_index.sql
+++ b/services/api/database/migrations/020_add_audit_log_actor_time_index.sql
@@ -1,0 +1,10 @@
+-- Composite index for actor-scoped audit trail queries.
+--
+-- Admin compliance queries that filter by actor and a time range perform
+-- sequential scans because the existing idx_audit_log_actor and
+-- idx_audit_log_timestamp indexes are single-column. The composite index
+-- covers the equality predicate on actor and the ORDER BY timestamp DESC
+-- in a single scan.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_log_actor_time
+    ON audit_log (actor, timestamp DESC);

--- a/services/api/database/migrations/rollbacks/017_add_analytics_events_market_id_down.sql
+++ b/services/api/database/migrations/rollbacks/017_add_analytics_events_market_id_down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_analytics_events_market_time;
+ALTER TABLE analytics_events DROP COLUMN IF EXISTS market_id;

--- a/services/api/database/migrations/rollbacks/018_add_email_tracking_email_status_index_down.sql
+++ b/services/api/database/migrations/rollbacks/018_add_email_tracking_email_status_index_down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_email_tracking_email_status_failed;
+DROP INDEX IF EXISTS idx_email_tracking_email_status;

--- a/services/api/database/migrations/rollbacks/019_add_newsletter_confirmed_at_index_down.sql
+++ b/services/api/database/migrations/rollbacks/019_add_newsletter_confirmed_at_index_down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_newsletter_confirmed_at;

--- a/services/api/database/migrations/rollbacks/020_add_audit_log_actor_time_index_down.sql
+++ b/services/api/database/migrations/rollbacks/020_add_audit_log_actor_time_index_down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_audit_log_actor_time;

--- a/services/api/src/migrations.rs
+++ b/services/api/src/migrations.rs
@@ -92,6 +92,26 @@ const MIGRATIONS: &[Migration] = &[
         name: "011_create_markets",
         sql: include_str!("../database/migrations/011_create_markets.sql"),
     },
+    Migration {
+        version: "017",
+        name: "017_add_analytics_events_market_id",
+        sql: include_str!("../database/migrations/017_add_analytics_events_market_id.sql"),
+    },
+    Migration {
+        version: "018",
+        name: "018_add_email_tracking_email_status_index",
+        sql: include_str!("../database/migrations/018_add_email_tracking_email_status_index.sql"),
+    },
+    Migration {
+        version: "019",
+        name: "019_add_newsletter_confirmed_at_index",
+        sql: include_str!("../database/migrations/019_add_newsletter_confirmed_at_index.sql"),
+    },
+    Migration {
+        version: "020",
+        name: "020_add_audit_log_actor_time_index",
+        sql: include_str!("../database/migrations/020_add_audit_log_actor_time_index.sql"),
+    },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#901** — Adds `market_id BIGINT` column to `analytics_events` and a composite index `(market_id, occurred_at DESC)` so market-scoped time-series queries use an index scan instead of a full table scan.
- **#902** — Adds composite index `(recipient_email, event_type)` on `email_events` plus a partial index scoped to `event_type IN ('bounce', 'dropped')` to accelerate failed/bounced email lookups for large subscriber lists.
- **#903** — Adds partial index `(confirmed_at) WHERE confirmed_at IS NOT NULL` on `newsletter_subscribers` for efficient subscriber growth bucketing and cleanup queries.
- **#904** — Adds composite index `(actor, timestamp DESC)` on `audit_log` so actor-scoped compliance queries resolve in a single index scan instead of a sequential scan.

All indexes use `CONCURRENTLY IF NOT EXISTS`. Rollback scripts are included for each migration. New migrations are registered in `src/migrations.rs` (017–020).

## Test plan

- [ ] Run `cargo check` to confirm migrations compile cleanly
- [ ] Apply migrations against a local Postgres instance and verify `\d analytics_events` shows `market_id` column and all four indexes exist
- [ ] Run `EXPLAIN ANALYZE` on representative queries to confirm index usage:
  - `SELECT * FROM analytics_events WHERE market_id = $1 ORDER BY occurred_at DESC LIMIT 50`
  - `SELECT * FROM email_events WHERE recipient_email = $1 AND event_type IN ('bounce', 'dropped')`
  - `SELECT * FROM newsletter_subscribers WHERE confirmed_at IS NOT NULL ORDER BY confirmed_at DESC`
  - `SELECT * FROM audit_log WHERE actor = $1 ORDER BY timestamp DESC LIMIT 100`

Closes #901
Closes #902
Closes #903
Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)