### PR TITLE
Standardize Statistics error recovery on soft-retry pattern

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,9 +2,11 @@
 
 import React, { ReactNode, ReactElement } from 'react';
 
+type FallbackRenderer = (reset: () => void) => ReactElement;
+
 interface Props {
   children: ReactNode;
-  fallback?: ReactElement;
+  fallback?: ReactElement | FallbackRenderer;
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
   section?: string;
 }
@@ -18,6 +20,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false, error: null };
+    this.reset = this.reset.bind(this);
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -29,8 +32,18 @@ export class ErrorBoundary extends React.Component<Props, State> {
     this.props.onError?.(error, errorInfo);
   }
 
+  // Soft-resets the boundary so children remount and retry on their own,
+  // instead of forcing a full page reload for recoverable errors.
+  reset() {
+    this.setState({ hasError: false, error: null });
+  }
+
   render() {
     if (this.state.hasError) {
+      if (typeof this.props.fallback === 'function') {
+        return this.props.fallback(this.reset);
+      }
+
       return (
         this.props.fallback || (
           <div 

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -214,21 +214,21 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
         </section>
 
         {/* Statistics Section */}
-        <ErrorBoundary section="statistics" fallback={
+        <ErrorBoundary section="statistics" fallback={(reset) => (
           <section className="statistics" aria-labelledby="statistics-heading">
             <h2 id="statistics-heading">Platform Statistics</h2>
             <div className="error-message" role="alert">
               <p>Unable to load statistics at this time. Please try again later.</p>
               <button
                 className="retry-button"
-                onClick={() => window.location.reload()}
+                onClick={reset}
                 aria-label="Retry loading statistics"
               >
                 Retry
               </button>
             </div>
           </section>
-        }>
+        )}>
           <Statistics />
         </ErrorBoundary>
 

--- a/frontend/src/components/__tests__/LandingPage.error-boundary.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.error-boundary.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { LandingPage } from '../LandingPage';
 
-// Mock the Statistics component to throw an error
+// Mock the Statistics component. Controlled by `mockShouldThrow` so tests can
+// simulate recovery after a retry (jest hoists jest.mock factories, so the
+// controlling variable must be prefixed with "mock" to be referenced here).
+let mockShouldThrow = true;
 jest.mock('../Statistics', () => {
   return {
     Statistics: () => {
-      throw new Error('Failed to load statistics');
+      if (mockShouldThrow) {
+        throw new Error('Failed to load statistics');
+      }
+      return <div>Statistics loaded</div>;
     },
   };
 });
@@ -32,6 +38,7 @@ jest.mock('../../lib/hooks/useDarkMode', () => ({
 describe('LandingPage with ErrorBoundary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockShouldThrow = true;
   });
 
   it('should render error fallback when Statistics throws', () => {
@@ -62,5 +69,18 @@ describe('LandingPage with ErrorBoundary', () => {
     const heading = screen.getByText('Platform Statistics');
     expect(heading).toBeInTheDocument();
     expect(heading.tagName).toBe('H2');
+  });
+
+  it('retries via a soft reset instead of reloading the page', () => {
+    render(<LandingPage />);
+
+    // Once Statistics recovers, the next render succeeds. A real
+    // window.location.reload() would be a no-op in jsdom and could never
+    // produce this text, so seeing it proves the boundary was reset in
+    // place rather than the page being reloaded.
+    mockShouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /retry loading statistics/i }));
+
+    expect(screen.getByText('Statistics loaded')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
closes #1172 
closes #1173 
closes #1174 
closes #1175 



ErrorBoundary's statistics fallback previously called window.location.reload() on retry, a full page reload, while Statistics' own internal error UI (for fetch failures) retries via execute() with no reload. Give ErrorBoundary a reset() method and let fallback be a render function that receives it, so render-crash retries also resolve via an in-place reset rather than a hard navigation. Full reload remains the default fallback behavior for boundaries that don't opt into a custom fallback (e.g. the app-level boundary in layout.tsx), reserved for genuinely unrecoverable crashes.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #
