### PR TITLE
fix: implement missing markets accessor functions used by place_bet/c…

### DIFF
--- a/contracts/predict-iq/src/lib.rs
+++ b/contracts/predict-iq/src/lib.rs
@@ -128,22 +128,18 @@ impl PredictIQ {
         )
     }
 
-    pub fn claim_winnings(
-        e: Env,
-        bettor: Address,
-        market_id: u64,
-        token_address: Address,
-    ) -> Result<i128, ErrorCode> {
-        crate::modules::bets::claim_winnings(&e, bettor, market_id, token_address)
+    pub fn claim_winnings(e: Env, bettor: Address, market_id: u64) -> Result<i128, ErrorCode> {
+        crate::modules::bets::claim_winnings(&e, bettor, market_id)
     }
 
     pub fn withdraw_refund(
         e: Env,
         bettor: Address,
         market_id: u64,
+        outcome: u32,
         token_address: Address,
     ) -> Result<i128, ErrorCode> {
-        crate::modules::bets::withdraw_refund(&e, bettor, market_id, token_address)
+        crate::modules::bets::withdraw_refund(&e, bettor, market_id, outcome, token_address)
     }
 
     pub fn get_market(e: Env, id: u64) -> Option<crate::types::Market> {

--- a/contracts/predict-iq/src/modules/bets.rs
+++ b/contracts/predict-iq/src/modules/bets.rs
@@ -145,22 +145,19 @@ pub fn place_bet(
         .checked_add(net_amount)
         .ok_or(ErrorCode::ArithmeticOverflow)?;
 
-    let outcome_stake = markets::get_outcome_stake(e, market_id, outcome);
+    let outcome_stake = markets::get_outcome_stake(&market, outcome);
     markets::set_outcome_stake(
-        e,
-        market_id,
+        &mut market,
         outcome,
         outcome_stake
             .checked_add(net_amount)
             .ok_or(ErrorCode::ArithmeticOverflow)?,
     );
-    markets::increment_outcome_bet_count(e, market_id, outcome);
 
     // Issue #24: Maintain actual winner count per outcome
     let is_new_bettor = existing_bet.amount == net_amount; // first bet on this outcome
     if is_new_bettor {
-        let current_count = market.winner_counts.get(outcome).unwrap_or(0);
-        market.winner_counts.set(outcome, current_count + 1);
+        markets::increment_outcome_bet_count(&mut market, outcome);
     }
 
     e.storage().persistent().set(&bet_key, &existing_bet);
@@ -285,7 +282,7 @@ pub fn claim_winnings(e: &Env, bettor: Address, market_id: u64) -> Result<i128, 
     // Parimutuel payout: winner's proportional share of the total pool.
     // winnings = (bet.amount * total_staked) / winning_outcome_stake
     // Integer division truncates down, favouring the protocol.
-    let winning_outcome_stake = markets::get_outcome_stake(e, market_id, winning_outcome);
+    let winning_outcome_stake = markets::get_outcome_stake(&market, winning_outcome);
     let winning_outcome_stake = if winning_outcome_stake > 0 {
         winning_outcome_stake
     } else {

--- a/contracts/predict-iq/src/modules/markets.rs
+++ b/contracts/predict-iq/src/modules/markets.rs
@@ -117,29 +117,12 @@ pub fn create_market_with_dispute_window(
 
     // Validate parent market if this is a conditional market
     if parent_id > 0 {
-        let parent_market = get_market(e, parent_id).ok_or(ErrorCode::MarketNotFound)?;
-
-        // Parent must be resolved
-        if parent_market.status != MarketStatus::Resolved {
-            return Err(ErrorCode::ParentMarketNotResolved);
-        }
-
-        // Parent must have resolved to the required outcome
-        let parent_winning_outcome = parent_market
-            .winning_outcome
-            .ok_or(ErrorCode::ParentMarketNotResolved)?;
-        if parent_winning_outcome != parent_outcome_idx {
-            return Err(ErrorCode::ParentMarketInvalidOutcome);
-        }
-
-        // Validate parent_outcome_idx is within parent's options range
-        if parent_outcome_idx >= parent_market.options.len() {
-            return Err(ErrorCode::InvalidOutcome);
-        }
+        validate_parent_market(e, parent_id, parent_outcome_idx)?;
 
         // Issue #069: Conditional market inherits parent constraints.
         // The conditional market's deadline must not exceed the parent's resolution_deadline
         // to ensure the conditional market cannot outlive its parent context.
+        let parent_market = get_market(e, parent_id).ok_or(ErrorCode::MarketNotFound)?;
         if deadline > parent_market.resolution_deadline {
             return Err(ErrorCode::DeadlinePassed);
         }
@@ -241,6 +224,9 @@ pub fn create_market_with_dispute_window(
         outcome_stakes: soroban_sdk::Map::new(e),
         pending_resolution_timestamp: None,
         dispute_snapshot_ledger: None,
+        dispute_timestamp: None,
+        winner_counts: soroban_sdk::Map::new(e),
+        total_claimed: 0,
     };
 
     e.storage()
@@ -281,6 +267,57 @@ pub fn create_market_with_dispute_window(
     );
 
     Ok(count)
+}
+
+/// Validates that a conditional market's parent has resolved to the outcome
+/// the conditional market depends on. Used both at market-creation time and
+/// again at bet-placement time (bets::place_bet), since a parent's resolution
+/// can only be checked, never assumed, once set at creation.
+pub fn validate_parent_market(
+    e: &Env,
+    parent_id: u64,
+    parent_outcome_idx: u32,
+) -> Result<(), ErrorCode> {
+    let parent_market = get_market(e, parent_id).ok_or(ErrorCode::MarketNotFound)?;
+
+    // Parent must be resolved
+    if parent_market.status != MarketStatus::Resolved {
+        return Err(ErrorCode::ParentMarketNotResolved);
+    }
+
+    // Parent must have resolved to the required outcome
+    let parent_winning_outcome = parent_market
+        .winning_outcome
+        .ok_or(ErrorCode::ParentMarketNotResolved)?;
+    if parent_winning_outcome != parent_outcome_idx {
+        return Err(ErrorCode::ParentMarketInvalidOutcome);
+    }
+
+    // Validate parent_outcome_idx is within parent's options range
+    if parent_outcome_idx >= parent_market.options.len() {
+        return Err(ErrorCode::InvalidOutcome);
+    }
+
+    Ok(())
+}
+
+/// Returns the amount currently staked on `outcome`.
+pub fn get_outcome_stake(market: &Market, outcome: u32) -> i128 {
+    market.outcome_stakes.get(outcome).unwrap_or(0)
+}
+
+/// Sets the amount staked on `outcome` to `amount`.
+pub fn set_outcome_stake(market: &mut Market, outcome: u32, amount: i128) {
+    market.outcome_stakes.set(outcome, amount);
+}
+
+/// Increments the unique-bettor count for `outcome` by one. Callers are
+/// responsible for only invoking this on a bettor's first bet on that
+/// outcome (see bets::place_bet), since winner_counts tracks unique
+/// bettors per outcome, not total bet transactions.
+pub fn increment_outcome_bet_count(market: &mut Market, outcome: u32) {
+    let current_count = market.winner_counts.get(outcome).unwrap_or(0);
+    market.winner_counts.set(outcome, current_count + 1);
 }
 
 pub fn get_market_dispute_window(e: &Env, market_id: u64) -> u64 {

--- a/contracts/predict-iq/src/modules/markets_conditional_test.rs
+++ b/contracts/predict-iq/src/modules/markets_conditional_test.rs
@@ -5,7 +5,7 @@ use crate::errors::ErrorCode;
 use crate::modules::markets;
 use crate::types::{CreatorReputation, MarketStatus, MarketTier, OracleConfig};
 use crate::{PredictIQ, PredictIQClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String, Vec};
 
 fn setup() -> (Env, PredictIQClient<'static>, Address, Address) {
     let env = Env::default();
@@ -413,4 +413,109 @@ fn test_tier_upgrade_path() {
         &0,
         &0,
     );
+}
+
+// ── place_bet accessor functions (markets::get_outcome_stake / set_outcome_stake /
+// increment_outcome_bet_count / validate_parent_market) ────────────────────────
+
+/// place_bet must correctly accumulate per-outcome stakes and unique-bettor counts
+/// via the real markets accessor functions, including on a conditional (child) market.
+#[test]
+fn test_place_bet_tracks_outcome_stakes_and_winner_counts() {
+    let (env, client, admin, cid) = setup();
+
+    let parent_id = create_resolved_market(&env, &client, &cid, &admin, 1000, 2000, 0);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin);
+    let token = token_id.address();
+
+    let child_id = client.create_market(
+        &admin,
+        &String::from_str(&env, "Child"),
+        &two_options(&env),
+        &1500,
+        &1800,
+        &oracle_config(&env),
+        &MarketTier::Basic,
+        &token,
+        &parent_id,
+        &0, // parent resolved to outcome 0
+    );
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&alice, &10_000);
+    token_client.mint(&bob, &10_000);
+    token_client.mint(&carol, &10_000);
+
+    client.place_bet(&alice, &child_id, &0, &4_000, &token, &None);
+    client.place_bet(&bob, &child_id, &0, &1_500, &token, &None); // same outcome, different bettor
+    client.place_bet(&carol, &child_id, &1, &2_500, &token, &None);
+
+    let market = client.get_market(&child_id).unwrap();
+    assert_eq!(
+        market.outcome_stakes.get(0).unwrap_or(0),
+        5_500,
+        "outcome 0 stake should be the sum of alice's and bob's bets"
+    );
+    assert_eq!(
+        market.outcome_stakes.get(1).unwrap_or(0),
+        2_500,
+        "outcome 1 stake should equal carol's bet"
+    );
+    assert_eq!(
+        market.winner_counts.get(0).unwrap_or(0),
+        2,
+        "two unique bettors placed bets on outcome 0"
+    );
+    assert_eq!(
+        market.winner_counts.get(1).unwrap_or(0),
+        1,
+        "one unique bettor placed a bet on outcome 1"
+    );
+}
+
+/// place_bet must re-validate the parent market at bet time via
+/// markets::validate_parent_market, not just trust state captured when the
+/// conditional market was created.
+#[test]
+fn test_place_bet_on_conditional_market_rejected_when_parent_reverts() {
+    let (env, client, admin, cid) = setup();
+
+    let parent_id = create_resolved_market(&env, &client, &cid, &admin, 1000, 2000, 0);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin);
+    let token = token_id.address();
+
+    let child_id = client.create_market(
+        &admin,
+        &String::from_str(&env, "Child"),
+        &two_options(&env),
+        &1500,
+        &1800,
+        &oracle_config(&env),
+        &MarketTier::Basic,
+        &token,
+        &parent_id,
+        &0,
+    );
+
+    // Simulate the parent's resolution being reverted (e.g. by a dispute) after
+    // the child market was already created.
+    env.as_contract(&cid, || {
+        let mut parent = markets::get_market(&env, parent_id).unwrap();
+        parent.status = MarketStatus::Active;
+        markets::update_market(&env, parent);
+    });
+
+    let alice = Address::generate(&env);
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&alice, &10_000);
+
+    let result = client.try_place_bet(&alice, &child_id, &0, &1_000, &token, &None);
+    assert_eq!(result, Err(Ok(ErrorCode::ParentMarketNotResolved)));
 }


### PR DESCRIPTION
closes #1180 
closes #1181 
closes #1182 
closes #1183 



…laim_winnings

bets::place_bet and bets::claim_winnings called markets::validate_parent_market, get_outcome_stake, set_outcome_stake, and increment_outcome_bet_count, none of which existed anywhere in the crate. Adds these as real functions operating on the in-memory Market struct (outcome_stakes/winner_counts), reusing the parent-validation logic previously inlined only in create_market_with_dispute_window.

Also fixes the Market{} initializer in create_market_with_dispute_window, which was missing dispute_timestamp/winner_counts/total_claimed, and updates lib.rs's claim_winnings/withdraw_refund wrappers to match bets.rs's actual signatures.

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #
