### PR TITLE
fix(security): harden API key scoping, HMAC_KEY validation, CORS dev-mode guard, and webhook replay protection

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,3 +113,12 @@ jobs:
             echo "❌ Container failed to start"
             exit 1
           fi
+
+      - name: Assert CORS_DEV_MODE is not set in production image
+        run: |
+          ENV_VARS=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' predictiq-api:test)
+          if echo "$ENV_VARS" | grep -q "^CORS_DEV_MODE=true"; then
+            echo "❌ CORS_DEV_MODE=true found in production Docker image environment!"
+            exit 1
+          fi
+          echo "✅ CORS_DEV_MODE=true is not baked into the production Docker image"

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -94,8 +94,10 @@ IDEMPOTENCY_WINDOW_SECS=86400
 # NEWSLETTER_RATE_LIMIT_WINDOW_SECS=3600
 
 # CORS
+# DANGER: CORS_DEV_MODE=true must NEVER be set in production.
+# The server will refuse to start if CORS_DEV_MODE=true and RUST_ENV=production.
 # Set CORS_DEV_MODE=true ONLY for local development — makes CORS fully permissive.
-# Never enable in production; a startup warning is logged when this is true.
+# A WARN-level message is logged at startup whenever dev mode is active.
 # CORS_DEV_MODE=false
 
 # Comma-separated list of exact origins allowed to make cross-origin requests.

--- a/services/api/EMAIL.md
+++ b/services/api/EMAIL.md
@@ -1,0 +1,43 @@
+# Email Replay Protection Strategy
+
+## Overview
+
+Webhook events from SendGrid are protected against replay attacks using a two-layer defence.
+
+### Layer 1 — Redis nonce (active window)
+
+On receipt, an atomic `INCR` is performed on a Redis key scoped to
+`(message_id, event_type, recipient_email)` with a TTL equal to
+`WEBHOOK_REPLAY_WINDOW_SECS` (default: 300 s, configurable via env).
+
+- If the counter returns **1** → first time seen, proceed.
+- If the counter returns **> 1** → replay within the active window, discard silently.
+
+The `INCR + EXPIRE` operation is executed as a Lua script to be atomic — there is no
+race window between checking and setting the key.
+
+### Layer 2 — Database dedup (historical)
+
+After the Redis check passes, a query against the `email_events` table verifies that no
+matching `(message_id, event_type, recipient_email)` row already exists.  This catches
+replays that arrive after the Redis TTL has expired (i.e. more than
+`WEBHOOK_REPLAY_WINDOW_SECS` seconds after the original event).
+
+## Server-side timestamp (`received_at`)
+
+The `received_at` time used for all deduplication decisions is **always the server-side
+wall-clock time** at which the request was processed.  The `timestamp` field present in
+the SendGrid webhook payload is **not used for any security decision** because it
+originates from an external, potentially spoofed source — an attacker who can replay a
+webhook payload could set an arbitrary timestamp to bypass window-based checks.
+
+## Deployment / migration notes
+
+- **New deployments**: both layers are active immediately; no migration needed.
+- **Existing deployments**: the DB dedup layer (Layer 2) remains effective for all
+  historical events regardless of Redis state.  The Redis layer (Layer 1) only covers
+  events received after the feature is deployed; events older than
+  `WEBHOOK_REPLAY_WINDOW_SECS` rely on the DB layer.
+- **Redis TTL configuration**: tune `WEBHOOK_REPLAY_WINDOW_SECS` to balance replay
+  protection window vs. Redis memory usage.  The default (300 s) matches the SendGrid
+  retry window.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -65,7 +65,7 @@ The following Prometheus gauges are exported on `/metrics` and updated on each s
 | `ADMIN_WHITELIST_IPS` | _(none)_ | Comma-separated IPs allowed to hit admin routes |
 | `TRUST_PROXY` | `true` | Trust `X-Forwarded-For` header |
 | `METRICS_PUBLIC` | `false` | Expose `/metrics` without auth |
-| `HMAC_KEY` | _(required)_ | Current HMAC secret key for signing tokens |
+| `HMAC_KEY` | _(required)_ | Current HMAC secret key for signing tokens — **must be at least 32 bytes (256 bits) after decoding**. The value may be a raw string, hex-encoded, or base64-encoded; the server decodes before measuring length. Generate with: `openssl rand -hex 32` |
 | `HMAC_KEY_PREVIOUS` | _(none)_ | Previous HMAC key for zero-downtime key rotation |
 | `HMAC_KEY_ROTATION_GRACE_SECONDS` | `3600` | Grace period (seconds) for accepting tokens signed with the previous key |
 

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use ipnet::IpNet;
 use std::{
     env,
@@ -5,6 +6,21 @@ use std::{
     str::FromStr,
     time::Duration,
 };
+
+fn hmac_key_entropy(data: &[u8]) -> f64 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0u32; 256];
+    for &b in data {
+        counts[b as usize] += 1;
+    }
+    let len = data.len() as f64;
+    counts.iter()
+        .filter(|&&c| c > 0)
+        .map(|&c| { let p = c as f64 / len; -p * p.log2() })
+        .sum()
+}
 
 // ── CORS configuration ────────────────────────────────────────────────────────
 
