### PR TITLE
  fix(contracts): enforce terminal-state invariants in resolve_market and unlock_tokens, remove fee-admin key landmine

### DIFF
--- a/contracts/predict-iq/src/modules/admin.rs
+++ b/contracts/predict-iq/src/modules/admin.rs
@@ -87,19 +87,6 @@ pub fn set_governance_token(e: &Env, token: Address) -> Result<(), ErrorCode> {
     Ok(())
 }
 
-pub fn set_fee_admin(e: &Env, fee_admin: Address) -> Result<(), ErrorCode> {
-    require_admin(e)?;
-    e.storage()
-        .persistent()
-        .set(&ConfigKey::GuardianAccount, &fee_admin);
-    bump_gov_ttl(e, &ConfigKey::GuardianAccount);
-    Ok(())
-}
-
-pub fn get_fee_admin(e: &Env) -> Option<Address> {
-    e.storage().persistent().get(&ConfigKey::GuardianAccount)
-}
-
 #[cfg(test)]
 mod ownership_transfer_tests {
     use super::{accept_admin, cancel_admin_transfer, get_admin, propose_admin, set_admin};
@@ -162,5 +149,37 @@ mod ownership_transfer_tests {
         let caller = Address::generate(&e);
         let err = accept_admin(&e, caller).unwrap_err();
         assert_eq!(err, ErrorCode::PendingTransferNotFound);
+    }
+}
+
+/// Issue #1195: admin::set_fee_admin/get_fee_admin used to write/read
+/// ConfigKey::GuardianAccount — the same key set_guardian/get_guardian use —
+/// instead of the dedicated ConfigKey::FeeAdmin key that fees::set_fee_admin
+/// correctly uses. The landmine functions have been removed; this test
+/// confirms the guardian address is never touched by the real fee-admin flow.
+#[cfg(test)]
+mod fee_admin_guardian_isolation_tests {
+    use super::{get_guardian, set_admin, set_guardian};
+    use crate::modules::fees;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    #[test]
+    fn fee_admin_flow_does_not_affect_guardian_address() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        let owner = Address::generate(&e);
+        set_admin(&e, owner);
+
+        let guardian = Address::generate(&e);
+        set_guardian(&e, guardian.clone()).unwrap();
+
+        let fee_admin = Address::generate(&e);
+        fees::set_fee_admin(&e, fee_admin.clone()).unwrap();
+
+        // The guardian address must be unchanged by the fee-admin flow, and
+        // the fee-admin and guardian addresses must be independently readable.
+        assert_eq!(get_guardian(&e), Some(guardian));
+        assert_eq!(fees::get_fee_admin(&e), Some(fee_admin));
     }
 }

--- a/contracts/predict-iq/src/modules/disputes.rs
+++ b/contracts/predict-iq/src/modules/disputes.rs
@@ -47,6 +47,14 @@ pub fn file_dispute(e: &Env, disciplinarian: Address, market_id: u64) -> Result<
 pub fn resolve_market(e: &Env, market_id: u64, winning_outcome: u32) -> Result<(), ErrorCode> {
     let mut market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
+    // Issue #1186: Resolved/Cancelled are terminal states (INVARIANTS.md §3) and
+    // must never be re-entered. Without this guard an admin could call this path
+    // twice with different outcomes after bettors already claimed under the
+    // first outcome, allowing overpayment against unchanged total_staked.
+    if market.status == MarketStatus::Resolved || market.status == MarketStatus::Cancelled {
+        return Err(ErrorCode::CannotChangeOutcome);
+    }
+
     if winning_outcome >= market.options.len() {
         return Err(ErrorCode::InvalidOutcome);
     }

--- a/contracts/predict-iq/src/modules/voting.rs
+++ b/contracts/predict-iq/src/modules/voting.rs
@@ -185,15 +185,19 @@ fn get_token_decimals(e: &Env, token: &Address) -> u32 {
     }
 }
 
