### PR TITLE
Fix issues surfaced while resolving PR merge conflicts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "next": "16.2.11",
-        "react": "19.2.7",
+        "react": "19.2.8",
         "react-dom": "19.2.8",
         "zod": "4.4.3"
       },
@@ -8821,9 +8821,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "next": "16.2.11",
-    "react": "19.2.7",
+    "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "4.4.3"
   },

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -194,7 +194,7 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
                 }}
                 aria-required="true"
                 aria-invalid={!!emailError}
-                aria-describedby={emailError ? 'email-error' : undefined}
+                aria-describedby={emailError ? 'email-error' : apiError ? 'api-error' : undefined}
                 placeholder={t('hero.emailPlaceholder')}
                 disabled={isSubmitted || isLoading}
               />

--- a/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import LandingPage from '../LandingPage';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 expect.extend(toHaveNoViolations);
 
@@ -147,6 +147,30 @@ describe('LandingPage Accessibility Tests', () => {
       
       expect(emailInput).toHaveAttribute('aria-describedby', 'email-error');
       expect(errorMessage).toHaveAttribute('id', 'email-error');
+    });
+
+    it('should have aria-describedby linking to the API error message', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({ message: 'Invalid email format' }),
+      });
+
+      render(<LandingPage />);
+
+      const emailInput = screen.getByLabelText(/email address/i);
+      const submitButton = screen.getByRole('button', { name: /get early access/i });
+
+      await userEvent.type(emailInput, 'test@example.com');
+      await userEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(emailInput).toHaveAttribute('aria-describedby', 'api-error');
+      });
+
+      const errorMessage = screen.getByRole('alert');
+      expect(errorMessage).toHaveAttribute('id', 'api-error');
     });
 
     it('should have aria-live region for status updates', () => {

--- a/frontend/src/components/__tests__/LandingPage.dataDriven.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.dataDriven.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import LandingPage from '../LandingPage';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 describe('LandingPage data-driven sections', () => {
   beforeEach(() => {

--- a/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LandingPage from '../LandingPage';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 const originalFetch = global.fetch;
 

--- a/frontend/src/components/__tests__/LandingPage.live-region.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.live-region.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LandingPage from '../LandingPage';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 const originalFetch = global.fetch;
 

--- a/frontend/src/components/__tests__/Statistics.test.tsx
+++ b/frontend/src/components/__tests__/Statistics.test.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { Statistics } from '../Statistics';
 import { ErrorBoundary } from '../ErrorBoundary';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 // Mock the API
-jest.mock('../../lib/api/client', () => ({
+jest.mock('../../lib/api/public-client', () => ({
   api: {
     getStatistics: jest.fn(),
   },

--- a/frontend/src/components/__tests__/accessibility.test.tsx
+++ b/frontend/src/components/__tests__/accessibility.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import LandingPage from '../LandingPage';
-import { api } from '../../lib/api/client';
+import { api } from '../../lib/api/public-client';
 
 expect.extend(toHaveNoViolations);
 

--- a/frontend/src/lib/hooks/__tests__/useI18n.test.ts
+++ b/frontend/src/lib/hooks/__tests__/useI18n.test.ts
@@ -7,6 +7,7 @@ describe('useI18n', () => {
     // Reset singleton and storage before each test
     i18n.setLocale('en');
     localStorage.clear();
+    document.documentElement.lang = '';
   });
 
   it('initialises with en locale', async () => {
@@ -14,6 +15,13 @@ describe('useI18n', () => {
 
     await waitFor(() => expect(result.current.locale).toBe('en'));
     expect(i18n.getLocale()).toBe('en');
+  });
+
+  it('sets document.documentElement.lang to the initial locale', async () => {
+    const { result } = renderHook(() => useI18n());
+
+    await waitFor(() => expect(result.current.locale).toBe('en'));
+    expect(document.documentElement.lang).toBe('en');
   });
 
   describe('setLocale with implemented locale (en)', () => {

--- a/frontend/src/lib/hooks/useI18n.ts
+++ b/frontend/src/lib/hooks/useI18n.ts
@@ -12,6 +12,12 @@ export function useI18n() {
     setLocaleState(i18n.getLocale());
   }, []);
 
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = locale;
+    }
+  }, [locale]);
+
   const setLocale = (newLocale: Locale) => {
     const applied = i18n.setLocale(newLocale);
     if (applied) {


### PR DESCRIPTION
Found while resolving conflicts across the frontend PR batch:

- react/react-dom version mismatch (19.2.7 vs 19.2.8) from an earlier dependabot merge in this batch — broke every React test suite.
- Ports #1231's non-superseded pieces (aria-describedby wiring, useI18n lang-sync effect) now that #1241 was chosen over #1231 for the API-client-split design.
- Fixes six test files still mocking `api` via the legacy `lib/api/client.ts` barrel while the components under test (`LandingPage`, `Statistics`) now import from `public-client.ts` post-#1241 — the mocks were silently inert, letting real fetch calls through and breaking test isolation.

All of `src/components/__tests__/` and `src/lib/` (260 tests) pass after this fix.