@@ -505,9 +521,45 @@ impl Config {
             }
         }
 
-        // Validate HMAC_KEY
+        // Validate HMAC_KEY — must be at least 32 bytes (256 bits) after decoding.
         if self.hmac_key.is_empty() {
             errors.push("HMAC_KEY: environment variable is not set or is empty".to_string());
+        } else {
+            let key_bytes: Vec<u8> = if let Ok(decoded) = hex::decode(&self.hmac_key) {
+                decoded
+            } else if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(&self.hmac_key) {
+                decoded
+            } else {
+                self.hmac_key.as_bytes().to_vec()
+            };
+
+            if key_bytes.len() < 32 {
+                errors.push(format!(
+                    "HMAC_KEY: must be at least 32 bytes (256 bits) after decoding; \
+                     got {} bytes. Generate a secure key with: openssl rand -hex 32",
+                    key_bytes.len()
+                ));
+            } else {
+                let entropy = hmac_key_entropy(&key_bytes);
+                if entropy < 3.5 {
+                    eprintln!(
+                        "Warning: HMAC_KEY appears to have low entropy ({:.2} bits/byte). \
+                         Use a randomly generated key: openssl rand -hex 32",
+                        entropy
+                    );
+                }
+            }
+        }
+
+        // Validate CORS_DEV_MODE is not enabled in production.
+        if self.cors.dev_mode {
+            let rust_env = std::env::var("RUST_ENV").unwrap_or_default();
+            if rust_env.eq_ignore_ascii_case("production") || rust_env.eq_ignore_ascii_case("prod") {
+                errors.push(
+                    "CORS_DEV_MODE=true is not allowed when RUST_ENV=production. \
+                     Remove or set CORS_DEV_MODE=false before deploying.".to_string()
+                );
+            }
         }
 
         // Warn if no API keys are configured — admin endpoints will reject all requests.

--- a/services/api/src/db.rs
+++ b/services/api/src/db.rs
@@ -738,24 +738,25 @@ impl Database {
     }
 
     /// Check whether an email event already exists (replay-attack guard).
+    ///
+    /// Deduplicates on (message_id, event_type, recipient_email) using server-side
+    /// created_at — the SendGrid-supplied timestamp is intentionally excluded because
+    /// it originates from an external, potentially spoofed source.
     pub async fn email_event_exists(
         &self,
         message_id: Option<&str>,
         event_type: &str,
         email: &str,
-        timestamp: i64,
     ) -> anyhow::Result<bool> {
         let count: i64 = self.with_timeout("email_event_exists", sqlx::query_scalar(
             "SELECT COUNT(*) FROM email_events
              WHERE message_id IS NOT DISTINCT FROM $1
                AND event_type = $2
-               AND recipient_email = $3
-               AND created_at = to_timestamp($4)",
+               AND recipient_email = $3",
         )
         .bind(message_id)
         .bind(event_type)
         .bind(email)
-        .bind(timestamp as f64)
         .fetch_one(&self.pool)).await.unwrap_or(0);
         Ok(count > 0)
     }

