### PR TITLE
Fix/four correctness issues

### DIFF
--- a/contracts/predict-iq/src/modules/events.rs
+++ b/contracts/predict-iq/src/modules/events.rs
@@ -185,9 +185,25 @@ pub fn emit_circuit_breaker_auto(e: &Env, contract_address: Address, error_count
     );
 }
 
-pub fn emit_fee_collected(e: &Env, _market_id: u64, contract_address: Address, amount: i128) {
+/// Emits a standardized fee-collection event.
+///
+/// Topic layout (fixed across every call site so indexers can interpret it
+/// unambiguously regardless of which fee path emitted it):
+/// - Topic 0: `fee_colct` symbol
+/// - Topic 1: market_id (u64, 0 when not tied to a specific market)
+/// - Topic 2: token - the asset address the fee was collected in
+/// - Topic 3: recipient - the address that actually holds the fee (e.g. the
+///   protocol treasury for market-creation fees, or this contract itself for
+///   accumulated per-bet fees tracked via `DataKey::FeeRevenue(token)`)
+pub fn emit_fee_collected(
+    e: &Env,
+    _market_id: u64,
+    token: Address,
+    recipient: Address,
+    amount: i128,
+) {
     e.events().publish(
-        (symbol_short!("fee_colct"), 0u64, contract_address),
+        (symbol_short!("fee_colct"), 0u64, token, recipient),
         (EVENT_VERSION, amount),
     );
 }

--- a/contracts/predict-iq/src/modules/fees.rs
+++ b/contracts/predict-iq/src/modules/fees.rs
@@ -110,9 +110,11 @@ pub fn collect_fee(e: &Env, token: Address, amount: i128) -> Result<(), ErrorCod
         .persistent()
         .set(&DataKey::TotalFeesCollected, &new_overall);
 
-    // Emit standardized fee collection event using centralized emitter
+    // Emit standardized fee collection event using centralized emitter.
+    // Fees are held by this contract until withdrawn, so the contract itself
+    // is the actual recipient; the token identifies which asset was collected.
     let contract_addr = e.current_contract_address();
-    crate::modules::events::emit_fee_collected(e, 0, contract_addr, amount);
+    crate::modules::events::emit_fee_collected(e, 0, token, contract_addr, amount);
     Ok(())
 }
 
@@ -293,6 +295,35 @@ mod tests {
             result.is_err(),
             "i128::MAX * 10_000 must overflow and return Err"
         );
+    }
+}
+
+#[cfg(test)]
+mod collect_fee_events_tests {
+    use crate::modules::fees;
+    use crate::PredictIQ;
+    use soroban_sdk::testutils::{Address as _, Events as _};
+    use soroban_sdk::{Address, Env};
+
+    #[test]
+    fn collect_fee_emits_fee_collected_event_with_token_address() {
+        let env = Env::default();
+        let contract_id = env.register(PredictIQ, ());
+        let token = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            fees::collect_fee(&env, token.clone(), 1_000).unwrap();
+        });
+
+        let events = env.events().all();
+        assert!(!events.is_empty());
+
+        // Issue: the per-bet fee event must identify which token the fee was
+        // collected in, even though it never transfers funds itself.
+        let events_debug = format!("{:?}", events);
+        assert!(events_debug.contains("fee_colct"));
+        let token_debug = format!("{:?}", token);
+        assert!(events_debug.contains(&token_debug));
     }
 }
 

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -467,6 +467,11 @@ pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     // Archive the market ID for off-chain indexers
     crate::modules::event_archive::archive_market(e, market_id);
 
+    // Clear all voting-state storage (votes, tallies, locked tokens/balances,
+    // dispute voter registry) so disputed-and-resolved markets don't leave an
+    // unbounded storage footprint behind after pruning.
+    crate::modules::voting::prune_market_voting_state(e, market_id, market.options.len());
+
     // Remove status index entry before dropping the market record.
     e.storage()
         .persistent()