-/// Issue #20: Require market to be Resolved before unlocking tokens.
+/// Issue #20: Require market to be Resolved (or Cancelled) before unlocking tokens.
 pub fn unlock_tokens(e: &Env, voter: Address, market_id: u64) -> Result<(), ErrorCode> {
     voter.require_auth();
 
     let market = markets::get_market(e, market_id).ok_or(ErrorCode::MarketNotFound)?;
 
     // Issue #20: Tokens remain locked throughout the entire dispute lifecycle.
-    // Only allow unlock once the market is fully Resolved.
-    if market.status != MarketStatus::Resolved {
+    // Only allow unlock once the market reaches a terminal state.
+    // Issue #1192: A Disputed market can transition to Cancelled via community
+    // vote (cancellation::cancel_market_vote); requiring Resolved only would
+    // permanently strand governance tokens locked via the fallback path with
+    // no code path to retrieve them.
+    if market.status != MarketStatus::Resolved && market.status != MarketStatus::Cancelled {
         return Err(ErrorCode::MarketNotResolved);
     }
 
@@ -434,5 +438,144 @@ mod decimal_normalization_tests {
         let one_7dec = normalize(10_000_000, 7); // 1 token at 7 decimals
         let one_18dec = normalize(1_000_000_000_000_000_000, 18); // 1 token at 18 decimals
         assert_eq!(one_7dec, one_18dec);
+    }
+}
+
+/// Issue #1192: Voters who locked governance tokens via cast_vote's fallback
+/// path must be able to recover them once the market reaches ANY terminal
+/// state, not just Resolved — including Cancelled (e.g. via community-voted
+/// cancel_market_vote from Disputed).
+#[cfg(test)]
+mod unlock_tokens_terminal_state_tests {
+    use super::{cast_vote, unlock_tokens, DataKey};
+    use crate::errors::ErrorCode;
+    use crate::modules::markets;
+    use crate::types::{ConfigKey, MarketStatus, MarketTier, OracleConfig};
+    use crate::{PredictIQ, PredictIQClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        token, Address, Env, String, Vec,
+    };
+
+    fn setup() -> (Env, PredictIQClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(PredictIQ, ());
+        let client = PredictIQClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &0);
+
+        (env, client, admin, contract_id)
+    }
+
+    /// StellarAssetContract supports balance()/transfer() but not balance_at(),
+    /// so casting a vote against it always exercises cast_vote's fallback path.
+    fn setup_gov_token(env: &Env, contract_id: &Address) -> Address {
+        let token_admin = Address::generate(env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin);
+        let token_address = token_id.address();
+        env.as_contract(contract_id, || {
+            env.storage()
+                .instance()
+                .set(&ConfigKey::GovernanceToken, &token_address);
+        });
+        token_address
+    }
+
+    fn create_market(env: &Env, client: &PredictIQClient, admin: &Address) -> u64 {
+        let options = Vec::from_array(
+            env,
+            [String::from_str(env, "Yes"), String::from_str(env, "No")],
+        );
+        let native_token = Address::generate(env);
+        client.create_market(
+            admin,
+            &String::from_str(env, "Fallback Lock Test"),
+            &options,
+            &1000,
+            &2000,
+            &OracleConfig {
+                oracle_address: Address::generate(env),
+                feed_id: String::from_str(env, "feed"),
+                min_responses: Some(1),
+                max_staleness_seconds: 3600,
+                max_confidence_bps: 200,
+                strike_price: None,
+            },
+            &MarketTier::Basic,
+            &native_token,
+            &0,
+            &0,
+        )
+    }
+
+    #[test]
+    fn unlock_tokens_succeeds_after_cancellation_for_fallback_locked_voter() {
+        let (env, client, admin, contract_id) = setup();
+        let gov_token = setup_gov_token(&env, &contract_id);
+        let market_id = create_market(&env, &client, &admin);
+
+        // Move market to Disputed so cast_vote's fallback lock path is reachable.
+        env.as_contract(&contract_id, || {
+            let mut market = markets::get_market(&env, market_id).unwrap();
+            market.status = MarketStatus::Disputed;
+            market.pending_resolution_timestamp = Some(1001);
+            market.dispute_timestamp = Some(1001);
+            market.dispute_snapshot_ledger = Some(env.ledger().sequence());
+            markets::update_market(&env, market);
+        });
+
+        let voter = Address::generate(&env);
+        token::StellarAssetClient::new(&env, &gov_token).mint(&voter, &500);
+        let token_client = token::Client::new(&env, &gov_token);
+        assert_eq!(token_client.balance(&voter), 500);
+
+        // Fallback path: balance_at is unsupported on the SAC, so cast_vote
+        // locks the caller-supplied weight in the contract.
+        env.as_contract(&contract_id, || {
+            cast_vote(&env, voter.clone(), market_id, 0, 500).unwrap();
+        });
+        assert_eq!(token_client.balance(&voter), 0);
+        assert_eq!(token_client.balance(&contract_id), 500);
+
+        // Community vote cancels the Disputed market — no path back to Resolved.
+        env.as_contract(&contract_id, || {
+            let mut market = markets::get_market(&env, market_id).unwrap();
+            market.status = MarketStatus::Cancelled;
+            markets::update_market(&env, market);
+        });
+
+        // Advance past the lock's unlock_time (market.resolution_deadline == 2000).
+        env.ledger().with_mut(|li| li.timestamp = 2001);
+
+        env.as_contract(&contract_id, || {
+            unlock_tokens(&env, voter.clone(), market_id).unwrap();
+        });
+
+        // Tokens are fully returned and the lock ledger entries are cleared.
+        assert_eq!(token_client.balance(&voter), 500);
+        assert_eq!(token_client.balance(&contract_id), 0);
+        env.as_contract(&contract_id, || {
+            assert!(!env
+                .storage()
+                .persistent()
+                .has(&DataKey::LockedTokens(market_id, voter.clone())));
+            assert!(!env
+                .storage()
+                .persistent()
+                .has(&DataKey::LockedBalance(market_id, voter.clone())));
+        });
+    }
+
+    #[test]
+    fn unlock_tokens_still_rejected_while_market_active() {
+        let (env, client, admin, contract_id) = setup();
+        let market_id = create_market(&env, &client, &admin);
+        let voter = Address::generate(&env);
+
+        let result = env.as_contract(&contract_id, || unlock_tokens(&env, voter, market_id));
+        assert_eq!(result, Err(ErrorCode::MarketNotResolved));
     }
 }

