### PR TITLE
Fail-closed trust proxy: default TRUST_PROXY=false and test

### DIFF
--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -553,7 +553,7 @@ impl Config {
             trust_proxy: env::var("TRUST_PROXY")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .unwrap_or(true),
+                .unwrap_or(false),
             request_signing_secret: env::var("REQUEST_SIGNING_SECRET").ok(),
             sendgrid_webhook_secret: env::var("SENDGRID_WEBHOOK_SECRET").ok(),
             webhook_replay_window_secs: env::var("WEBHOOK_REPLAY_WINDOW_SECS")

--- a/services/api/tests/security_tests.rs
+++ b/services/api/tests/security_tests.rs
@@ -123,6 +123,24 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
+    fn trust_proxy_defaults_to_false_in_from_env() {
+        // Preserve existing env and restore after the test to avoid flakiness
+        let orig_trust = std::env::var("TRUST_PROXY").ok();
+        let orig_trusted = std::env::var("TRUSTED_PROXY_CIDRS").ok();
+        // Ensure variables are not set to simulate fresh deployment
+        std::env::remove_var("TRUST_PROXY");
+        std::env::remove_var("TRUSTED_PROXY_CIDRS");
+
+        let cfg = predictiq_api::config::Config::from_env();
+        assert_eq!(cfg.trust_proxy, false, "TRUST_PROXY must default to false");
+        assert!(cfg.trusted_proxy_cidrs.is_empty(), "TRUSTED_PROXY_CIDRS must default to empty");
+
+        // Restore original environment
+        if let Some(v) = orig_trust { std::env::set_var("TRUST_PROXY", v); }
+        if let Some(v) = orig_trusted { std::env::set_var("TRUSTED_PROXY_CIDRS", v); }
+    }
+
+    #[test]
     fn trust_proxy_disabled_xff_is_ignored() {
         use axum::extract::ConnectInfo;
         use axum::http::HeaderMap;


### PR DESCRIPTION
Closes #1109

---

Change: default TRUST_PROXY to false so X-Forwarded-For / X-Real-IP are ignored unless TRUSTED_PROXY_CIDRS is explicitly configured.\n\nTest: adds a focused unit test asserting Config::from_env() defaults (TRUST_PROXY == false and TRUSTED_PROXY_CIDRS empty).\n\nFiles changed:\n- services/api/src/config.rs\n- services/api/tests/security_tests.rs\n\nHow to test locally:\n- cd services/api\n- cargo test trust_proxy_defaults_to_false\n\nCloses: #1109