@@ -482,4 +487,126 @@ pub fn prune_market(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
     crate::modules::events::emit_market_pruned(e, market_id, current_time);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod markets_prune_tests {
+    use super::*;
+    use crate::modules::voting;
+    use crate::types::{LockedTokens, Vote};
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Map};
+
+    /// Builds and stores a disputed-then-resolved market directly (bypassing the
+    /// public create/dispute/resolve flow) with a voter's full voting-state
+    /// footprint (Vote, VoteTally, LockedTokens, LockedBalance, DisputeVoters).
+    fn seed_resolved_market_with_voting_state(e: &Env, market_id: u64, voter: &Address) {
+        let market = Market {
+            id: market_id,
+            creator: Address::generate(e),
+            description: String::from_str(e, "test market"),
+            options: Vec::from_array(
+                e,
+                [String::from_str(e, "Yes"), String::from_str(e, "No")],
+            ),
+            status: MarketStatus::Resolved,
+            deadline: 100,
+            resolution_deadline: 200,
+            winning_outcome: Some(0),
+            oracle_config: OracleConfig {
+                oracle_address: Address::generate(e),
+                feed_id: String::from_str(e, "test"),
+                min_responses: Some(1),
+                max_staleness_seconds: 3600,
+                max_confidence_bps: 100,
+                strike_price: None,
+            },
+            total_staked: 0,
+            payout_mode: crate::types::PayoutMode::Pull,
+            tier: MarketTier::Basic,
+            creation_deposit: 0,
+            parent_id: 0,
+            parent_outcome_idx: 0,
+            resolved_at: Some(0),
+            token_address: Address::generate(e),
+            outcome_stakes: Map::new(e),
+            pending_resolution_timestamp: None,
+            dispute_snapshot_ledger: None,
+            dispute_timestamp: Some(0),
+            winner_counts: Map::new(e),
+            total_claimed: 0,
+        };
+        e.storage().persistent().set(&DataKey::Market(market_id), &market);
+        e.storage()
+            .persistent()
+            .set(&DataKey::StatusIndex(market_id, MarketStatus::Resolved), &true);
+
+        // Seed the full voting-state footprint that `prune_market_voting_state`
+        // is responsible for clearing.
+        let voters = Vec::from_array(e, [voter.clone()]);
+        e.storage()
+            .persistent()
+            .set(&voting::DataKey::DisputeVoters(market_id), &voters);
+        e.storage().persistent().set(
+            &voting::DataKey::Vote(market_id, voter.clone()),
+            &Vote {
+                market_id,
+                voter: voter.clone(),
+                outcome: 0,
+                weight: 500,
+            },
+        );
+        e.storage().persistent().set(
+            &voting::DataKey::LockedTokens(market_id, voter.clone()),
+            &LockedTokens {
+                voter: voter.clone(),
+                market_id,
+                amount: 500,
+                unlock_time: 0,
+            },
+        );
+        e.storage()
+            .persistent()
+            .set(&voting::DataKey::LockedBalance(market_id, voter.clone()), &500i128);
+        e.storage()
+            .persistent()
+            .set(&voting::DataKey::VoteTally(market_id, 0), &500i128);
+    }
+
+    #[test]
+    fn prune_market_clears_voting_state() {
+        let e = Env::default();
+        let market_id = 1u64;
+        let voter = Address::generate(&e);
+
+        seed_resolved_market_with_voting_state(&e, market_id, &voter);
+
+        // Advance past the prune grace period.
+        e.ledger().set_timestamp(PRUNE_GRACE_PERIOD + 1);
+
+        prune_market(&e, market_id).unwrap();
+
+        assert!(!e
+            .storage()
+            .persistent()
+            .has(&voting::DataKey::DisputeVoters(market_id)));
+        assert!(!e
+            .storage()
+            .persistent()
+            .has(&voting::DataKey::Vote(market_id, voter.clone())));
+        assert!(!e
+            .storage()
+            .persistent()
+            .has(&voting::DataKey::LockedTokens(market_id, voter.clone())));
+        assert!(!e
+            .storage()
+            .persistent()
+            .has(&voting::DataKey::LockedBalance(market_id, voter.clone())));
+        assert!(!e
+            .storage()
+            .persistent()
+            .has(&voting::DataKey::VoteTally(market_id, 0)));
+
+        // The market record itself is gone too, as before this fix.
+        assert!(get_market(&e, market_id).is_none());
+    }
 }

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -196,8 +196,8 @@ pub fn create_market_with_dispute_window(
         let treasury = get_protocol_treasury(e);
         token_client.transfer(&creator, &treasury, &creation_fee);
 
-        // Emit fee collection event
-        crate::modules::events::emit_fee_collected(e, 0, treasury, creation_fee);
+        // Emit fee collection event, identifying both the token and the actual recipient
+        crate::modules::events::emit_fee_collected(e, 0, native_token.clone(), treasury, creation_fee);
     }
 
     // Lock deposit if required

--- a/contracts/predict-iq/src/modules/migration.rs
+++ b/contracts/predict-iq/src/modules/migration.rs
@@ -1,6 +1,6 @@
 use crate::errors::ErrorCode;
-use crate::types::ConfigKey;
-use soroban_sdk::{contracttype, Env, Vec};
+use crate::types::{ConfigKey, Guardian};
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 /// Storage migration context for tracking version changes
 #[contracttype]
@@ -10,8 +10,24 @@ pub struct MigrationContext {
     pub to_version: u32,
 }
 
-/// Execute a storage migration with rollback capability
-/// Post-migration validation checks key invariants. If validation fails, migration fails atomically.
+/// Snapshot of the storage this module guarantees to restore on rollback.
+/// Scope is intentionally limited to the keys `verify_migration_integrity` checks
+/// (`ConfigKey::Admin`, `ConfigKey::GuardianSet`).
+#[contracttype]
+#[derive(Clone)]
+struct MigrationBackup {
+    admin: Option<Address>,
+    guardian_set: Option<Vec<Guardian>>,
+}
+
+/// Execute a storage migration with rollback capability.
+///
+/// Rollback scope: only `ConfigKey::Admin` and `ConfigKey::GuardianSet` -- the keys
+/// `verify_migration_integrity` validates -- are snapshotted before `migration_fn`
+/// runs and are genuinely restored to their prior values if `migration_fn` errors or
+/// post-migration validation fails. Any other storage mutated by `migration_fn` is
+/// NOT automatically reverted; migrations that touch state outside these two keys
+/// must be manually reversible or safely re-driveable.
 pub fn execute_migration(
     e: &Env,
     from_version: u32,
@@ -48,22 +64,42 @@ pub fn execute_migration(
     }
 }
 
-/// Backup current storage state before migration
+/// Snapshot the actual pre-migration values of `ConfigKey::Admin` and
+/// `ConfigKey::GuardianSet` (the keys `verify_migration_integrity` checks).
 fn backup_storage_state(e: &Env, version: u32) -> Result<(), ErrorCode> {
     let backup_key = format!("migration:backup:v{}", version);
-    let timestamp = e.ledger().timestamp();
+    let backup = MigrationBackup {
+        admin: e.storage().persistent().get(&ConfigKey::Admin),
+        guardian_set: e.storage().persistent().get(&ConfigKey::GuardianSet),
+    };
 
-    e.storage().persistent().set(&backup_key, &timestamp);
+    e.storage().persistent().set(&backup_key, &backup);
 
     Ok(())
 }
 
