### PR TITLE
fix: derive dark-mode toggle initial state from DOM class (#1159)

### DIFF
--- a/frontend/src/lib/hooks/__tests__/useDarkMode.test.ts
+++ b/frontend/src/lib/hooks/__tests__/useDarkMode.test.ts
@@ -116,6 +116,68 @@ describe('useDarkMode', () => {
     expect(document.documentElement.classList.contains('light-mode')).toBe(true);
   });
 
+  // ------------------------------------------------------------------
+  // Bug #1159 — lazy initializer reads DOM class on first render
+  // ------------------------------------------------------------------
+
+  it('reads dark-mode class from DOM and returns isDarkMode:true on the very first render (before isLoaded)', () => {
+    // Simulate what the inline init script does before React hydrates.
+    document.documentElement.classList.add('dark-mode');
+
+    const { result } = renderHook(() => useDarkMode());
+
+    // isDarkMode must be true on the FIRST render, not only after useEffect.
+    expect(result.current.isDarkMode).toBe(true);
+  });
+
+  it('reads light-mode class from DOM and returns isDarkMode:false on the very first render', () => {
+    document.documentElement.classList.add('light-mode');
+
+    const { result } = renderHook(() => useDarkMode());
+
+    expect(result.current.isDarkMode).toBe(false);
+  });
+
+  it('no stale icon flash: isDarkMode is already correct before isLoaded becomes true', async () => {
+    // Init script applied dark-mode before React renders.
+    document.documentElement.classList.add('dark-mode');
+
+    const { result } = renderHook(() => useDarkMode());
+
+    // Before any effects run, the state should already reflect dark mode.
+    expect(result.current.isDarkMode).toBe(true);
+
+    // After effects run and isLoaded is true, it should still be dark.
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.isDarkMode).toBe(true);
+  });
+
+  it('falls back to getDarkModePreference when no DOM class is set', async () => {
+    // Neither class present — should fall back to system/storage preference.
+    mockMatchMedia(false);
+
+    const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.isDarkMode).toBe(false);
+  });
+
+  it('toggleDarkMode still works correctly after lazy-init from DOM class', async () => {
+    document.documentElement.classList.add('dark-mode');
+
+    const { result } = renderHook(() => useDarkMode());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
+    expect(localStorage.getItem('darkMode')).toBe('false');
+  });
+
   it('should add dark-mode class to document element', async () => {
     const { result } = renderHook(() => useDarkMode());
 

--- a/frontend/src/lib/hooks/useDarkMode.ts
+++ b/frontend/src/lib/hooks/useDarkMode.ts
@@ -3,25 +3,78 @@ import {
   DARK_MODE_STORAGE_KEY,
   applyDarkModePreference,
   getDarkModePreference,
+  type DarkModePreference,
 } from '../darkMode';
 
-const defaultPreference = {
-  isDarkMode: false,
-  hasStoredPreference: false,
-};
+/**
+ * Read the dark-mode state that the blocking inline init script already applied
+ * to <html> before the first paint.  Called as a lazy useState initializer so
+ * it runs synchronously on the very first render — not inside a useEffect —
+ * which means the toggle icon/aria-label are correct from frame 0.
+ *
+ * Falls back to getDarkModePreference() in environments where the DOM is not
+ * available (SSR) or where the init script did not run (neither class present).
+ */
+function readInitialDarkMode(): DarkModePreference {
+  if (typeof document === 'undefined') {
+    // SSR: no DOM, return neutral default (server renders no toggle state).
+    return { isDarkMode: false, hasStoredPreference: false };
+  }
+
+  const classList = document.documentElement.classList;
+
+  if (classList.contains('dark-mode')) {
+    return { isDarkMode: true, hasStoredPreference: true };
+  }
+
+  if (classList.contains('light-mode')) {
+    return { isDarkMode: false, hasStoredPreference: true };
+  }
+
+  // Init script didn't run or neither class was applied — derive from storage /
+  // system preference the same way getDarkModePreference() does.
+  return getDarkModePreference();
+}
 
 /**
- * Hook for managing dark mode preference
- * Respects system preference and allows manual toggle
- * Persists preference to localStorage
+ * Returns true when the inline init script has already applied a class to
+ * <html>, meaning the lazy initializer already captured the correct state
+ * and the mount effect should not overwrite it.
+ */
+function domClassWasApplied(): boolean {
+  if (typeof document === 'undefined') return false;
+  const cl = document.documentElement.classList;
+  return cl.contains('dark-mode') || cl.contains('light-mode');
+}
+
+/**
+ * Hook for managing dark mode preference.
+ * Respects system preference and allows manual toggle.
+ * Persists preference to localStorage.
+ *
+ * The initial rendered state is derived from the DOM class applied by the
+ * blocking inline script in layout.tsx, so the toggle icon and aria-label
+ * are correct on the very first paint with no flash of incorrect state.
  */
 export function useDarkMode() {
-  const [preference, setPreference] = useState(defaultPreference);
+  // Lazy initializer: runs synchronously on first render, reads the DOM class
+  // that the init script applied before paint.
+  const [preference, setPreference] = useState<DarkModePreference>(readInitialDarkMode);
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    const initialPreference = getDarkModePreference();
+    if (domClassWasApplied()) {
+      // The init script already applied the correct class and the lazy
+      // initializer already captured it — no need to re-derive or re-apply.
+      // Just mark the hook as loaded.
+      setIsLoaded(true);
+      return;
+    }
 
+    // Fallback path: init script didn't run (e.g. hydration mismatch, test
+    // environments without the script). Derive preference from storage / system
+    // and apply it now.
+    const initialPreference = getDarkModePreference();
     setPreference(initialPreference);
     applyDarkModePreference(initialPreference);
     setIsLoaded(true);


### PR DESCRIPTION
## Summary

Fixes #1159. The blocking inline script in `layout.tsx` applies the correct `dark-mode`/`light-mode` class to `<html>` before first paint, but `useDarkMode` started from a hardcoded `{ isDarkMode: false }` default and only read the real preference inside a `useEffect` after mount. For a dark-mode user this meant the toggle icon showed ☀️ ("Switch to dark mode") while the background was already dark — a stale/incorrect state for at least one paint.

## Root Cause

`useState(defaultPreference)` initializes synchronously with a hardcoded `false`, ignoring the class the init script already applied. `result.current` after `renderHook` reflects state *after* effects, so the effect was also overwriting the correct lazy-initialized value.

## Fix

Two changes to `useDarkMode.ts`:

**1. Lazy `useState` initializer** — `readInitialDarkMode()` reads `document.documentElement.classList` synchronously on the first render (before any effects):
- `dark-mode` class present → `{ isDarkMode: true, hasStoredPreference: true }`
- `light-mode` class present → `{ isDarkMode: false, hasStoredPreference: true }`
- Neither class → falls back to `getDarkModePreference()` (SSR / init script didn't run)

**2. Guard in the mount `useEffect`** — `domClassWasApplied()` skips `setPreference` when the DOM class was already the source of truth, preventing the effect from overwriting the correct state. Just marks `isLoaded = true`.

## Tests

5 new tests added:
- `isDarkMode` is `true` on the **very first render** when `dark-mode` class is set (before `isLoaded`)
- `isDarkMode` is `false` on the first render when `light-mode` class is set
- No stale flash: state is correct both before and after `isLoaded` becomes `true`
- Falls back correctly when neither class is set
- `toggleDarkMode` continues to work after lazy-init

```
Tests: 15 passed, 15 total
```

`cd frontend && npm run build` — Compiled successfully, zero warnings.

## Acceptance Criteria

- [x] Toggle icon/label matches the actually-applied theme on first render, no flash of incorrect state
- [x] Toggling between modes continues to work correctly after the fix
- [x] A test sets the `dark-mode` class before render and asserts the toggle shows the correct initial state

## PR Checklist

- [x] Branch named conventionally (`fix/dark-mode-toggle-shows-a-stale-incorrect-icon-an`)
- [x] `cd frontend && npm run build` passes with zero warnings
- [x] `cd frontend && npm test -- useDarkMode` — 15 tests pass  closes #1159 