### PR TITLE
Fix/terraform workflow security hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,16 @@ jobs:
     strategy:
       matrix:
         environment: [dev, staging, prod]
+    env:
+      TF_VAR_db_username: ${{ secrets[format('DB_USERNAME_{0}', matrix.environment)] }}
+      TF_VAR_db_password: ${{ secrets[format('DB_PASSWORD_{0}', matrix.environment)] }}
+      TF_VAR_hmac_key: ${{ secrets[format('HMAC_KEY_{0}', matrix.environment)] }}
+      TF_VAR_sendgrid_api_key: ${{ secrets[format('SENDGRID_API_KEY_{0}', matrix.environment)] }}
+      TF_VAR_api_signing_key: ${{ secrets[format('API_SIGNING_KEY_{0}', matrix.environment)] }}
+      TF_VAR_acm_certificate_arn: ${{ secrets[format('ACM_CERTIFICATE_ARN_{0}', matrix.environment)] }}
+      TF_VAR_api_image_uri: ${{ secrets[format('API_IMAGE_URI_{0}', matrix.environment)] }}
+      TF_VAR_redis_auth_token: ${{ secrets[format('REDIS_AUTH_TOKEN_{0}', matrix.environment)] }}
+      TF_VAR_sendgrid_key_rotated_at: ${{ secrets[format('SENDGRID_KEY_ROTATED_AT_{0}', matrix.environment)] }}
     steps:
       - uses: actions/checkout@v4
 
@@ -132,6 +142,16 @@ jobs:
       matrix:
         environment: [dev, staging, prod]
       max-parallel: 1
+    env:
+      TF_VAR_db_username: ${{ secrets[format('DB_USERNAME_{0}', matrix.environment)] }}
+      TF_VAR_db_password: ${{ secrets[format('DB_PASSWORD_{0}', matrix.environment)] }}
+      TF_VAR_hmac_key: ${{ secrets[format('HMAC_KEY_{0}', matrix.environment)] }}
+      TF_VAR_sendgrid_api_key: ${{ secrets[format('SENDGRID_API_KEY_{0}', matrix.environment)] }}
+      TF_VAR_api_signing_key: ${{ secrets[format('API_SIGNING_KEY_{0}', matrix.environment)] }}
+      TF_VAR_acm_certificate_arn: ${{ secrets[format('ACM_CERTIFICATE_ARN_{0}', matrix.environment)] }}
+      TF_VAR_api_image_uri: ${{ secrets[format('API_IMAGE_URI_{0}', matrix.environment)] }}
+      TF_VAR_redis_auth_token: ${{ secrets[format('REDIS_AUTH_TOKEN_{0}', matrix.environment)] }}
+      TF_VAR_sendgrid_key_rotated_at: ${{ secrets[format('SENDGRID_KEY_ROTATED_AT_{0}', matrix.environment)] }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,11 @@ jobs:
       matrix:
         environment: [dev, staging, prod]
       max-parallel: 1
+    # Ties each matrix leg to a GitHub Environment of the same name. Configure
+    # a "prod" environment with required reviewers in repo settings so that
+    # leg pauses for manual approval; dev/staging can stay unprotected and will
+    # keep auto-applying on merge to main, matching environments/README.md.
+    environment: ${{ matrix.environment }}
     env:
       TF_VAR_db_username: ${{ secrets[format('DB_USERNAME_{0}', matrix.environment)] }}
       TF_VAR_db_password: ${{ secrets[format('DB_PASSWORD_{0}', matrix.environment)] }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,13 @@ jobs:
 
       - name: Output infrastructure details
         working-directory: infrastructure/terraform
-        run: terraform output -json > /tmp/outputs-${{ matrix.environment }}.json
+        run: |
+          # Human-readable output still relies on Terraform's own `sensitive`
+          # redaction, so it's safe to print to the (already access-controlled) logs.
+          terraform output
+          # -json bypasses that redaction entirely, so strip the sensitive keys
+          # ourselves before anything touches disk / an uploaded artifact.
+          terraform output -json | jq 'del(.rds_endpoint, .redis_endpoint)' > /tmp/outputs-${{ matrix.environment }}.json
 
       - name: Upload outputs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 env:
   TF_WORKING_DIR: infrastructure/terraform
@@ -92,8 +93,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Terraform Init


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

Description:
- Sensitive output leak (High): deploy.yml wrote terraform output -json straight to a file uploaded as a build artifact. Terraform's sensitive = true only redacts the human-readable CLI output, not -json, so rds_endpoint/redis_endpoint were exposed in plaintext to anyone with artifact-read access. Now the JSON is piped through jq 'del(.rds_endpoint, .redis_endpoint)' before it's written, and a plain terraform output is printed to logs (still correctly redacted) for anyone who needs to eyeball values.
- Missing required variables (Critical): terraform plan/apply only passed the per-environment .tfvars file, none of which set the required no-default sensitive variables (db_username, db_password, hmac_key, sendgrid_api_key, api_signing_key, acm_certificate_arn, api_image_uri, redis_auth_token, sendgrid_key_rotated_at) — every environment hard-failed with "No value for required variable". Added TF_VAR_* env vars to the plan and apply jobs, sourced from per-environment GitHub secrets (secrets[format('DB_PASSWORD_{0}', matrix.environment)], etc.), matching the AWS_ROLE_{0} pattern already used in this file.
- Prod applies with no approval gate (Critical): the apply job's matrix ran prod automatically on every push to main with no environment: key, contradicting environments/README.md's documented manual-approval requirement. Added environment: ${{ matrix.environment }} to the apply job so each leg maps to a same-named GitHub Environment — configure a prod environment with required reviewers in repo settings to enforce the pause; dev/staging are unaffected and keep auto-applying.
- Static long-lived AWS keys (High): terraform.yml authenticated with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY repo secrets, including on the prod matrix leg, unlike deploy.yml's short-lived OIDC role assumption. Switched to role-to-assume: ${{ secrets.AWS_ROLE_ARN }} (resolved per GitHub Environment via the job's existing environment: key) and added the id-token: write permission OIDC requires.
## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #1204 
Closes #1205 
Closes #1206 
Closes #1207
