### PR TITLE
fix: stop submit button from dropping keyboard focus on submit

### DIFF
--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -24,6 +24,10 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (isLoading || isSubmitted) {
+      return;
+    }
+
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!email) {
       setEmailError(t('hero.emailRequired'));
@@ -181,9 +185,9 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
               )}
             </div>
 
-            <button 
-              type="submit" 
-              disabled={isSubmitted || isLoading}
+            <button
+              type="submit"
+              aria-disabled={isSubmitted || isLoading}
               aria-label={
                 isLoading 
                   ? 'Submitting...' 

--- a/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
@@ -303,7 +303,7 @@ describe('LandingPage Accessibility Tests', () => {
       
       await waitFor(() => {
         expect(emailInput).toBeDisabled();
-        expect(submitButton).toBeDisabled();
+        expect(submitButton).toHaveAttribute('aria-disabled', 'true');
       });
     });
 
@@ -326,13 +326,46 @@ describe('LandingPage Accessibility Tests', () => {
       
       await userEvent.type(emailInput, 'test@example.com');
       await userEvent.click(submitButton);
-      
-      expect(submitButton).toBeDisabled();
+
+      expect(submitButton).toHaveAttribute('aria-disabled', 'true');
       expect(emailInput).toBeDisabled();
-      
+
       resolvePromise!({ success: true, message: 'Subscribed' });
       await waitFor(() => {
-        expect(submitButton).toBeDisabled();
+        expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    it('does not trigger a second API call when the submit button is activated again while in-flight', async () => {
+      let resolvePromise: (value: { success: boolean; message: string }) => void;
+      const promise = new Promise<{ success: boolean; message: string }>((resolve) => {
+        resolvePromise = resolve;
+      });
+      (global.fetch as jest.Mock).mockReturnValueOnce(
+        promise.then(() => ({
+          ok: true,
+          text: async () => JSON.stringify({ success: true, message: 'Subscribed' }),
+        }))
+      );
+
+      render(<LandingPage />);
+
+      const emailInput = screen.getByLabelText(/email address/i);
+      const submitButton = screen.getByRole('button', { name: /get early access/i });
+
+      await userEvent.type(emailInput, 'test@example.com');
+      await userEvent.click(submitButton);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // Button remains focusable (aria-disabled, not disabled) — re-activating it
+      // while the request is in-flight must not fire a second request.
+      await userEvent.click(submitButton, { skipPointerEventsCheck: true });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      resolvePromise!({ success: true, message: 'Subscribed' });
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /subscribed/i })).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
@@ -56,4 +56,24 @@ describe('LandingPage handleKeyDown', () => {
       screen.queryByRole('button', { name: /subscribed/i }),
     ).not.toBeInTheDocument();
   });
+
+  it('keeps keyboard focus on the submit button through loading and success, instead of silently dropping it', async () => {
+    render(<LandingPage />);
+    const emailInput = screen.getByLabelText(/email address/i);
+    const submitButton = screen.getByRole('button', { name: /get early access/i });
+
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.tab();
+    expect(submitButton).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+
+    // While the request is in-flight the button is aria-disabled (not natively
+    // disabled), so it stays in the document and keeps focus.
+    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+    expect(submitButton).toHaveFocus();
+
+    await screen.findByRole('button', { name: /subscribed/i });
+    expect(submitButton).toHaveFocus();
+  });
 });

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -332,15 +332,16 @@ header[role='banner'] {
 .hero button[type='submit'] {
   flex: 0 0 auto;
 }
-.hero button[type='submit']:hover:not(:disabled),
+.hero button[type='submit']:hover:not(:disabled):not([aria-disabled='true']),
 .retry-button:hover {
   transform: translateY(-2px) scale(1.01);
   box-shadow: var(--shadow-glow-gold), 0 14px 30px -12px rgba(139, 92, 246, 0.5);
 }
-.hero button[type='submit']:active:not(:disabled) {
+.hero button[type='submit']:active:not(:disabled):not([aria-disabled='true']) {
   transform: translateY(0) scale(0.98);
 }
-.hero button[type='submit']:disabled {
+.hero button[type='submit']:disabled,
+.hero button[type='submit'][aria-disabled='true'] {
   cursor: not-allowed;
   opacity: 0.6;
   box-shadow: none;


### PR DESCRIPTION
closes #1164 
closes #1165 
closes #1166 
closes #1167 




Newsletter submit button used the native disabled attribute, which browsers unfocus automatically. Since isLoading flips synchronously in handleSubmit, a keyboard/screen-reader user's focus was silently dropped to <body> right after submitting. Switch to aria-disabled and guard against re-submission in handleSubmit instead, so the button stays focusable and keyboard focus never moves unexpectedly.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #
