### PR TITLE
fix: only invalidate cache tags when mutation response body reports success (#1162)

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -549,6 +549,84 @@ describe('API Client', () => {
       const second = await api.getFeaturedMarkets();
       expect(second).toEqual([{ id: 1, title: 'Resolved Market' }]);
     });
+
+    it('does not invalidate cache when mutation returns success:false (#1162)', async () => {
+      // Prime a statistics cache entry.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ total_markets: 10 }),
+      });
+      await api.getStatistics();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // newsletterSubscribe returns 200 with success:false (business-logic failure).
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ success: false, message: 'Email already subscribed' }),
+      });
+      await api.newsletterSubscribe({ email: 'existing@example.com' });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Cache must NOT be invalidated — next getStatistics should return cached value.
+      const cachedStats = await api.getStatistics();
+      expect(cachedStats).toEqual({ total_markets: 10 });
+      // fetch should not have been called again (still 2 calls total).
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates cache when mutation returns success:true (#1162)', async () => {
+      // Prime a statistics cache entry.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ total_markets: 10 }),
+      });
+      await api.getStatistics();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // newsletterSubscribe succeeds.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ success: true, message: 'Subscribed!' }),
+      });
+      await api.newsletterSubscribe({ email: 'new@example.com' });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Cache MUST be invalidated — next getStatistics should hit the network.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ total_markets: 11 }),
+      });
+      const freshStats = await api.getStatistics();
+      expect(freshStats).toEqual({ total_markets: 11 });
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('invalidates cache for mutations that do not use success envelope (#1162)', async () => {
+      // Prime a markets cache entry.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify([{ id: 1, title: 'Market' }]),
+      });
+      await api.getFeaturedMarkets();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // resolveMarket returns { invalidated_keys: N } (no success field).
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ invalidated_keys: 2 }),
+      });
+      await api.resolveMarket(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Cache MUST be invalidated — next getFeaturedMarkets hits the network.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify([{ id: 1, title: 'Resolved' }]),
+      });
+      const freshMarkets = await api.getFeaturedMarkets();
+      expect(freshMarkets).toEqual([{ id: 1, title: 'Resolved' }]);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('DELETE requests', () => {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -307,11 +307,21 @@ async function request<T>(
 
       // On mutations, invalidate only the affected resource tags instead of
       // the entire cache. Fall back to a full clear for untagged mutations.
+      //
+      // Guard: some endpoints return { success: false, message: '...' } with a
+      // 200 status to signal business-logic failure (e.g. newsletterSubscribe).
+      // Only bust the cache when the mutation actually succeeded — i.e. when the
+      // response has no `success` field (non-envelope endpoints) or when
+      // `success` is explicitly `true`.
       if (method === "POST" || method === "DELETE") {
-        if (options.cacheTags?.length) {
-          apiCache.invalidateByTags(options.cacheTags);
-        } else {
-          apiCache.invalidateByPattern('.*');
+        const bodyObj = (typeof data === 'object' && data !== null) ? data as Record<string, unknown> : null;
+        const succeeded = bodyObj === null || !('success' in bodyObj) || bodyObj['success'] === true;
+        if (succeeded) {
+          if (options.cacheTags?.length) {
+            apiCache.invalidateByTags(options.cacheTags);
+          } else {
+            apiCache.invalidateByPattern('.*');
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes #1162 — cache tags were being invalidated for any POST/DELETE that returned HTTP 2xx, regardless of whether the response body's `success` field indicated a business-logic failure.

## Root Cause

The invalidation block in `request()` fired unconditionally on every 2xx mutation response:

```ts
// before
if (method === "POST" || method === "DELETE") {
  if (options.cacheTags?.length) {
    apiCache.invalidateByTags(options.cacheTags);
  } else {
    apiCache.invalidateByPattern('.*');
  }
}
```

`newsletterSubscribe` and `newsletterUnsubscribe` both carry `[CacheTag.NEWSLETTER, CacheTag.STATISTICS]` tags and can return `{ success: false, message: '...' }` with HTTP 200. A rejected subscription was therefore busting the statistics cache, triggering an unnecessary refetch and a brief stale flicker for unrelated cached data.

## Fix

```ts
// after — guard invalidation behind the response body's success field
if (method === "POST" || method === "DELETE") {
  const bodyObj = (typeof data === 'object' && data !== null)
    ? data as Record<string, unknown>
    : null;
  const succeeded =
    bodyObj === null ||
    !('success' in bodyObj) ||
    bodyObj['success'] === true;
  if (succeeded) {
    if (options.cacheTags?.length) {
      apiCache.invalidateByTags(options.cacheTags);
    } else {
      apiCache.invalidateByPattern('.*');
    }
  }
}
```

Rules:
- **No `success` field** → treat as success (non-envelope endpoints like `resolveMarket`)
- **`success: true`** → invalidate as before
- **`success: false`** → skip invalidation entirely

## Tests

Added 3 new tests to the *Cache invalidation strategy* suite in `client.test.ts`:

1. **success:false** — 200 response with `{ success: false }` does NOT invalidate cache
2. **success:true** — 200 response with `{ success: true }` DOES invalidate cache
3. **no success field** — 200 response without `success` key DOES invalidate cache (non-envelope endpoint)

## Checklist

- [x] Branch named `fix/cache-tags-are-invalidated-even-when-a-mutation`
- [x] `cd frontend && npm test -- client` — **52 tests, 1 suite, all passed**
- [x] `cd frontend && npm run build` — compiled successfully, 0 warnings closes #1162 