### PR TITLE
fix(gdpr): send export email in POST body, not GET query string

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -35,7 +35,7 @@ describe('API Client', () => {
       ['getTransactionStatus', () => api.getTransactionStatus('0xdead'), 'GET', '/api/blockchain/tx/0xdead'],
       ['newsletterConfirm', () => api.newsletterConfirm('tok'), 'GET', '/api/v1/newsletter/confirm'],
       ['newsletterUnsubscribe', () => api.newsletterUnsubscribe('a@b.com'), 'DELETE', '/api/v1/newsletter/unsubscribe'],
-      ['newsletterGdprExport', () => api.newsletterGdprExport('a@b.com'), 'GET', '/api/v1/newsletter/gdpr/export'],
+      ['newsletterGdprExport', () => api.newsletterGdprExport('a@b.com'), 'POST', '/api/v1/newsletter/gdpr/export'],
       ['newsletterGdprDelete', () => api.newsletterGdprDelete('a@b.com'), 'DELETE', '/api/v1/newsletter/gdpr/delete'],
       ['resolveMarket', () => api.resolveMarket(3), 'POST', '/api/markets/3/resolve'],
       ['emailPreview', () => api.emailPreview('welcome'), 'GET', '/api/v1/email/preview/welcome'],
@@ -548,6 +548,27 @@ describe('API Client', () => {
       });
       const second = await api.getFeaturedMarkets();
       expect(second).toEqual([{ id: 1, title: 'Resolved Market' }]);
+    });
+  });
+
+  describe('GDPR export (#1156)', () => {
+    it('sends email in the POST request body, not as a URL query parameter', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ success: true, data: {} }),
+      });
+
+      await api.newsletterGdprExport('user@example.com');
+
+      const [calledUrl, calledInit] = (global.fetch as jest.Mock).mock.calls[0];
+
+      // Email must NOT appear in the URL to prevent logging PII in access logs.
+      expect(calledUrl).not.toContain('user@example.com');
+      expect(calledUrl).not.toContain('email=');
+
+      // Email MUST be in the JSON body.
+      expect(calledInit.method).toBe('POST');
+      expect(JSON.parse(calledInit.body as string)).toEqual({ email: 'user@example.com' });
     });
   });
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -448,9 +448,9 @@ export const api = {
 
   newsletterGdprExport: (email: string, signal?: AbortSignal) =>
     request<{ success: boolean; data: Record<string, unknown> }>(
-      "GET",
+      "POST",
       "/api/v1/newsletter/gdpr/export",
-      { params: { email }, cacheTags: [CacheTag.NEWSLETTER], signal }
+      { body: { email }, cacheTags: [CacheTag.NEWSLETTER], signal }
     ),
 
   newsletterGdprDelete: (email: string, signal?: AbortSignal) =>

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -387,17 +387,16 @@ paths:
           $ref: "#/components/responses/ApiError"
 
   /api/v1/newsletter/gdpr/export:
-    get:
+    post:
       tags: [newsletter]
       operationId: newsletterGdprExport
       summary: GDPR data export for a subscriber
-      parameters:
-        - name: email
-          in: query
-          required: true
-          schema:
-            type: string
-            format: email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmailRequest"
       responses:
         "200":
           description: Subscriber data

--- a/services/api/src/handlers.rs
+++ b/services/api/src/handlers.rs
@@ -366,6 +366,11 @@ pub struct NewsletterExportQuery {
     pub email: String,
 }
 
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+pub struct NewsletterExportBody {
+    pub email: String,
+}
+
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct NewsletterResponse {
     pub success: bool,
@@ -634,10 +639,10 @@ pub async fn newsletter_unsubscribe(
 }
 
 #[utoipa::path(
-    get,
+    post,
     path = "/api/v1/newsletter/gdpr/export",
     tag = "newsletter",
-    params(NewsletterExportQuery),
+    request_body = NewsletterExportBody,
     responses(
         (status = 200, description = "GDPR data export", body = NewsletterExportResponse),
         (status = 400, description = "Invalid email", body = NewsletterResponse),
@@ -649,7 +654,7 @@ pub async fn newsletter_gdpr_export(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     connect_info: Option<axum::extract::ConnectInfo<std::net::SocketAddr>>,
-    Query(query): Query<NewsletterExportQuery>,
+    Json(body): Json<NewsletterExportBody>,
 ) -> Result<Response, ApiError> {
     use crate::security::extract_client_ip_cidrs;
     let ip = extract_client_ip_cidrs(
@@ -677,7 +682,7 @@ pub async fn newsletter_gdpr_export(
             .into_response());
     }
 
-    let Some(email) = normalized_email(&query.email) else {
+    let Some(email) = normalized_email(&body.email) else {
         return Ok((
             StatusCode::BAD_REQUEST,
             Json(NewsletterResponse {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -388,7 +388,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/v1/newsletter/subscribe", post(handlers::newsletter_subscribe))
         .route("/api/v1/newsletter/confirm", get(handlers::newsletter_confirm))
         .route("/api/v1/newsletter/unsubscribe", get(handlers::newsletter_unsubscribe))
-        .route("/api/v1/newsletter/gdpr/export", get(handlers::newsletter_gdpr_export))
+        .route("/api/v1/newsletter/gdpr/export", post(handlers::newsletter_gdpr_export))
         .route("/api/v1/newsletter/gdpr/delete", axum::routing::delete(handlers::newsletter_gdpr_delete))
         .layer(middleware::from_fn(correlation::correlation_id_middleware))
         .layer(TraceLayer::new_for_http())

--- a/services/api/tests/openapi_contract_test.rs
+++ b/services/api/tests/openapi_contract_test.rs
@@ -27,7 +27,7 @@ mod tests {
         ("POST", "/api/v1/newsletter/subscribe"),
         ("GET", "/api/v1/newsletter/confirm"),
         ("DELETE", "/api/v1/newsletter/unsubscribe"),
-        ("GET", "/api/v1/newsletter/gdpr/export"),
+        ("POST", "/api/v1/newsletter/gdpr/export"),
         ("DELETE", "/api/v1/newsletter/gdpr/delete"),
         ("GET", "/api/v1/email/preview/{template_name}"),
         ("POST", "/api/v1/email/test"),


### PR DESCRIPTION
## Summary

Fixes #1156

The GDPR data export endpoint was sending the user's email address as a URL query parameter (`GET /api/v1/newsletter/gdpr/export?email=...`), exposing PII to server access logs, browser history, and intermediary proxy logs.

## Changes

**Frontend (`client.ts`)**
- `newsletterGdprExport` changed from `GET` + `params: { email }` to `POST` + `body: { email }`

**Backend (`handlers.rs`, `main.rs`)**
- Added `NewsletterExportBody` struct for JSON body deserialization
- Handler extractor changed from `Query<NewsletterExportQuery>` to `Json<NewsletterExportBody>`
- `#[utoipa::path]` updated from `get` to `post` with `request_body`
- Route registration changed from `get()` to `post()`

**Tests (`client.test.ts`)**
- Updated `it.each` entry for `newsletterGdprExport` to expect `POST`
- Added `describe('GDPR export (#1156)')` with a test asserting:
  - The email does **not** appear in the URL
  - The email **is** present in the JSON request body

## Testing

```
cd frontend && npm test -- client --watchAll=false
```

All 50 tests pass, including the new GDPR export test.

## Build

`next build` compiles successfully with zero warnings. closes #1156 