### PR TITLE
Fix Gitleaks allowlist regexes for localhost/127.0.0.1

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,8 +44,10 @@ paths = [
 
 regexes = [
   '''example\.com''',
-  '''localhost''',
-  '''127\.0\.0\.1''',
+  '''^localhost$''',
+  '''^127\.0\.0\.1$''',
+  '''^postgres(ql)?://(?:postgres|user|admin|root|example):(?:password|pass|postgres|example|secret)@(?:localhost|127\.0\.0\.1)(?::[0-9]+)?/[A-Za-z0-9_-]+$''',
+  '''^redis://(?:postgres|user|admin|root|example):(?:password|pass|postgres|example|secret)@(?:localhost|127\.0\.0\.1):[0-9]+$''',
   '''GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX''',
   '''SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX''',
 ]


### PR DESCRIPTION
Scope Gitleaks allowlist regexes so generic localhost and 127.0.0.1 substrings do not allowlist real connection strings. Added placeholder-specific permit patterns for postgres and redis URLs and validated locally with Gitleaks.


closes #1217 