### PR TITLE
fix(security): store SendGrid API key in Secrets Manager with rotation tracking (#893)

### DIFF
--- a/docs/runbooks/sendgrid-api-key-rotation.md
+++ b/docs/runbooks/sendgrid-api-key-rotation.md
@@ -1,0 +1,167 @@
+# SendGrid API Key Rotation Runbook
+
+## Overview
+
+The SendGrid API key (`SENDGRID_API_KEY`) is stored in AWS Secrets Manager and
+injected into the ECS task at deploy time via the `SENDGRID_API_KEY` secret.
+A companion secret (`SENDGRID_KEY_ROTATED_AT`) records the date (YYYY-MM-DD)
+the key was last rotated. The application reads this at startup and emits a
+`SECURITY WARNING` log if the key is **90 days or older**.
+
+Rotate the key proactively every 90 days, or immediately if compromise is
+suspected.
+
+---
+
+## When to Rotate
+
+| Trigger | Action |
+|---------|--------|
+| Startup warning: key ≥ 90 days old | Scheduled rotation (follow steps below) |
+| Suspected key compromise or leak | Emergency rotation (follow steps below + revoke old key first) |
+| Staff offboarding (key holder) | Rotate within 24 hours |
+| Security audit finding | Rotate within the remediation SLA |
+
+---
+
+## Rotation Steps
+
+### 1. Generate a new API key in SendGrid
+
+1. Log into [SendGrid](https://app.sendgrid.com) with your organisation account.
+2. Navigate to **Settings → API Keys → Create API Key**.
+3. Set the permissions to **Restricted Access**:
+   - **Mail Send** → Full Access
+   - All others → No Access
+4. Copy the new key value (it is only shown once).
+
+### 2. Update the secret in AWS Secrets Manager
+
+```bash
+# Set these for your environment (prod / staging / dev)
+ENVIRONMENT=prod
+NEW_KEY="SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ROTATION_DATE=$(date +%Y-%m-%d)
+
+# Update the API key secret
+aws secretsmanager put-secret-value \
+  --secret-id "predictiq/${ENVIRONMENT}/sendgrid-api-key" \
+  --secret-string "${NEW_KEY}"
+
+# Update the rotation-date metadata secret
+aws secretsmanager put-secret-value \
+  --secret-id "predictiq/${ENVIRONMENT}/sendgrid-key-rotated-at" \
+  --secret-string "${ROTATION_DATE}"
+```
+
+### 3. Trigger a rolling ECS deployment to pick up the new secret
+
+ECS injects secrets at task launch time, so a new deployment is required:
+
+```bash
+# Force a new deployment (no image change needed)
+aws ecs update-service \
+  --cluster predictiq-${ENVIRONMENT} \
+  --service predictiq-${ENVIRONMENT}-api \
+  --force-new-deployment
+```
+
+Monitor the deployment:
+
+```bash
+aws ecs wait services-stable \
+  --cluster predictiq-${ENVIRONMENT} \
+  --services predictiq-${ENVIRONMENT}-api
+echo "Deployment complete"
+```
+
+### 4. Verify the new key is active
+
+```bash
+# Check startup logs for the age-check info line (should show age_days = 0)
+aws logs filter-log-events \
+  --log-group-name "/ecs/predictiq-${ENVIRONMENT}" \
+  --filter-pattern "SendGrid API key age check passed" \
+  --start-time $(date -d '5 minutes ago' +%s000)
+
+# Send a test email via the API (adjust endpoint / auth as needed)
+curl -sf -X POST https://api.predictiq.com/api/v1/newsletter/subscribe \
+  -H "Content-Type: application/json" \
+  -d '{"email": "rotation-test@example.com"}' \
+  && echo "Test subscription queued"
+```
+
+### 5. Revoke the old key in SendGrid
+
+1. Return to **Settings → API Keys** in SendGrid.
+2. Find the old key (by name/date), click the action menu, and select **Delete**.
+3. Confirm deletion.
+
+> **Never leave both the old and new key active longer than needed.** Revoke
+> the old key as soon as the new deployment is stable.
+
+### 6. Update Terraform state (if managing via Terraform)
+
+If the `sendgrid_api_key` variable is managed in a `.tfvars` file or CI/CD
+secret store, update it to the new value so the next `terraform apply` does not
+overwrite the secret you just set manually.
+
+```bash
+# Example: update the secret in your CI/CD secret store, then run:
+terraform apply -var="sendgrid_api_key=${NEW_KEY}" \
+                -var="sendgrid_key_rotated_at=${ROTATION_DATE}"
+```
+
+---
+
+## Emergency Rotation (Key Compromised)
+
+If you believe the key has been leaked or is actively being misused:
+
+1. **Immediately** delete the compromised key in the SendGrid dashboard
+   (step 5 above) **before** generating a new one.
+2. Check SendGrid **Activity Feed** for unexpected sends from the compromised key.
+3. Follow steps 1–6 above to issue a new key.
+4. File a security incident and notify the security team.
+
+---
+
+## Rollback
+
+If the new key does not work (e.g. email delivery failures after deployment):
+
+1. Restore the old secret value from Secrets Manager version history:
+   ```bash
+   # List versions to find the previous AWSPREVIOUS stage
+   aws secretsmanager list-secret-version-ids \
+     --secret-id "predictiq/${ENVIRONMENT}/sendgrid-api-key"
+
+   # Restore the previous version (replace VERSION_ID)
+   aws secretsmanager update-secret-version-stage \
+     --secret-id "predictiq/${ENVIRONMENT}/sendgrid-api-key" \
+     --version-stage AWSCURRENT \
+     --move-to-version-id <PREVIOUS_VERSION_ID> \
+     --remove-from-version-id <CURRENT_VERSION_ID>
+   ```
+2. Force a new ECS deployment to pick up the restored secret.
+3. Investigate why the new key failed (wrong permissions, copy-paste error, etc.).
+
+---
+
+## Automation / Future Improvements
+
+- Enable [Secrets Manager automatic rotation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html)
+  with a Lambda rotation function once SendGrid's key API is integrated.
+- Add a CloudWatch alarm on the `SECURITY WARNING` log pattern so PagerDuty
+  fires automatically when the key exceeds 90 days.
+- Consider storing a key fingerprint (SHA-256 of the key prefix) alongside
+  `SENDGRID_KEY_ROTATED_AT` to detect out-of-band key changes.
+
+---
+
+## Related
+
+- [SendGrid API Key documentation](https://docs.sendgrid.com/ui/account-and-settings/api-keys)
+- `infrastructure/terraform/modules/ecs/main.tf` — Secrets Manager resources
+- `services/api/src/config.rs` — `warn_if_sendgrid_key_stale()`
+- Security issue: [#893](https://github.com/solutions-plug/predictIQ/issues/893)

--- a/infrastructure/terraform/modules/ecs/main.tf
+++ b/infrastructure/terraform/modules/ecs/main.tf
@@ -44,6 +44,21 @@ variable "redis_url" {
   sensitive = true
 }
 
+# SendGrid API key stored in Secrets Manager.
+# Set this to the raw API key value; Terraform will create the secret version.
+variable "sendgrid_api_key" {
+  type      = string
+  sensitive = true
+}
+
+# ISO-8601 date (YYYY-MM-DD) recording when SENDGRID_API_KEY was last rotated.
+# Stored as Secrets Manager metadata so ops tooling and the startup check can
+# read it without touching the key itself.
+variable "sendgrid_key_rotated_at" {
+  type        = string
+  description = "Date the SendGrid API key was last rotated (YYYY-MM-DD, e.g. 2026-06-30)"
+}
+
 locals {
   common_tags = {
     Project   = "predictiq"
@@ -116,6 +131,14 @@ resource "aws_ecs_task_definition" "api" {
         {
           name      = "REDIS_URL"
           valueFrom = aws_secretsmanager_secret.redis_url.arn
+        },
+        {
+          name      = "SENDGRID_API_KEY"
+          valueFrom = aws_secretsmanager_secret.sendgrid_api_key.arn
+        },
+        {
+          name      = "SENDGRID_KEY_ROTATED_AT"
+          valueFrom = aws_secretsmanager_secret.sendgrid_key_rotated_at.arn
         }
       ]
       logConfiguration = {
@@ -307,6 +330,44 @@ resource "aws_secretsmanager_secret_version" "redis_url" {
   secret_string   = var.redis_url
 }
 
+# ── SendGrid ────────────────────────────────────────────────────────────────
+
+resource "aws_secretsmanager_secret" "sendgrid_api_key" {
+  name        = "predictiq/${var.environment}/sendgrid-api-key"
+  description = "SendGrid API key used by the predictIQ API for transactional email. Rotate every 90 days — see docs/runbooks/sendgrid-api-key-rotation.md."
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "predictiq-${var.environment}-sendgrid-api-key"
+    }
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "sendgrid_api_key" {
+  secret_id     = aws_secretsmanager_secret.sendgrid_api_key.id
+  secret_string = var.sendgrid_api_key
+}
+
+# Stores only the rotation date (YYYY-MM-DD string) — not the key itself.
+# The application reads this at startup to warn if the key is older than 90 days.
+resource "aws_secretsmanager_secret" "sendgrid_key_rotated_at" {
+  name        = "predictiq/${var.environment}/sendgrid-key-rotated-at"
+  description = "ISO-8601 date (YYYY-MM-DD) when SENDGRID_API_KEY was last rotated. Update this alongside the key itself."
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "predictiq-${var.environment}-sendgrid-key-rotated-at"
+    }
+  )
+}
+
+resource "aws_secretsmanager_secret_version" "sendgrid_key_rotated_at" {
+  secret_id     = aws_secretsmanager_secret.sendgrid_key_rotated_at.id
+  secret_string = var.sendgrid_key_rotated_at
+}
+
 resource "aws_iam_role" "ecs_task_execution_role" {
   name = "predictiq-${var.environment}-ecs-task-execution-role"
 
@@ -350,7 +411,9 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
         ]
         Resource = [
           aws_secretsmanager_secret.database_url.arn,
-          aws_secretsmanager_secret.redis_url.arn
+          aws_secretsmanager_secret.redis_url.arn,
+          aws_secretsmanager_secret.sendgrid_api_key.arn,
+          aws_secretsmanager_secret.sendgrid_key_rotated_at.arn
         ]
       }
     ]

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -1,3 +1,4 @@
+use chrono;
 use ipnet::IpNet;
 use std::{
     env,
@@ -176,6 +177,11 @@ pub struct Config {
     pub content_default_page_size: i64,
     pub sendgrid_api_key: Option<String>,
     pub from_email: Option<String>,
+    /// ISO-8601 date (YYYY-MM-DD) recording when SENDGRID_API_KEY was last
+    /// rotated. Injected from Secrets Manager via `SENDGRID_KEY_ROTATED_AT`.
+    /// When set and the key is older than 90 days the server logs a warning at
+    /// startup so on-call engineers are notified before the key is revoked.
+    pub sendgrid_key_rotated_at: Option<String>,
     pub base_url: String,
     pub api_keys: Vec<String>,
     pub admin_whitelist_ips: Vec<IpAddr>,
@@ -380,6 +386,7 @@ impl Config {
                 .unwrap_or(20),
             sendgrid_api_key: env::var("SENDGRID_API_KEY").ok(),
             from_email: env::var("FROM_EMAIL").ok(),
+            sendgrid_key_rotated_at: env::var("SENDGRID_KEY_ROTATED_AT").ok(),
             base_url: env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".to_string()),
             api_keys: env::var("API_KEYS")
                 .ok()
@@ -465,6 +472,65 @@ impl Config {
             BlockchainNetwork::Testnet => "testnet",
             BlockchainNetwork::Mainnet => "mainnet",
             BlockchainNetwork::Custom => "custom",
+        }
+    }
+
+    /// Emit a `tracing::warn!` if `SENDGRID_KEY_ROTATED_AT` is set and the key
+    /// is older than `max_age_days` days (default 90).
+    ///
+    /// The check is best-effort: if the date cannot be parsed the function logs
+    /// a warning and returns — it never hard-errors so a misconfigured date
+    /// doesn't prevent startup.
+    pub fn warn_if_sendgrid_key_stale(&self) {
+        const MAX_AGE_DAYS: i64 = 90;
+        let rotated_at = match self.sendgrid_key_rotated_at.as_deref() {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                tracing::warn!(
+                    "SENDGRID_KEY_ROTATED_AT is not set — cannot verify SendGrid API key age. \
+                     Set this to the ISO-8601 date (YYYY-MM-DD) when the key was last rotated. \
+                     See docs/runbooks/sendgrid-api-key-rotation.md."
+                );
+                return;
+            }
+        };
+
+        let rotated_date = match chrono::NaiveDate::parse_from_str(rotated_at, "%Y-%m-%d") {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    rotated_at,
+                    error = %e,
+                    "SENDGRID_KEY_ROTATED_AT could not be parsed as YYYY-MM-DD; \
+                     skipping key-age check. See docs/runbooks/sendgrid-api-key-rotation.md."
+                );
+                return;
+            }
+        };
+
+        let today = chrono::Utc::now().date_naive();
+        let age_days = (today - rotated_date).num_days();
+
+        if age_days >= MAX_AGE_DAYS {
+            tracing::warn!(
+                age_days,
+                max_age_days = MAX_AGE_DAYS,
+                rotated_at,
+                "SECURITY WARNING: SendGrid API key is {} days old (limit: {} days). \
+                 Rotate the key now and update SENDGRID_KEY_ROTATED_AT. \
+                 Follow docs/runbooks/sendgrid-api-key-rotation.md.",
+                age_days,
+                MAX_AGE_DAYS,
+            );
+        } else {
+            tracing::info!(
+                age_days,
+                max_age_days = MAX_AGE_DAYS,
+                rotated_at,
+                "SendGrid API key age check passed ({}/{} days)",
+                age_days,
+                MAX_AGE_DAYS,
+            );
         }
     }
 
@@ -708,6 +774,7 @@ mod tests {
             content_default_page_size: 20,
             sendgrid_api_key: None,
             from_email: None,
+            sendgrid_key_rotated_at: None,
             base_url: "http://localhost:8080".to_string(),
             api_keys: vec![],
             admin_whitelist_ips: vec![],
@@ -779,6 +846,7 @@ mod tests {
             content_default_page_size: 20,
             sendgrid_api_key: None,
             from_email: None,
+            sendgrid_key_rotated_at: None,
             base_url: "http://localhost:8080".to_string(),
             api_keys: vec![],
             admin_whitelist_ips: vec![],
@@ -850,6 +918,7 @@ mod tests {
             content_default_page_size: 20,
             sendgrid_api_key: None,
             from_email: None,
+            sendgrid_key_rotated_at: None,
             base_url: "http://localhost:8080".to_string(),
             api_keys: vec![],
             admin_whitelist_ips: vec![],
@@ -921,6 +990,7 @@ mod tests {
             content_default_page_size: 20,
             sendgrid_api_key: None,
             from_email: None,
+            sendgrid_key_rotated_at: None,
             base_url: "http://localhost:8080".to_string(),
             api_keys: vec![],
             admin_whitelist_ips: vec![],

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -94,6 +94,9 @@ async fn main() -> anyhow::Result<()> {
     // Validate required configuration before proceeding
     config.validate()?;
 
+    // Warn at startup if the SendGrid API key is older than 90 days.
+    config.warn_if_sendgrid_key_stale();
+
     let metrics = Metrics::new()?;
     let cache = RedisCache::new(&config.redis_url).await?;
     let db = Database::new(&config.database_url, cache.clone(), metrics.clone(), &config.db_pool).await?;


### PR DESCRIPTION
## Summary

closes #893.

`SENDGRID_API_KEY` was loaded from a plain-text environment variable with no record of when it was last rotated and no tooling to prompt rotation. This PR moves the key to AWS Secrets Manager and adds a startup age-check so the on-call team is warned before the key becomes stale.

---

## Changes

### Infrastructure (`infrastructure/terraform/modules/ecs/main.tf`)
- Added `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version` for:
  - `predictiq/{env}/sendgrid-api-key` — stores the raw API key
  - `predictiq/{env}/sendgrid-key-rotated-at` — stores the rotation date (YYYY-MM-DD) as a metadata-only secret so ops tooling can check it without touching the key
- Added input variables `sendgrid_api_key` (sensitive) and `sendgrid_key_rotated_at`
- Injected both secrets into the ECS task definition `secrets` block (`SENDGRID_API_KEY`, `SENDGRID_KEY_ROTATED_AT`)
- Added both secret ARNs to the task-execution IAM role's `GetSecretValue` policy

### Application (`services/api/src/config.rs`)
- Added `sendgrid_key_rotated_at: Option<String>` field populated from `SENDGRID_KEY_ROTATED_AT`
- Added `Config::warn_if_sendgrid_key_stale()`:
  - Parses the date, computes `today - rotated_at` in days
  - Emits `tracing::warn!` with structured fields (`age_days`, `max_age_days`, `rotated_at`) when age ≥ 90 days
  - Emits a separate warning if the variable is absent or unparseable (never hard-errors to avoid blocking startup)

### Startup (`services/api/src/main.rs`)
- Calls `config.warn_if_sendgrid_key_stale()` immediately after `config.validate()`

### Runbook (`docs/runbooks/sendgrid-api-key-rotation.md`)
- Documents when to rotate (scheduled, emergency, offboarding)
- Step-by-step procedure covering all environments
- Emergency rotation path (key compromised): revoke first, then re-key
- Rollback via Secrets Manager version history
- Future automation notes (Lambda auto-rotation, CloudWatch alarm on warning log pattern)

---

## Acceptance criteria

- [x] `SENDGRID_API_KEY` stored in AWS Secrets Manager; ECS task definition loads it from Secrets Manager
- [x] `SENDGRID_KEY_ROTATED_AT` secret metadata field; startup warning when key is older than 90 days
- [x] Rotation runbook documented in `docs/runbooks/sendgrid-api-key-rotation.md`