### PR TITLE
  fix: undefined cancel-vote constant, deposit re-drain, dispute timelock bypass, and paused-claim exploit

### DIFF
--- a/contracts/predict-iq/src/modules/bets.rs
+++ b/contracts/predict-iq/src/modules/bets.rs
@@ -253,6 +253,11 @@ fn internal_claim_amount(
 pub fn claim_winnings(e: &Env, bettor: Address, market_id: u64) -> Result<i128, ErrorCode> {
     bettor.require_auth();
 
+    // Claiming moves funds out of the contract, so it must respect the circuit
+    // breaker just like place_bet and withdraw_refund — a paused contract must
+    // not allow any token egress.
+    crate::modules::circuit_breaker::require_not_paused_for_high_risk(e)?;
+
     let market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
     if market.status != MarketStatus::Resolved {

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -407,7 +407,7 @@ pub fn release_creation_deposit(
     market_id: u64,
     native_token: Address,
 ) -> Result<(), ErrorCode> {
-    let market = get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
+    let mut market = get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
     // Only the market creator may reclaim their own deposit
     market.creator.require_auth();
@@ -416,13 +416,15 @@ pub fn release_creation_deposit(
         return Err(ErrorCode::MarketNotActive);
     }
 
-    if market.creation_deposit > 0 {
+    let deposit = market.creation_deposit;
+    if deposit > 0 {
+        // Checks-effects-interactions: zero and persist before transferring so
+        // repeat calls cannot re-drain the deposit.
+        market.creation_deposit = 0;
+        update_market(e, market.clone());
+
         let token_client = token::Client::new(e, &native_token);
-        token_client.transfer(
-            &e.current_contract_address(),
-            &market.creator,
-            &market.creation_deposit,
-        );
+        token_client.transfer(&e.current_contract_address(), &market.creator, &deposit);
     }
 
     Ok(())

--- a/contracts/predict-iq/src/modules/resolution.rs
+++ b/contracts/predict-iq/src/modules/resolution.rs
@@ -167,13 +167,16 @@ pub fn finalize_resolution(e: &Env, market_id: u64) -> Result<(), ErrorCode> {
             Ok(())
         }
         MarketStatus::Disputed => {
-            // Check if 72h voting period has passed since dispute was filed
-            // dispute sets resolution_deadline += 3 days; use pending_resolution_timestamp as base
+            // Check if 72h voting period has passed since the dispute was actually
+            // filed. Must use dispute_timestamp (set in file_dispute), not
+            // pending_resolution_timestamp (set earlier at oracle resolution) —
+            // otherwise a late-filed dispute inherits a stale deadline and the
+            // voting window can be bypassed.
             let dispute_ts = market
-                .pending_resolution_timestamp
+                .dispute_timestamp
                 .ok_or(ErrorCode::MarketNotDisputed)?;
             if e.ledger().timestamp() < dispute_ts + VOTING_PERIOD_SECONDS {
-                return Err(ErrorCode::VotingNotStarted);
+                return Err(ErrorCode::TimelockActive);
             }
 
             // Calculate voting outcome

--- a/contracts/predict-iq/src/modules/voting.rs
+++ b/contracts/predict-iq/src/modules/voting.rs
@@ -2,7 +2,7 @@ use crate::errors::ErrorCode;
 use crate::modules::markets;
 // Issue #171: ConfigKey (including GovernanceToken variant) must be explicitly imported
 // from types. Previously missing, causing compilation failure in cast_vote.
-use crate::types::{ConfigKey, LockedTokens, MarketStatus, Vote};
+use crate::types::{ConfigKey, LockedTokens, MarketStatus, Vote, CANCEL_OUTCOME_INDEX};
 use soroban_sdk::{contracttype, token, Address, Env, IntoVal, Symbol, Val, Vec};
 
 #[contracttype]
@@ -32,7 +32,7 @@ pub fn cast_vote(
         return Err(ErrorCode::MarketNotDisputed);
     }
 
-    if outcome >= market.options.len() {
+    if outcome != CANCEL_OUTCOME_INDEX && outcome >= market.options.len() {
         return Err(ErrorCode::InvalidOutcome);
     }
 

--- a/contracts/predict-iq/src/types.rs
+++ b/contracts/predict-iq/src/types.rs
@@ -104,6 +104,7 @@ pub struct OracleConfig {
 // Gas optimization constants
 pub const MAX_PUSH_PAYOUT_WINNERS: u32 = 50; // Threshold for switching to pull mode
 pub const MAX_OUTCOMES_PER_MARKET: u32 = 100; // Limit to prevent excessive iteration
+pub const CANCEL_OUTCOME_INDEX: u32 = u32::MAX; // Sentinel outcome for community cancel votes
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION

PR Body

## Summary
- Define `CANCEL_OUTCOME_INDEX` and let `cast_vote` accept it as a special sentinel outcome, so community "cancel market" votes can actually be cast instead of failing to compile / always reverting (#1184).
- Zero and persist `market.creation_deposit` before transferring in `release_creation_deposit`, closing an unbounded repeat-drain of contract funds (#1185).
- Use `market.dispute_timestamp` (not the stale `pending_resolution_timestamp`) as the base for the 72h voting window in `finalize_resolution`'s `Disputed` arm, and return `TimelockActive` instead of `VotingNotStarted`, so the dispute voting window can no longer be bypassed (#1187).
- Add a circuit-breaker check to `claim_winnings` so payouts can't be claimed while the contract is paused, matching `place_bet`/`withdraw_refund` (#1188).

## Known blocker (pre-existing, not introduced by this PR)
`main` currently fails to build independent of these changes — confirmed via `git stash` before touching any files. ~28 compile errors exist in `contracts/predict-iq`, including calls to `markets::get_outcome_stake` / `set_outcome_stake` / `increment_outcome_bet_count` / `validate_parent_market` that don't exist in `markets.rs`, missing `ErrorCode`/`ConfigKey` variants, and a `Market` initializer missing fields. This PR's changes reduce the error count from 28 to 26 (fixing the undefined-constant compile error from #1184) but do not touch the remaining unrelated breakage.

Because of this, `cargo build` / `cargo test` / `cargo clippy` could not be run to completion in this environment, so the tests required by each issue's "Testing Requirements" are **not included** here — they need to be added once the baseline build is fixed. Flagging this rather than silently skipping it.

## Test plan
- [ ] Fix the pre-existing baseline compile errors (separate issue/PR)
- [ ] `cd contracts/predict-iq && cargo build --release` passes with zero warnings
- [ ] `cd contracts/predict-iq && cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Add and pass a test casting enough cancel votes to cross 75% and asserting `Cancelled` (#1184)
- [ ] Add and pass a test calling `release_creation_deposit` twice and asserting the second call transfers 0 (#1185)
- [ ] Wire in / add a test asserting `finalize_resolution` rejects with `TimelockActive` before 72h from `dispute_timestamp` (#1187)
- [ ] Add and pass a test pausing the contract and asserting `claim_winnings` is rejected (#1188)

Closes #1184,

closes  #1185, 

closes #1187

closes  #1188