-/// Restore storage state from backup
+/// Restore `ConfigKey::Admin` and `ConfigKey::GuardianSet` to the values captured
+/// by `backup_storage_state`, genuinely reverting them rather than just clearing
+/// a marker.
 fn restore_storage_state(e: &Env, version: u32) -> Result<(), ErrorCode> {
     let backup_key = format!("migration:backup:v{}", version);
 
-    if !e.storage().persistent().has(&backup_key) {
-        return Err(ErrorCode::NotAuthorized);
+    let backup: MigrationBackup = e
+        .storage()
+        .persistent()
+        .get(&backup_key)
+        .ok_or(ErrorCode::NotAuthorized)?;
+
+    match backup.admin {
+        Some(admin) => e.storage().persistent().set(&ConfigKey::Admin, &admin),
+        None => e.storage().persistent().remove(&ConfigKey::Admin),
+    }
+    match backup.guardian_set {
+        Some(guardians) => e
+            .storage()
+            .persistent()
+            .set(&ConfigKey::GuardianSet, &guardians),
+        None => e.storage().persistent().remove(&ConfigKey::GuardianSet),
     }
 
     e.storage().persistent().remove(&backup_key);
@@ -136,24 +172,21 @@ pub fn validate_all_markets_stake_invariant(e: &Env, market_count: u64) -> Resul
     Ok(true)
 }
 
-/// Reverse a migration to previous version
+/// Reverse a migration to previous version.
+///
+/// Same rollback scope as `execute_migration`: genuinely restores
+/// `ConfigKey::Admin` and `ConfigKey::GuardianSet` from the snapshot taken
+/// before the migration ran.
 pub fn reverse_migration(e: &Env, from_version: u32, to_version: u32) -> Result<(), ErrorCode> {
     if from_version >= to_version {
         return Err(ErrorCode::NotAuthorized);
     }
 
-    // Verify backup exists
-    let backup_key = format!("migration:backup:v{}", from_version);
-    if !e.storage().persistent().has(&backup_key) {
-        return Err(ErrorCode::NotAuthorized);
-    }
+    restore_storage_state(e, from_version)?;
 
     // Clear migration log entry
     let migration_log_key = "migration:log";
     e.storage().persistent().remove(&migration_log_key);
-
-    // Remove backup after successful reversal
-    e.storage().persistent().remove(&backup_key);
 
     Ok(())
 }
@@ -184,20 +217,42 @@ mod tests {
 
         let env = soroban_sdk::Env::default();
         let admin = Address::generate(&env);
+        let original_guardians = Vec::from_array(
+            &env,
+            [Guardian {
+                address: Address::generate(&env),
+                voting_power: 1,
+            }],
+        );
 
         env.storage().persistent().set(&ConfigKey::Admin, &admin);
         env.storage()
             .persistent()
-            .set(&ConfigKey::GuardianSet, &admin);
+            .set(&ConfigKey::GuardianSet, &original_guardians);
 
-        // Migration that removes admin key (invalidates state)
+        // Migration that removes Admin and overwrites GuardianSet. Removing Admin
+        // invalidates state (verify_migration_integrity fails), which must trigger
+        // a genuine rollback of both snapshotted keys -- not just marker cleanup.
+        let tampered_guardians: Vec<Guardian> = Vec::new(&env);
         let result = execute_migration(&env, 1, 2, |_e| {
             _e.storage().persistent().remove(&ConfigKey::Admin);
+            _e.storage()
+                .persistent()
+                .set(&ConfigKey::GuardianSet, &tampered_guardians);
             Ok(())
         });
 
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), ErrorCode::MigrationValidationError);
-        assert!(env.storage().persistent().has(&ConfigKey::Admin));
+
+        let restored_admin: Address = env.storage().persistent().get(&ConfigKey::Admin).unwrap();
+        assert_eq!(restored_admin, admin);
+
+        let restored_guardians: Vec<Guardian> = env
+            .storage()
+            .persistent()
+            .get(&ConfigKey::GuardianSet)
+            .unwrap();
+        assert_eq!(restored_guardians, original_guardians);
     }
 }

--- a/contracts/predict-iq/src/modules/monitoring.rs
+++ b/contracts/predict-iq/src/modules/monitoring.rs
@@ -119,8 +119,8 @@ mod tests {
         reset_monitoring, track_error, track_storage_count, DataKey, STORAGE_ALERT_THRESHOLD,
     };
     use soroban_sdk::{
-        testutils::{Events, Ledger},
-        Env,
+        testutils::{Address as _, Events, Ledger},
+        Address, Env,
     };
 
     #[test]