--- a/services/api/src/email/webhook.rs
+++ b/services/api/src/email/webhook.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use axum::{extract::State, http::{HeaderMap, StatusCode}, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
+use crate::cache::RedisCache;
 use crate::db::Database;
 use crate::email::types::SuppressionType;
 
@@ -27,11 +28,13 @@ pub struct SendGridEvent {
 #[derive(Clone)]
 pub struct WebhookHandler {
     db: Database,
+    cache: RedisCache,
+    replay_window_secs: u64,
 }
 
 impl WebhookHandler {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(db: Database, cache: RedisCache, replay_window_secs: u64) -> Self {
+        Self { db, cache, replay_window_secs }
     }
 
     /// Process SendGrid webhook events
@@ -66,7 +69,6 @@ impl WebhookHandler {
         let event_type = event.event.as_str();
         let email = event.email.as_str();
         let message_id = event.message_id.as_deref();
-        let timestamp = event.timestamp;
 
         tracing::info!(
             "Processing SendGrid event: {} for {} (message_id: {:?})",
@@ -75,9 +77,35 @@ impl WebhookHandler {
             message_id
         );
 
-        // Check for replay attack
-        if self.db.email_event_exists(message_id, event_type, email, timestamp).await? {
-            tracing::warn!("Replay attack detected for event: {} {} {} {}", message_id.unwrap_or(""), event_type, email, timestamp);
+        // Primary replay guard: atomic Redis nonce using server-side received_at.
+        // The SendGrid-supplied timestamp is NOT used here — it originates from an
+        // external source and can be forged to bypass window-based checks.
+        let nonce_key = format!(
+            "webhook_nonce:{}:{}:{}",
+            message_id.unwrap_or(""),
+            event_type,
+            email
+        );
+        let ttl = Duration::from_secs(self.replay_window_secs);
+        let seen_count = self.cache.incr_with_ttl(&nonce_key, ttl).await.unwrap_or(1);
+        if seen_count > 1 {
+            tracing::warn!(
+                "Replay attack detected (Redis nonce) for event: {} {} {}",
+                message_id.unwrap_or(""),
+                event_type,
+                email
+            );
+            return Ok(());
+        }
+
+        // Secondary guard: DB dedup for events that arrive after the Redis TTL expires.
+        if self.db.email_event_exists(message_id, event_type, email).await? {
+            tracing::warn!(
+                "Duplicate event detected (DB) for event: {} {} {}",
+                message_id.unwrap_or(""),
+                event_type,
+                email
+            );
             return Ok(()); // Skip processing
         }
 

--- a/services/api/src/idempotency.rs
+++ b/services/api/src/idempotency.rs
@@ -18,6 +18,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::AppState;
 
@@ -44,7 +45,10 @@ fn extract_user_identity(req: &Request) -> String {
     req.headers()
         .get("x-api-key")
         .and_then(|v| v.to_str().ok())
-        .map(|k| format!("api:{}", &k[..16.min(k.len())]))
+        .map(|k| {
+            let hash = hex::encode(Sha256::digest(k.as_bytes()));
+            format!("api:{}", hash)
+        })
         .or_else(|| {
             req.headers()
                 .get("authorization")

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
 
     let email_service = EmailService::new(config.clone())?;
     let email_queue = EmailQueue::new(cache.clone(), db.clone());
-    let webhook_handler = WebhookHandler::new(db.clone());
+    let webhook_handler = WebhookHandler::new(db.clone(), cache.clone(), config.webhook_replay_window_secs);
     let audit_logger = AuditLogger::new(db.pool());
 
     let bind_addr = config.bind_addr;


### PR DESCRIPTION
## Summary

- ** closes #886 ** — `idempotency.rs`: Replace 16-char API key truncation with SHA-256 hash of the full key, eliminating cross-user idempotency bucket collisions from shared key prefixes
- ** closes #887 ** — `config.rs` + `docker.yml`: Startup assertion refuses to launch when `CORS_DEV_MODE=true` and `RUST_ENV=production`; WARN log already present on dev-mode activation; CI step added to assert the flag is not baked into the production Docker image; `.env.example` updated with explicit danger warning
- ** closes #888 * * — `config.rs` + `README.md`: `HMAC_KEY` validation now requires ≥ 32 bytes (256 bits) after hex/base64 decoding, with a startup warning for low-entropy keys; `README.md` documents `openssl rand -hex 32` as the generation command
- ** closes #885 ** — `webhook.rs` + `db.rs` + `EMAIL.md`: Webhook replay detection no longer trusts the SendGrid-supplied timestamp; replaced with a two-layer server-side mechanism: (1) atomic Redis nonce via `incr_with_ttl` scoped to `(message_id, event_type, email)` as the primary guard within the replay window, (2) DB dedup query without the untrusted timestamp as the secondary guard for events outside the Redis TTL; replay strategy documented in `services/api/EMAIL.md`

## Test plan

- [ ] Start service with `RUST_ENV=production CORS_DEV_MODE=true` — should exit at startup with a config error
- [ ] Start service with `RUST_ENV=production CORS_DEV_MODE=false` — should start normally
- [ ] Start service with `HMAC_KEY` shorter than 32 bytes — should exit with a config error
- [ ] Start service with a weak (low-entropy) `HMAC_KEY` ≥ 32 bytes — should start with a warning printed to stderr
- [ ] Send two identical SendGrid webhook payloads within `WEBHOOK_REPLAY_WINDOW_SECS` — second should be discarded (Redis nonce check)
- [ ] Verify idempotency keys for two API keys that share the same 16-character prefix are now stored under different scoped keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)