### PR TITLE
Fix/terraform module variable mismatches

### DIFF
--- a/contracts/predict-iq/src/modules/sac.rs
+++ b/contracts/predict-iq/src/modules/sac.rs
@@ -69,16 +69,71 @@ pub fn check_token_not_frozen(
     }
 }
 
-/// Check if contract can receive tokens (not frozen)
-/// Returns true if the contract's balance can be modified
+/// Check if the contract itself can receive/send tokens (not frozen).
+/// Classic Stellar assets wrapped by a SAC expose freeze as deauthorization:
+/// a deauthorized (frozen) account fails `authorized()` and cannot transfer.
+/// Returns Ok(()) if the contract is authorized or the token doesn't support
+/// authorization (freeze is not applicable).
+/// Returns Err(ErrorCode::TokenFrozen) if the contract has been deauthorized.
 pub fn verify_contract_not_frozen(e: &Env, token_address: &Address) -> Result<(), ErrorCode> {
     let client = token::Client::new(e, token_address);
     let contract_addr = e.current_contract_address();
 
-    // Try to get balance - if frozen, this will succeed but transfers will fail
-    let _balance = client.balance(&contract_addr);
+    match client.try_authorized(&contract_addr) {
+        Ok(Ok(is_authorized)) => {
+            if is_authorized {
+                Ok(())
+            } else {
+                e.events().publish(
+                    (symbol_short!("ctr_frz"), token_address.clone()),
+                    (),
+                );
+                Err(ErrorCode::TokenFrozen)
+            }
+        }
+        // Token doesn't support authorization or the view call failed -
+        // treat as not frozen, matching check_token_not_frozen's behavior.
+        _ => Ok(()),
+    }
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn verify_contract_not_frozen_ok_when_authorized() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        let token_admin = Address::generate(&e);
+        let sac = e.register_stellar_asset_contract_v2(token_admin);
+        let token_address = sac.address();
+        let contract_addr = Address::generate(&e);
+
+        let result = e.as_contract(&contract_addr, || verify_contract_not_frozen(&e, &token_address));
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn verify_contract_not_frozen_detects_frozen_contract() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        let token_admin = Address::generate(&e);
+        let sac = e.register_stellar_asset_contract_v2(token_admin);
+        let token_address = sac.address();
+        let asset_client = token::StellarAssetClient::new(&e, &token_address);
+        let contract_addr = Address::generate(&e);
+
+        // Deauthorize the contract's trustline - this is how Classic Stellar
+        // assets implement freeze.
+        asset_client.set_authorized(&contract_addr, &false);
+
+        let result = e.as_contract(&contract_addr, || verify_contract_not_frozen(&e, &token_address));
+        assert_eq!(result, Err(ErrorCode::TokenFrozen));
+    }
 }
 
 /// Issue #27: ErrorCode::AssetClawedBack now exists in errors.rs.

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -103,6 +103,7 @@ module "redis" {
   node_type          = var.redis_node_type
   num_cache_clusters = var.redis_num_nodes
   engine_version     = var.redis_engine_version
+  redis_auth_token   = var.redis_auth_token
   ecs_tasks_sg_id    = aws_security_group.ecs_tasks.id
 }
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -101,7 +101,7 @@ module "redis" {
   vpc_id             = module.vpc.vpc_id
   subnet_ids         = module.vpc.private_subnet_ids
   node_type          = var.redis_node_type
-  num_cache_nodes    = var.redis_num_nodes
+  num_cache_clusters = var.redis_num_nodes
   engine_version     = var.redis_engine_version
   ecs_tasks_sg_id    = aws_security_group.ecs_tasks.id
 }
@@ -118,7 +118,11 @@ module "ecs" {
   api_desired_count     = var.api_desired_count
   api_cpu               = var.api_cpu
   api_memory            = var.api_memory
-  database_url          = module.rds.database_url
+  db_host               = module.rds.endpoint
+  db_port               = 5432
+  db_name               = var.db_name
+  db_user               = var.db_username
+  db_password           = var.db_password
   redis_url             = module.redis.redis_url
   acm_certificate_arn   = var.acm_certificate_arn
   hmac_key              = var.hmac_key

--- a/infrastructure/terraform/modules/ecs/main.tf
+++ b/infrastructure/terraform/modules/ecs/main.tf
@@ -631,7 +631,11 @@ output "alb_dns_name" {
 output "secret_arns" {
   description = "Map of secret name → ARN for all Secrets Manager secrets managed by this module"
   value = {
-    database_url     = aws_secretsmanager_secret.database_url.arn
+    db_host          = aws_secretsmanager_secret.db_host.arn
+    db_port          = aws_secretsmanager_secret.db_port.arn
+    db_name          = aws_secretsmanager_secret.db_name.arn
+    db_user          = aws_secretsmanager_secret.db_user.arn
+    db_password      = aws_secretsmanager_secret.db_password.arn
     redis_url        = aws_secretsmanager_secret.redis_url.arn
     hmac_key         = aws_secretsmanager_secret.hmac_key.arn
     sendgrid_api_key = aws_secretsmanager_secret.sendgrid_api_key.arn

--- a/infrastructure/terraform/modules/rds/main.tf
+++ b/infrastructure/terraform/modules/rds/main.tf
@@ -104,7 +104,7 @@ resource "aws_db_instance" "main" {
   backup_retention_period = var.backup_retention
   backup_window           = "03:00-04:00"
   maintenance_window      = "mon:04:00-mon:05:00"
-  deletion_protection     = var.deletion_protection
+  deletion_protection     = var.environment == "prod" ? true : var.deletion_protection
 
   multi_az               = var.environment == "prod" ? true : false
   publicly_accessible    = false
@@ -117,6 +117,10 @@ resource "aws_db_instance" "main" {
       Name = "predictiq-${var.environment}-db"
     }
   )
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 output "sg_id" {

--- a/infrastructure/terraform/modules/redis/main.tf
+++ b/infrastructure/terraform/modules/redis/main.tf
@@ -23,6 +23,12 @@ variable "engine_version" {
   type = string
 }
 
+variable "redis_auth_token" {
+  type        = string
+  sensitive   = true
+  description = "AUTH token required to authenticate to the Redis replication group"
+}
+
 variable "redis_multi_az_enabled" {
   type        = bool
   default     = true
@@ -94,6 +100,7 @@ resource "aws_elasticache_replication_group" "main" {
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
+  auth_token                 = var.redis_auth_token
 
   maintenance_window = "mon:03:00-mon:04:00"
 
@@ -115,6 +122,6 @@ output "endpoint" {
 }
 
 output "redis_url" {
-  value     = "redis://${aws_elasticache_replication_group.main.primary_endpoint_address}:6379"
+  value     = "redis://:${var.redis_auth_token}@${aws_elasticache_replication_group.main.primary_endpoint_address}:6379"
   sensitive = true
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->
1. verify_contract_not_frozen was a no-op guard (contracts/predict-iq/src/modules/sac.rs)
The function only called balance(), which doesn't reflect frozen status — so it always returned Ok(()) regardless of whether the contract's tokens were actually frozen, despite its name and docs implying a real check. Fixed it to check the contract's authorized() state on the token (the mechanism Classic Stellar assets use to implement freeze via SAC deauthorization), returning ErrorCode::TokenFrozen when the contract has been deauthorized. Added unit tests covering both the authorized and frozen cases.

2. Terraform root/child module variable mismatches (infrastructure/terraform/main.tf, modules/ecs/main.tf)
- Root main.tf passed database_url into the ecs module, but that module only declares db_host/db_port/db_name/db_user/db_password — none of which were being supplied. Fixed by passing the individual fields instead.
- Root main.tf passed num_cache_nodes into the redis module, but the module only declares num_cache_clusters. Renamed the argument to match.
- The ecs module's secret_arns output referenced aws_secretsmanager_secret.database_url, a resource that doesn't exist anywhere in the module. Replaced it with the real per-field db secret ARNs (db_host, db_port, db_name, db_user, db_password).

3. Production RDS had no real delete protection (infrastructure/terraform/modules/rds/main.tf)
deletion_protection defaulted to false and was never overridden for prod by the root module or production/terraform.tfvars, and there was no prevent_destroy lifecycle guard — meaning a terraform destroy, an accidental recreation, or console deletion could wipe the production database. Now deletion_protection is forced to true whenever environment == "prod", and a lifecycle { prevent_destroy = true } block was added to the DB instance.

4. Redis had zero authentication (infrastructure/terraform/modules/redis/main.tf, root main.tf)
redis_auth_token was declared with strong validation at the root module (implying AUTH was intended) but was never passed into the redis module, which didn't even declare a variable to receive it, and the replication group had no auth_token argument despite transit_encryption_enabled = true. Added a redis_auth_token variable to the redis module, set it as the replication group's auth_token, passed it from the root module, and embedded it into the redis_url output so the existing ECS REDIS_URL secret carries the credential to the API service without any new plumbing on the ECS side.
## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation update
- [ ] CI / tooling change
- [x] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #1200
Closes #1201 
Closes #1202 
Closes #1203