@@ -185,5 +185,31 @@ mod tests {
         let e = Env::default();
         let count = track_storage_count(&e);
         assert!(count >= 0);
+    }
+
+    /// Issue: track_error was documented as the trigger for the auto circuit
+    /// breaker but nothing in the codebase ever called it from a real failure
+    /// path. This drives a burst of failures through `sac::safe_transfer`
+    /// (transfers to an address with no deployed token contract, which
+    /// `try_transfer` surfaces as a recoverable error rather than a host trap)
+    /// and asserts the documented threshold actually trips the breaker.
+    #[test]
+    fn repeated_transfer_failures_trip_circuit_breaker() {
+        let e = Env::default();
+        let token = Address::generate(&e);
+        let from = Address::generate(&e);
+        let to = Address::generate(&e);
+
+        for _ in 0..11 {
+            let result = crate::modules::sac::safe_transfer(&e, &token, &from, &to, &100);
+            assert!(result.is_err());
+        }
+
+        let state: crate::types::CircuitBreakerState = e
+            .storage()
+            .instance()
+            .get(&crate::types::ConfigKey::CircuitBreakerState)
+            .unwrap();
+        assert_eq!(state, crate::types::CircuitBreakerState::Open);
     }
 }

--- a/contracts/predict-iq/src/modules/oracles.rs
+++ b/contracts/predict-iq/src/modules/oracles.rs
@@ -100,6 +100,7 @@ pub fn validate_oracle_staleness(
             any_found = true;
             let age = current_time.saturating_sub(update_time);
             if age > max_staleness {
+                crate::modules::monitoring::track_error(e);
                 return Err(ErrorCode::StalePrice);
             }
         }
@@ -108,6 +109,7 @@ pub fn validate_oracle_staleness(
     if any_found {
         Ok(())
     } else {
+        crate::modules::monitoring::track_error(e);
         Err(ErrorCode::OracleFailure)
     }
 }

--- a/contracts/predict-iq/src/modules/sac.rs
+++ b/contracts/predict-iq/src/modules/sac.rs
@@ -20,6 +20,7 @@ pub fn safe_transfer(
                 (symbol_short!("xfer_fail"), from.clone(), to.clone()),
                 (token_address.clone(), *amount),
             );
+            crate::modules::monitoring::track_error(e);
             ErrorCode::TransferFailed
         })?
         .map_err(|_| {
@@ -27,6 +28,7 @@ pub fn safe_transfer(
                 (symbol_short!("xfer_fail"), from.clone(), to.clone()),
                 (token_address.clone(), *amount),
             );
+            crate::modules::monitoring::track_error(e);
             ErrorCode::TransferFailed
         })
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->
1. 176b05e — migration rollback (modules/migration.rs)
backup_storage_state used to store just a timestamp; restore_storage_state only checked/cleared that marker — no state was ever actually reverted. Now both snapshot and restore the real values of ConfigKey::Admin and ConfigKey::GuardianSet (the two keys verify_migration_integrity checks), via a new MigrationBackup struct. reverse_migration now routes through the same restore path instead of duplicating the old fake-check. Doc comments spell out that rollback scope is limited to those two keys — a migration_fn touching other storage must be self-reversible. Rewrote the existing test to tamper with both keys and assert they come back to their original values, not just "the marker was cleared."

2. b1ad505 — voting-state pruning (modules/markets.rs)
prune_market deleted the market record but never called voting::prune_market_voting_state, so every disputed-and-resolved market left its Vote/VoteTally/LockedTokens/LockedBalance/DisputeVoters entries in storage forever. Added the call before the record is removed. New test seeds a resolved market plus a full voting-state footprint directly, prunes it, and asserts every voting key is gone.

3. a7c6178 — fee event standardization (modules/events.rs, modules/fees.rs, modules/markets.rs)
emit_fee_collected's address param meant "recipient" at one call site and "the contract itself" at the other, and never carried the token. Added an explicit token parameter; both call sites (collect_fee, create_market_with_dispute_window) now pass the real token address alongside the recipient. New test asserts collect_fee's emitted event contains the token address.

4. 76bd4e8 — circuit breaker wiring (modules/monitoring.rs, modules/sac.rs, modules/oracles.rs)
track_error was documented as tripping the breaker after 10 errors but nothing ever called it. Wired it into sac::safe_transfer's two failure paths and oracles::validate_oracle_staleness's StalePrice/OracleFailure paths. New test drives 11 failed transfers through safe_transfer and asserts CircuitBreakerState::Open.
## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #1196
Closes #1197
Closes #1198
Closes #1199