### PR TITLE
Fix/tts security timing expiry sanitize provider

### DIFF
--- a/services/tts/src/TTSService.ts
+++ b/services/tts/src/TTSService.ts
@@ -484,7 +484,7 @@ export function authenticate(credential: string | undefined, auth: AuthConfig): 
   if (!constantTimeEqual(expected, sigB64)) throw new AuthError("Invalid JWT signature");
 
   const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
-  if (payload.exp !== undefined && payload.exp < Math.floor(Date.now() / 1000)) {
+  if (payload.exp === undefined || payload.exp < Math.floor(Date.now() / 1000)) {
     throw new AuthError("JWT expired");
   }
 

--- a/services/tts/src/TTSService.ts
+++ b/services/tts/src/TTSService.ts
@@ -16,7 +16,7 @@
 
 import fs from "fs/promises";
 import path from "path";
-import { createHash } from "crypto";
+import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { trace, SpanStatusCode, Span } from "@opentelemetry/api";
 import CircuitBreaker from "opossum";
 import type { SharedStoreConfig } from "./SharedStore";
@@ -433,6 +433,22 @@ export class AuthError extends Error {
 }
 
 /**
+ * Constant-time string comparison to prevent timing side-channel attacks
+ * (CWE-208). Both inputs are padded to equal length before comparison so
+ * that `timingSafeEqual` always receives same-length buffers.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  const len = Math.max(bufA.length, bufB.length);
+  const paddedA = Buffer.alloc(len, 0);
+  const paddedB = Buffer.alloc(len, 0);
+  bufA.copy(paddedA);
+  bufB.copy(paddedB);
+  return timingSafeEqual(paddedA, paddedB);
+}
+
+/**
  * Verify `credential` against `auth` and return a stable tenant identity for it:
  * - API key auth: the key itself is the tenant boundary.
  * - JWT auth: the `sub` claim if present, otherwise the raw credential.
@@ -442,7 +458,18 @@ export function authenticate(credential: string | undefined, auth: AuthConfig): 
   if (!credential) throw new AuthError("Missing credential");
 
   if (auth.type === "apikey") {
-    if (!auth.keys.includes(credential)) throw new AuthError("Invalid API key");
+    let keyValid = 0;
+    const credBuf = Buffer.from(credential);
+    for (const key of auth.keys) {
+      const keyBuf = Buffer.from(key);
+      const len = Math.max(credBuf.length, keyBuf.length);
+      const paddedCred = Buffer.alloc(len, 0);
+      const paddedKey = Buffer.alloc(len, 0);
+      credBuf.copy(paddedCred);
+      keyBuf.copy(paddedKey);
+      keyValid |= timingSafeEqual(paddedCred, paddedKey) ? 1 : 0;
+    }
+    if (keyValid === 0) throw new AuthError("Invalid API key");
     return credential;
   }
 
@@ -450,12 +477,11 @@ export function authenticate(credential: string | undefined, auth: AuthConfig): 
   if (parts.length !== 3) throw new AuthError("Malformed JWT");
 
   const [headerB64, payloadB64, sigB64] = parts;
-  const { createHmac } = require("crypto") as typeof import("crypto");
   const expected = createHmac("sha256", auth.secret)
     .update(`${headerB64}.${payloadB64}`)
     .digest("base64url");
 
-  if (expected !== sigB64) throw new AuthError("Invalid JWT signature");
+  if (!constantTimeEqual(expected, sigB64)) throw new AuthError("Invalid JWT signature");
 
   const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
   if (payload.exp !== undefined && payload.exp < Math.floor(Date.now() / 1000)) {

--- a/services/tts/src/__tests__/auth.test.ts
+++ b/services/tts/src/__tests__/auth.test.ts
@@ -23,8 +23,9 @@ function makeJwt(payload: object, secret: string): string {
   return `${header}.${body}.${sig}`;
 }
 
-const VALID_JWT = makeJwt({ sub: "user1" }, JWT_SECRET);
+const VALID_JWT = makeJwt({ sub: "user1", exp: Math.floor(Date.now() / 1000) + 3600 }, JWT_SECRET);
 const EXPIRED_JWT = makeJwt({ sub: "user1", exp: Math.floor(Date.now() / 1000) - 60 }, JWT_SECRET);
+const NO_EXP_JWT = makeJwt({ sub: "user1" }, JWT_SECRET);
 
 // ---------------------------------------------------------------------------
 // authenticate() — API key
@@ -68,6 +69,10 @@ describe("authenticate — jwt", () => {
 
   it("throws AuthError for an expired JWT", () => {
     expect(() => authenticate(EXPIRED_JWT, JWT_CONFIG)).toThrow(AuthError);
+  });
+
+  it("throws AuthError for a JWT without an exp claim", () => {
+    expect(() => authenticate(NO_EXP_JWT, JWT_CONFIG)).toThrow(AuthError);
   });
 
   it("throws AuthError for a malformed token", () => {

--- a/services/tts/src/__tests__/server.test.ts
+++ b/services/tts/src/__tests__/server.test.ts
@@ -8,6 +8,10 @@
 
 import request from "supertest";
 import app from "../server";
+import { TTSProviderError } from "../TTSService";
+import { providerErrorMessage } from "../server";
+
+const GENERIC_PROVIDER_ERROR = "TTS provider request failed";
 
 describe("security headers", () => {
   it("are present on a successful response (GET /tts/voices)", async () => {
@@ -73,5 +77,21 @@ describe("existing TTS functionality is unaffected by the new middleware", () =>
     const res = await request(app).post("/tts/enqueue").send({ text: "hello" });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Missing text or voiceId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue: provider error messages are sanitized (no upstream details leaked)
+// ---------------------------------------------------------------------------
+
+describe("provider error sanitization", () => {
+  it("providerErrorMessage returns a generic message for TTSProviderError", () => {
+    const err = new TTSProviderError("elevenlabs", "Upstream body leaked internal request-id");
+    expect(providerErrorMessage(err)).toBe(GENERIC_PROVIDER_ERROR);
+  });
+
+  it("providerErrorMessage returns the original message for non-provider errors", () => {
+    const err = new Error("Some other error");
+    expect(providerErrorMessage(err)).toBe("Some other error");
   });
 });

--- a/services/tts/src/__tests__/server.test.ts
+++ b/services/tts/src/__tests__/server.test.ts
@@ -95,3 +95,54 @@ describe("provider error sanitization", () => {
     expect(providerErrorMessage(err)).toBe("Some other error");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue: provider value is validated in route handlers
+// ---------------------------------------------------------------------------
+
+describe("provider validation", () => {
+  it("POST /tts/enqueue returns 400 for an unrecognized provider", async () => {
+    const res = await request(app)
+      .post("/tts/enqueue")
+      .send({ text: "hello", voiceId: "el-rachel-en", provider: "azure" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unknown provider/);
+  });
+
+  it("POST /tts/enqueue returns 400 for a misspelled provider", async () => {
+    const res = await request(app)
+      .post("/tts/enqueue")
+      .send({ text: "hello", voiceId: "el-rachel-en", provider: "elevenlabs-pro" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unknown provider/);
+  });
+
+  it("POST /tts/enqueue continues to work with provider omitted", async () => {
+    const res = await request(app)
+      .post("/tts/enqueue")
+      .send({ text: "hello", voiceId: "el-rachel-en" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("pending");
+  });
+
+  it("POST /tts/generate returns 400 for an unrecognized provider", async () => {
+    const res = await request(app)
+      .post("/tts/generate")
+      .send({ text: "hello", voiceId: "el-rachel-en", provider: "unknown" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unknown provider/);
+  });
+
+  it("POST /tts/generate continues to work with provider omitted", async () => {
+    const res = await request(app)
+      .post("/tts/generate")
+      .send({ text: "hello", voiceId: "el-rachel-en" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("outputPath");
+  });
+});

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -235,6 +235,17 @@ export function providerErrorMessage(error: any): string {
   return error.message;
 }
 
+const VALID_PROVIDERS = new Set(["elevenlabs", "google"]);
+
+/** Validate that `provider` is a recognized value; return false and respond 400 if not. */
+function validateProvider(provider: any, res: Response): boolean {
+  if (provider !== undefined && !VALID_PROVIDERS.has(provider)) {
+    res.status(400).json({ error: `Unknown provider: ${provider}` });
+    return false;
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // TTS endpoints
 // ---------------------------------------------------------------------------
@@ -271,11 +282,13 @@ app.post("/tts/enqueue", async (req: Request, res: Response) => {
     }
 
     const voice = VOICES[voiceId];
-    if (!voice) {
-      return res.status(400).json({ error: `Unknown voice: ${voiceId}` });
-    }
+     if (!voice) {
+       return res.status(400).json({ error: `Unknown voice: ${voiceId}` });
+     }
 
-    // enqueueAsync so rate limiting is enforced consistently across
+     if (!validateProvider(provider, res)) return;
+
+     // enqueueAsync so rate limiting is enforced consistently across
     // replicas when REDIS_URL / config.sharedStore is configured (#1133).
     const credential = extractCredential(req);
     const jobId = await service.enqueueAsync(text, voice, provider, credential, rateLimitKey, bypassCache);
@@ -375,11 +388,13 @@ app.post("/tts/generate", async (req: Request, res: Response) => {
     }
 
     const voice = VOICES[voiceId];
-    if (!voice) {
-      return res.status(400).json({ error: `Unknown voice: ${voiceId}` });
-    }
+     if (!voice) {
+       return res.status(400).json({ error: `Unknown voice: ${voiceId}` });
+     }
 
-    const credential = extractCredential(req);
+     if (!validateProvider(provider, res)) return;
+
+     const credential = extractCredential(req);
     const outputPath = await service.generate(
       text,
       voice,

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -18,7 +18,7 @@
 
 import express, { Express, Request, Response, NextFunction } from "express";
 import rateLimit from "express-rate-limit";
-import { TTSService, TTSConfig, VOICES, AuthError } from "./TTSService";
+import { TTSService, TTSConfig, VOICES, AuthError, TTSProviderError } from "./TTSService";
 import {
   HealthChecker,
   createHealthCheckHandler,
@@ -224,6 +224,18 @@ app.get("/health/ready", createReadinessHandler(healthChecker));
 app.get("/health/live", createLivenessHandler(healthChecker));
 
 // ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/** Return a generic message for provider errors to avoid leaking upstream details. */
+export function providerErrorMessage(error: any): string {
+  if (error instanceof TTSProviderError) {
+    return "TTS provider request failed";
+  }
+  return error.message;
+}
+
+// ---------------------------------------------------------------------------
 // TTS endpoints
 // ---------------------------------------------------------------------------
 
@@ -269,13 +281,13 @@ app.post("/tts/enqueue", async (req: Request, res: Response) => {
     const jobId = await service.enqueueAsync(text, voice, provider, credential, rateLimitKey, bypassCache);
     res.json({ jobId, status: "pending" });
   } catch (error: any) {
-    const statusCode = error.statusCode || 500;
-    res.status(statusCode).json({ error: error.message });
-  }
-});
+     const statusCode = error.statusCode || 500;
+     res.status(statusCode).json({ error: providerErrorMessage(error) });
+   }
+ });
 
 /**
- * GET /tts/job/:id
+  * GET /tts/job/:id
  * Get the status and details of a TTS job.
  *
  * Response:
@@ -378,13 +390,13 @@ app.post("/tts/generate", async (req: Request, res: Response) => {
     );
     res.json({ outputPath });
   } catch (error: any) {
-    const statusCode = error.statusCode || 500;
-    res.status(statusCode).json({ error: error.message });
-  }
-});
+     const statusCode = error.statusCode || 500;
+     res.status(statusCode).json({ error: providerErrorMessage(error) });
+   }
+ });
 
 /**
- * GET /tts/voices
+  * GET /tts/voices
  * List available voices.
  *
  * Response:


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [x] CI / tooling change
- [ ] Breaking change

## Testing Done

<!-- Describe how you tested this change. -->

## Bundle Size

<!-- Run `npm run analyze` in the frontend directory and fill in the table below.
     Baseline: vendor ~220 kB, main ~90 kB, _app ~60 kB (all gzip). -->

| Chunk | Before | After |
|---|---|---|
| vendor.js | | |
| main*.js | | |
| pages/_app*.js | | |

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes, or breaking changes are documented above
- [ ] If you **added or changed an API endpoint**, regenerated the OpenAPI spec and committed the result:
  ```bash
  cd services/api && cargo run --bin generate-openapi > openapi.yaml
  git add openapi.yaml && git commit -m "chore: regenerate openapi.yaml"
  ```
- [ ] If you **changed system architecture** (new service, database, external dependency, or network boundary), updated [`docs/architecture.md`](../docs/architecture.md)
- [ ] Bundle size checked (if frontend changes)

## Related Issues

Closes #1140
closes #1141 
closes #1142 
closes #1143 