--- a/contracts/predict-iq/src/test.rs
+++ b/contracts/predict-iq/src/test.rs
@@ -2760,6 +2760,42 @@ mod dispute_resolution_tests {
         assert_eq!(result, Err(Ok(crate::errors::ErrorCode::MarketNotFound)));
     }
 
+    /// Issue #1186: Once resolved, the admin override must not be able to
+    /// re-resolve the market with a different outcome — Resolved is terminal.
+    #[test]
+    fn test_resolve_market_rejects_already_resolved_market() {
+        let (env, client, _admin, contract_id) = setup();
+        let market_id = create_market(&env, &client, &contract_id);
+
+        client.resolve_market(&market_id, &1);
+        let result = client.try_resolve_market(&market_id, &0);
+        assert_eq!(
+            result,
+            Err(Ok(crate::errors::ErrorCode::CannotChangeOutcome))
+        );
+
+        // Original outcome must remain unchanged.
+        let market = client.get_market(&market_id).unwrap();
+        assert_eq!(market.status, MarketStatus::Resolved);
+        assert_eq!(market.winning_outcome, Some(1));
+    }
+
+    /// Issue #1186: A Cancelled market must also be terminal for the admin
+    /// resolve override — it must not be resolvable after cancellation.
+    #[test]
+    fn test_resolve_market_rejects_cancelled_market() {
+        let (env, client, _admin, contract_id) = setup();
+        let market_id = create_market(&env, &client, &contract_id);
+
+        seed_market_status(&env, &contract_id, market_id, MarketStatus::Cancelled, None, None);
+
+        let result = client.try_resolve_market(&market_id, &0);
+        assert_eq!(
+            result,
+            Err(Ok(crate::errors::ErrorCode::CannotChangeOutcome))
+        );
+    }
+
     // ── cast_vote weight calculation and tally ────────────────────────────────
 
     fn setup_gov_token(env: &Env, _client: &PredictIQClient, contract_id: &Address) -> Address {


### PR DESCRIPTION

Body:


## Summary

Fixes three related contract-safety issues in `contracts/predict-iq`:

closes #1186  — `disputes::resolve_market` (the admin override, called from `lib.rs::resolve_market`) had no guard against re-resolving an already-`Resolved` or `Cancelled` market. Per `INVARIANTS.md` §3, those states are terminal "at all times"; without the guard, an admin could call this path twice with different outcomes after bettors had already claimed under the first outcome, allowing overpayment against an unchanged `total_staked`/`outcome_stakes`.
closes #1192 — `voting::unlock_tokens` hard-required `MarketStatus::Resolved`, but a `Disputed` market can also terminate via community-voted `cancel_market_vote` → `Cancelled`. Voters who locked governance tokens through `cast_vote`'s fallback path (used when the governance token doesn't support `balance_at`) had no way to recover them if the market was later cancelled instead of resolved.
closes #1195** — `admin::set_fee_admin`/`get_fee_admin` read and wrote `ConfigKey::GuardianAccount` — the same key `set_guardian`/`get_guardian` use — instead of the dedicated `ConfigKey::FeeAdmin` that the real, wired-up flow (`fees::set_fee_admin`/`get_fee_admin`) correctly uses. The functions were dead code with no callers, but calling them would have silently overwritten the guardian address that gates pause/unpause/emergency governance. Removed rather than repointed, since `fees::set_fee_admin` already implements this correctly and is the one exposed via `lib.rs`.
closes #1193
## Changes

- `modules/disputes.rs`: `resolve_market` now rejects with `ErrorCode::CannotChangeOutcome` if `market.status` is `Resolved` or `Cancelled`, matching the identical guard already used in `cancellation::cancel_market_admin` and `resolution::finalize_resolution`.
- `modules/voting.rs`: `unlock_tokens` now accepts `Resolved` **or** `Cancelled` as valid terminal states.
- `modules/admin.rs`: removed the dead, miskeyed `set_fee_admin`/`get_fee_admin` functions.
- `test.rs` / `modules/voting.rs` / `modules/admin.rs`: added regression tests for all three fixes.

## Test plan

- [ ] `cd contracts/predict-iq && cargo test disputes`
- [ ] `cd contracts/predict-iq && cargo test voting`
- [ ] `cd contracts/predict-iq && cargo test admin`
- [ ] `cd contracts/predict-iq && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd contracts/predict-iq && cargo build --release`

**Note:** these commands could not be run to completion in the dev environment used to prepare this PR — `main` currently has ~27 pre-existing compile errors in unrelated production code (e.g. a missing `CANCEL_OUTCOME_INDEX