### PR TITLE
Fix/tts audio download timeout api client schema

### DIFF
--- a/frontend/src/lib/api/__tests__/client-schema-path-contract.test.ts
+++ b/frontend/src/lib/api/__tests__/client-schema-path-contract.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Contract test (#3 — API client paths must match the generated OpenAPI schema).
+ *
+ * public-client.ts / admin-client.ts previously hardcoded paths like
+ * `/api/statistics`, `/api/markets/featured`, `/api/content`,
+ * `/api/blockchain/...`, and `/api/markets/{id}/resolve`, while
+ * schema.d.ts — auto-generated from services/api/openapi.yaml, the source
+ * of truth — defines all of these under an `/api/v1/...` prefix. Every one
+ * of those calls 404'd against the real backend.
+ *
+ * This test reads the literal path keys out of the `paths` interface in
+ * schema.d.ts (rather than a mocked api.* function) and asserts that every
+ * request the clients actually make resolves to one of those schema-defined
+ * paths, catching prefix/path drift instead of a runtime 404.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { api as publicApi } from '../public-client';
+import { api as adminApi } from '../admin-client';
+
+function schemaPathKeys(): Set<string> {
+  const schemaSrc = fs.readFileSync(path.join(__dirname, '../schema.d.ts'), 'utf8');
+  const pathsBlock = schemaSrc.match(/export interface paths \{([\s\S]*?)\n\}\n/);
+  if (!pathsBlock) {
+    throw new Error('Could not locate the `paths` interface in schema.d.ts');
+  }
+  const keys = new Set<string>();
+  const keyPattern = /^\s{4}"([^"]+)":\s*\{/gm;
+  let match: RegExpExecArray | null;
+  while ((match = keyPattern.exec(pathsBlock[1]))) {
+    keys.add(match[1]);
+  }
+  return keys;
+}
+
+function fillTemplate(template: string, params: Record<string, string>): string {
+  let filled = template;
+  for (const [name, value] of Object.entries(params)) {
+    filled = filled.replace(`{${name}}`, encodeURIComponent(value));
+  }
+  return filled;
+}
+
+describe('API client paths match schema.d.ts (contract test, #3)', () => {
+  const schemaPaths = schemaPathKeys();
+
+  const mockOk = (data: unknown = {}) =>
+    ((global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(data),
+    }));
+
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  const cases: Array<{
+    name: string;
+    template: string;
+    params: Record<string, string>;
+    call: () => Promise<unknown>;
+  }> = [
+    { name: 'getStatistics', template: '/api/v1/statistics', params: {}, call: () => publicApi.getStatistics() },
+    {
+      name: 'getFeaturedMarkets',
+      template: '/api/v1/markets/featured',
+      params: {},
+      call: () => publicApi.getFeaturedMarkets(),
+    },
+    { name: 'getContent', template: '/api/v1/content', params: {}, call: () => publicApi.getContent() },
+    {
+      name: 'getBlockchainHealth',
+      template: '/api/v1/blockchain/health',
+      params: {},
+      call: () => publicApi.getBlockchainHealth(),
+    },
+    {
+      name: 'getBlockchainMarket',
+      template: '/api/v1/blockchain/markets/{market_id}',
+      params: { market_id: '42' },
+      call: () => publicApi.getBlockchainMarket('42'),
+    },
+    {
+      name: 'getBlockchainStats',
+      template: '/api/v1/blockchain/stats',
+      params: {},
+      call: () => publicApi.getBlockchainStats(),
+    },
+    {
+      name: 'getUserBets',
+      template: '/api/v1/blockchain/users/{user}/bets',
+      params: { user: 'GABC' },
+      call: () => publicApi.getUserBets('GABC'),
+    },
+    {
+      name: 'getOracleResult',
+      template: '/api/v1/blockchain/oracle/{market_id}',
+      params: { market_id: '42' },
+      call: () => publicApi.getOracleResult('42'),
+    },
+    {
+      name: 'getTransactionStatus',
+      template: '/api/v1/blockchain/tx/{tx_hash}',
+      params: { tx_hash: '0xdead' },
+      call: () => publicApi.getTransactionStatus('0xdead'),
+    },
+    {
+      name: 'resolveMarket',
+      template: '/api/v1/markets/{market_id}/resolve',
+      params: { market_id: '42' },
+      call: () => adminApi.resolveMarket('42'),
+    },
+  ];
+
+  it('every path used by the client is declared in schema.d.ts', () => {
+    for (const { template } of cases) {
+      expect(schemaPaths.has(template)).toBe(true);
+    }
+  });
+
+  it.each(cases.map((c) => [c.name, c] as const))(
+    '%s requests exactly the schema-defined path',
+    async (_name, { template, params, call }) => {
+      mockOk();
+      await call();
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      const calledPath = new URL(calledUrl).pathname;
+      expect(calledPath).toBe(fillTemplate(template, params));
+    },
+  );
+});

--- a/frontend/src/lib/api/__tests__/client-schema-type-contract.test.ts
+++ b/frontend/src/lib/api/__tests__/client-schema-type-contract.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Compile-time contract test (#4 — client.ts types must derive from
+ * schema.d.ts, not be hand-duplicated).
+ *
+ * public-client.ts / admin-client.ts claimed to be "generated from the
+ * OpenAPI schema" but never imported anything from schema.d.ts — every
+ * request path and response shape was hand-typed, which is what let the
+ * /api/v1/ prefix drift (see #50) ship undetected: nothing tied the client
+ * to the backend contract.
+ *
+ * Both clients now declare their paths as `... satisfies Record<string,
+ * keyof paths>` and their response generics as `components['schemas'][...]`.
+ * `AssertPath<P>` below only compiles when `P` is a real key of the
+ * generated `paths` interface, so if services/api/openapi.yaml changes and
+ * schema.d.ts is regenerated without one of these paths, the corresponding
+ * line fails `tsc --noEmit` / `next build` — turning what used to be a
+ * silent runtime 404 into a build-time error.
+ *
+ * jest (via next/jest + SWC) strips types at transform time, so this file's
+ * `it()` below only proves the module loads; the actual contract is
+ * enforced by `npx tsc --noEmit --project tsconfig.json` and `npm run
+ * build`, both required by CI and the PR checklist.
+ */
+
+import type { paths, components } from '../schema';
+
+type AssertPath<P extends keyof paths> = P;
+
+// Every path public-client.ts / admin-client.ts calls must resolve here —
+// mirrors the `PATHS` objects in both modules.
+type _Statistics = AssertPath<'/api/v1/statistics'>;
+type _FeaturedMarkets = AssertPath<'/api/v1/markets/featured'>;
+type _Content = AssertPath<'/api/v1/content'>;
+type _BlockchainHealth = AssertPath<'/api/v1/blockchain/health'>;
+type _BlockchainMarket = AssertPath<'/api/v1/blockchain/markets/{market_id}'>;
+type _BlockchainStats = AssertPath<'/api/v1/blockchain/stats'>;
+type _UserBets = AssertPath<'/api/v1/blockchain/users/{user}/bets'>;
+type _OracleResult = AssertPath<'/api/v1/blockchain/oracle/{market_id}'>;
+type _TransactionStatus = AssertPath<'/api/v1/blockchain/tx/{tx_hash}'>;
+type _ResolveMarket = AssertPath<'/api/v1/markets/{market_id}/resolve'>;
+
+// Deliberately-wrong path proving the check has teeth. Uncommenting this
+// line fails `tsc --noEmit` with:
+//   Type '"/api/v1/statistics/bogus"' does not satisfy the constraint 'keyof paths'.
+// (verified manually — left commented so the build stays green)
+// type _Mismatch = AssertPath<'/api/v1/statistics/bogus'>;
+
+// Response shapes the clients request must also come from schema.d.ts,
+// not be hand-duplicated inline object literals.
+type _StatisticsShape = components['schemas']['AnyObject'];
+type _FeaturedMarketShape = components['schemas']['FeaturedMarketView'];
+type _BlockchainHealthShape = components['schemas']['BlockchainHealth'];
+type _InvalidationResultShape = components['schemas']['InvalidationResult'];
+
+describe('client.ts path/type contract with schema.d.ts (#4)', () => {
+  it('compiles only because every AssertPath<...> above is a real schema.d.ts path', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -28,16 +28,16 @@ describe('API Client', () => {
     const base = 'http://localhost:3001';
 
     it.each([
-      ['getFeaturedMarkets', () => api.getFeaturedMarkets(), 'GET', '/api/markets/featured'],
-      ['getBlockchainStats', () => api.getBlockchainStats(), 'GET', '/api/blockchain/stats'],
-      ['getUserBets', () => api.getUserBets('GABC'), 'GET', '/api/blockchain/users/GABC/bets'],
-      ['getOracleResult', () => api.getOracleResult(7), 'GET', '/api/blockchain/oracle/7'],
-      ['getTransactionStatus', () => api.getTransactionStatus('0xdead'), 'GET', '/api/blockchain/tx/0xdead'],
+      ['getFeaturedMarkets', () => api.getFeaturedMarkets(), 'GET', '/api/v1/markets/featured'],
+      ['getBlockchainStats', () => api.getBlockchainStats(), 'GET', '/api/v1/blockchain/stats'],
+      ['getUserBets', () => api.getUserBets('GABC'), 'GET', '/api/v1/blockchain/users/GABC/bets'],
+      ['getOracleResult', () => api.getOracleResult(7), 'GET', '/api/v1/blockchain/oracle/7'],
+      ['getTransactionStatus', () => api.getTransactionStatus('0xdead'), 'GET', '/api/v1/blockchain/tx/0xdead'],
       ['newsletterConfirm', () => api.newsletterConfirm('tok'), 'GET', '/api/v1/newsletter/confirm'],
       ['newsletterUnsubscribe', () => api.newsletterUnsubscribe('a@b.com'), 'DELETE', '/api/v1/newsletter/unsubscribe'],
       ['newsletterGdprExport', () => api.newsletterGdprExport('a@b.com'), 'POST', '/api/v1/newsletter/gdpr/export'],
       ['newsletterGdprDelete', () => api.newsletterGdprDelete('a@b.com'), 'DELETE', '/api/v1/newsletter/gdpr/delete'],
-      ['resolveMarket', () => api.resolveMarket(3), 'POST', '/api/markets/3/resolve'],
+      ['resolveMarket', () => api.resolveMarket(3), 'POST', '/api/v1/markets/3/resolve'],
       ['emailPreview', () => api.emailPreview('welcome'), 'GET', '/api/v1/email/preview/welcome'],
       ['emailSendTest', () => api.emailSendTest({ recipient: 'a@b.com', template_name: 'welcome' }), 'POST', '/api/v1/email/test'],
       ['getEmailAnalytics', () => api.getEmailAnalytics({ days: 7 }), 'GET', '/api/v1/email/analytics'],
@@ -63,7 +63,7 @@ describe('API Client', () => {
        mockOk();
        await api.getBlockchainMarket('foo/bar');
        expect(global.fetch).toHaveBeenCalledWith(
-         expect.stringContaining('/api/blockchain/markets/foo%2Fbar'),
+         expect.stringContaining('/api/v1/blockchain/markets/foo%2Fbar'),
          expect.any(Object),
        );
      });
@@ -72,7 +72,7 @@ describe('API Client', () => {
        mockOk();
        await api.getUserBets('user/name');
        expect(global.fetch).toHaveBeenCalledWith(
-         expect.stringContaining('/api/blockchain/users/user%2Fname/bets'),
+         expect.stringContaining('/api/v1/blockchain/users/user%2Fname/bets'),
          expect.any(Object),
        );
      });
@@ -710,7 +710,7 @@ describe('API Client', () => {
       mockOk();
       await api.getBlockchainMarket('foo/bar');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/markets/foo%2Fbar`,
+        `${base}/api/v1/blockchain/markets/foo%2Fbar`,
         expect.any(Object),
       );
     });
@@ -719,7 +719,7 @@ describe('API Client', () => {
       mockOk();
       await api.getUserBets('GA/BC');
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/blockchain/users/GA%2FBC/bets'),
+        expect.stringContaining('/api/v1/blockchain/users/GA%2FBC/bets'),
         expect.any(Object),
       );
     });
@@ -728,7 +728,7 @@ describe('API Client', () => {
       mockOk();
       await api.getOracleResult('a/b?c#d');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/oracle/a%2Fb%3Fc%23d`,
+        `${base}/api/v1/blockchain/oracle/a%2Fb%3Fc%23d`,
         expect.any(Object),
       );
     });
@@ -737,7 +737,7 @@ describe('API Client', () => {
       mockOk();
       await api.getTransactionStatus('0x/dead');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/tx/0x%2Fdead`,
+        `${base}/api/v1/blockchain/tx/0x%2Fdead`,
         expect.any(Object),
       );
     });
@@ -746,7 +746,7 @@ describe('API Client', () => {
       mockOk();
       await api.resolveMarket('10/20');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/markets/10%2F20/resolve`,
+        `${base}/api/v1/markets/10%2F20/resolve`,
         expect.any(Object),
       );
     });
@@ -764,7 +764,7 @@ describe('API Client', () => {
       mockOk();
       await api.getBlockchainMarket(42);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/markets/42`,
+        `${base}/api/v1/blockchain/markets/42`,
         expect.any(Object),
       );
     });
@@ -804,7 +804,7 @@ describe('API Client', () => {
       mockOk();
       await api.getBlockchainMarket('foo/bar');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/markets/foo%2Fbar`,
+        `${base}/api/v1/blockchain/markets/foo%2Fbar`,
         expect.any(Object),
       );
     });
@@ -813,7 +813,7 @@ describe('API Client', () => {
       mockOk();
       await api.getUserBets('GA/BC');
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/blockchain/users/GA%2FBC/bets'),
+        expect.stringContaining('/api/v1/blockchain/users/GA%2FBC/bets'),
         expect.any(Object),
       );
     });
@@ -822,7 +822,7 @@ describe('API Client', () => {
       mockOk();
       await api.getOracleResult('a/b?c#d');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/oracle/a%2Fb%3Fc%23d`,
+        `${base}/api/v1/blockchain/oracle/a%2Fb%3Fc%23d`,
         expect.any(Object),
       );
     });
@@ -831,7 +831,7 @@ describe('API Client', () => {
       mockOk();
       await api.getTransactionStatus('0x/dead');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/tx/0x%2Fdead`,
+        `${base}/api/v1/blockchain/tx/0x%2Fdead`,
         expect.any(Object),
       );
     });
@@ -840,7 +840,7 @@ describe('API Client', () => {
       mockOk();
       await api.resolveMarket('10/20');
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/markets/10%2F20/resolve`,
+        `${base}/api/v1/markets/10%2F20/resolve`,
         expect.any(Object),
       );
     });
@@ -858,7 +858,7 @@ describe('API Client', () => {
       mockOk();
       await api.getBlockchainMarket(42);
       expect(global.fetch).toHaveBeenCalledWith(
-        `${base}/api/blockchain/markets/42`,
+        `${base}/api/v1/blockchain/markets/42`,
         expect.any(Object),
       );
     });

--- a/frontend/src/lib/api/admin-client.ts
+++ b/frontend/src/lib/api/admin-client.ts
@@ -16,14 +16,23 @@ export {
   CacheTag,
 } from './public-client';
 
-import { api as publicApi, CacheTag } from './public-client';
+import { api as publicApi, CacheTag, fillPath } from './public-client';
 import { apiCache, CACHE_TTL } from './cache';
 import { getEnvConfig } from '../env';
+import type { paths, components } from './schema';
 
 const config = getEnvConfig();
 const BASE_URL = config.NEXT_PUBLIC_API_URL.replace(/\/$/, "");
 
 type HttpMethod = "GET" | "POST" | "DELETE";
+
+/**
+ * Admin-only request paths, checked with `satisfies keyof paths` against
+ * schema.d.ts (see the matching comment in public-client.ts, and #50/#51).
+ */
+const PATHS = {
+  resolveMarket: "/api/v1/markets/{market_id}/resolve",
+} satisfies Record<string, keyof paths>;
 
 // ---------------------------------------------------------------------------
 // Internal request helper (mirrors public-client; kept private to this module)
@@ -288,10 +297,11 @@ export const api = {
 
   // Admin / email
   resolveMarket: (marketId: number | string, signal?: AbortSignal) =>
-    request<{ invalidated_keys: number }>("POST", `/api/v1/markets/${encodeURIComponent(marketId)}/resolve`, {
-      cacheTags: [CacheTag.MARKETS, CacheTag.BLOCKCHAIN, CacheTag.STATISTICS],
-      signal,
-    }),
+    request<components['schemas']['InvalidationResult']>(
+      "POST",
+      fillPath(PATHS.resolveMarket, 'market_id', marketId),
+      { cacheTags: [CacheTag.MARKETS, CacheTag.BLOCKCHAIN, CacheTag.STATISTICS], signal },
+    ),
 
   emailPreview: (templateName: string, signal?: AbortSignal) =>
     request<Record<string, unknown>>("GET", `/api/v1/email/preview/${encodeURIComponent(templateName)}`, {

--- a/frontend/src/lib/api/admin-client.ts
+++ b/frontend/src/lib/api/admin-client.ts
@@ -288,7 +288,7 @@ export const api = {
 
   // Admin / email
   resolveMarket: (marketId: number | string, signal?: AbortSignal) =>
-    request<{ invalidated_keys: number }>("POST", `/api/markets/${encodeURIComponent(marketId)}/resolve`, {
+    request<{ invalidated_keys: number }>("POST", `/api/v1/markets/${encodeURIComponent(marketId)}/resolve`, {
       cacheTags: [CacheTag.MARKETS, CacheTag.BLOCKCHAIN, CacheTag.STATISTICS],
       signal,
     }),

--- a/frontend/src/lib/api/public-client.ts
+++ b/frontend/src/lib/api/public-client.ts
@@ -292,7 +292,7 @@ export const api = {
   health: (signal?: AbortSignal) => request<string>("GET", "/health", { signal }),
 
   getStatistics: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/statistics", {
+    request<Record<string, unknown>>("GET", "/api/v1/statistics", {
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.STATISTICS],
       signal,
@@ -308,39 +308,39 @@ export const api = {
         onchain_volume: string;
         resolved_outcome?: number | null;
       }>
-    >("GET", "/api/markets/featured", {
+    >("GET", "/api/v1/markets/featured", {
       cacheTtl: CACHE_TTL.SHORT,
       cacheTags: [CacheTag.MARKETS],
       signal,
     }),
 
   getContent: (params?: { page?: number; page_size?: number }, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/content", { params, cacheTtl: CACHE_TTL.MEDIUM, signal }),
+    request<Record<string, unknown>>("GET", "/api/v1/content", { params, cacheTtl: CACHE_TTL.MEDIUM, signal }),
 
   // Blockchain (read-only)
   getBlockchainHealth: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/blockchain/health", {
+    request<Record<string, unknown>>("GET", "/api/v1/blockchain/health", {
       cacheTtl: CACHE_TTL.SHORT,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,
     }),
 
   getBlockchainMarket: (marketId: number | string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/blockchain/markets/${encodeURIComponent(marketId)}`, {
+    request<Record<string, unknown>>("GET", `/api/v1/blockchain/markets/${encodeURIComponent(marketId)}`, {
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.BLOCKCHAIN, CacheTag.MARKETS],
       signal,
     }),
 
   getBlockchainStats: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/blockchain/stats", {
+    request<Record<string, unknown>>("GET", "/api/v1/blockchain/stats", {
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,
     }),
 
   getUserBets: (user: string, params?: { page?: number; page_size?: number }, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/blockchain/users/${encodeURIComponent(user)}/bets`, {
+    request<Record<string, unknown>>("GET", `/api/v1/blockchain/users/${encodeURIComponent(user)}/bets`, {
       params,
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.BLOCKCHAIN],
@@ -348,14 +348,14 @@ export const api = {
     }),
 
   getOracleResult: (marketId: number | string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/blockchain/oracle/${encodeURIComponent(marketId)}`, {
+    request<Record<string, unknown>>("GET", `/api/v1/blockchain/oracle/${encodeURIComponent(marketId)}`, {
       cacheTtl: CACHE_TTL.LONG,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,
     }),
 
   getTransactionStatus: (txHash: string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/blockchain/tx/${encodeURIComponent(txHash)}`, {
+    request<Record<string, unknown>>("GET", `/api/v1/blockchain/tx/${encodeURIComponent(txHash)}`, {
       cacheTtl: CACHE_TTL.LONG,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,

--- a/frontend/src/lib/api/public-client.ts
+++ b/frontend/src/lib/api/public-client.ts
@@ -14,11 +14,36 @@
 
 import { getEnvConfig } from '../env';
 import { apiCache, CACHE_TTL } from './cache';
+import type { paths, components } from './schema';
 
 const config = getEnvConfig();
 const BASE_URL = config.NEXT_PUBLIC_API_URL.replace(/\/$/, "");
 
 type HttpMethod = "GET" | "POST" | "DELETE";
+
+/**
+ * Request paths, keyed by client method name. Each value is checked with
+ * `satisfies keyof paths` against schema.d.ts (auto-generated from
+ * services/api/openapi.yaml) so that renaming or removing a path on the
+ * backend fails this file's type check instead of shipping a silent 404
+ * (see #50, #51).
+ */
+const PATHS = {
+  statistics: "/api/v1/statistics",
+  featuredMarkets: "/api/v1/markets/featured",
+  content: "/api/v1/content",
+  blockchainHealth: "/api/v1/blockchain/health",
+  blockchainMarket: "/api/v1/blockchain/markets/{market_id}",
+  blockchainStats: "/api/v1/blockchain/stats",
+  userBets: "/api/v1/blockchain/users/{user}/bets",
+  oracleResult: "/api/v1/blockchain/oracle/{market_id}",
+  transactionStatus: "/api/v1/blockchain/tx/{tx_hash}",
+} satisfies Record<string, keyof paths>;
+
+/** Fills a `{placeholder}` segment of a schema path template with an encoded value. */
+export function fillPath(template: string, placeholder: string, value: string | number): string {
+  return template.replace(`{${placeholder}}`, encodeURIComponent(value));
+}
 
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
   maxRetries: 3,
@@ -292,55 +317,46 @@ export const api = {
   health: (signal?: AbortSignal) => request<string>("GET", "/health", { signal }),
 
   getStatistics: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/v1/statistics", {
+    request<components['schemas']['AnyObject']>("GET", PATHS.statistics, {
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.STATISTICS],
       signal,
     }),
 
   getFeaturedMarkets: (signal?: AbortSignal) =>
-    request<
-      Array<{
-        id: number;
-        title: string;
-        volume: number;
-        ends_at: string;
-        onchain_volume: string;
-        resolved_outcome?: number | null;
-      }>
-    >("GET", "/api/v1/markets/featured", {
+    request<components['schemas']['FeaturedMarketView'][]>("GET", PATHS.featuredMarkets, {
       cacheTtl: CACHE_TTL.SHORT,
       cacheTags: [CacheTag.MARKETS],
       signal,
     }),
 
   getContent: (params?: { page?: number; page_size?: number }, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/v1/content", { params, cacheTtl: CACHE_TTL.MEDIUM, signal }),
+    request<components['schemas']['AnyObject']>("GET", PATHS.content, { params, cacheTtl: CACHE_TTL.MEDIUM, signal }),
 
   // Blockchain (read-only)
   getBlockchainHealth: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/v1/blockchain/health", {
+    request<components['schemas']['BlockchainHealth']>("GET", PATHS.blockchainHealth, {
       cacheTtl: CACHE_TTL.SHORT,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,
     }),
 
   getBlockchainMarket: (marketId: number | string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/v1/blockchain/markets/${encodeURIComponent(marketId)}`, {
-      cacheTtl: CACHE_TTL.MEDIUM,
-      cacheTags: [CacheTag.BLOCKCHAIN, CacheTag.MARKETS],
-      signal,
-    }),
+    request<components['schemas']['AnyObject']>(
+      "GET",
+      fillPath(PATHS.blockchainMarket, 'market_id', marketId),
+      { cacheTtl: CACHE_TTL.MEDIUM, cacheTags: [CacheTag.BLOCKCHAIN, CacheTag.MARKETS], signal },
+    ),
 
   getBlockchainStats: (signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", "/api/v1/blockchain/stats", {
+    request<components['schemas']['AnyObject']>("GET", PATHS.blockchainStats, {
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,
     }),
 
   getUserBets: (user: string, params?: { page?: number; page_size?: number }, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/v1/blockchain/users/${encodeURIComponent(user)}/bets`, {
+    request<components['schemas']['AnyObject']>("GET", fillPath(PATHS.userBets, 'user', user), {
       params,
       cacheTtl: CACHE_TTL.MEDIUM,
       cacheTags: [CacheTag.BLOCKCHAIN],
@@ -348,14 +364,14 @@ export const api = {
     }),
 
   getOracleResult: (marketId: number | string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/v1/blockchain/oracle/${encodeURIComponent(marketId)}`, {
-      cacheTtl: CACHE_TTL.LONG,
-      cacheTags: [CacheTag.BLOCKCHAIN],
-      signal,
-    }),
+    request<components['schemas']['AnyObject']>(
+      "GET",
+      fillPath(PATHS.oracleResult, 'market_id', marketId),
+      { cacheTtl: CACHE_TTL.LONG, cacheTags: [CacheTag.BLOCKCHAIN], signal },
+    ),
 
   getTransactionStatus: (txHash: string, signal?: AbortSignal) =>
-    request<Record<string, unknown>>("GET", `/api/v1/blockchain/tx/${encodeURIComponent(txHash)}`, {
+    request<components['schemas']['AnyObject']>("GET", fillPath(PATHS.transactionStatus, 'tx_hash', txHash), {
       cacheTtl: CACHE_TTL.LONG,
       cacheTags: [CacheTag.BLOCKCHAIN],
       signal,

--- a/services/tts/src/TTSService.ts
+++ b/services/tts/src/TTSService.ts
@@ -283,6 +283,26 @@ function isRetryable(err: unknown): boolean {
   return true;
 }
 
+/**
+ * Derives the synchronous `generate()` wait timeout from the configured
+ * retry budget (issue #1136): worst case a job burns through
+ * `retry.maxRetries + 1` attempts per provider, each up to `retry.maxDelayMs`
+ * of backoff plus `providerTimeoutMs` for the call itself, and — on failure —
+ * falls over to a second provider that gets its own full budget. Without
+ * this, a hardcoded synchronous timeout smaller than the retry budget can
+ * reject the HTTP caller while `_process(job)` keeps running in the
+ * background and eventually completes with no way for the caller to know.
+ */
+export function deriveSyncWaitTimeoutMs(
+  retry: RetryConfig,
+  providerCount: number,
+  providerTimeoutMs: number
+): number {
+  const attemptsPerProvider = retry.maxRetries + 1;
+  const perProviderBudgetMs = attemptsPerProvider * (retry.maxDelayMs + providerTimeoutMs);
+  return perProviderBudgetMs * Math.max(providerCount, 1);
+}
+
 /** Full-jitter exponential backoff: delay ∈ [0, min(maxDelayMs, 1000 * 2^attempt)]. */
 export async function backoffDelay(attempt: number, maxDelayMs: number): Promise<void> {
   const cap = Math.min(maxDelayMs, 1000 * Math.pow(2, attempt));
@@ -389,6 +409,16 @@ export interface TTSConfig {
   circuitBreaker?: CircuitBreakerConfig;
   /** Retry config for transient provider errors — omit to use defaults */
   retry?: RetryConfig;
+  /**
+   * Timeout in milliseconds for the synchronous `generate()` / POST
+   * /tts/generate wait loop (issue #1136). Omit to derive it from `retry`
+   * and `circuitBreaker.timeoutMs` via `deriveSyncWaitTimeoutMs` so it can
+   * never be smaller than the budget background processing is actually
+   * allowed to use — a hardcoded value here that's shorter than that budget
+   * causes the HTTP caller to time out while `_process(job)` keeps running
+   * and eventually completes with no way for the caller to know.
+   */
+  syncWaitTimeoutMs?: number;
   /**
    * Shared, cross-replica backing (e.g. Redis) for job status, rate
    * limiting, and cache (issue #1133). Omit to keep process-local in-memory
@@ -827,6 +857,17 @@ export class TTSService {
   }
 
   /**
+   * Resolves the synchronous wait timeout: an explicit `config.syncWaitTimeoutMs`
+   * wins, otherwise it's derived from the retry budget (see
+   * `deriveSyncWaitTimeoutMs` and the `syncWaitTimeoutMs` doc comment).
+   */
+  private _syncWaitTimeoutMs(): number {
+    if (this.config.syncWaitTimeoutMs !== undefined) return this.config.syncWaitTimeoutMs;
+    const providerCount = (this.config.elevenlabs ? 1 : 0) + (this.config.google ? 1 : 0);
+    return deriveSyncWaitTimeoutMs(this._retryConfig(), providerCount, this.cbConfig.timeoutMs);
+  }
+
+  /**
    * Returns a snapshot of each provider's circuit breaker state.
    * Exposed in /health/ready so operators can see the breaker state
    * without needing to inspect service logs.
@@ -1006,7 +1047,7 @@ export class TTSService {
     bypassCache?: boolean
   ): Promise<string> {
     const id = await this.enqueueAsync(text, voice, provider, credential, rateLimitKey, bypassCache);
-    return this._waitForJob(id);
+    return this._waitForJob(id, 200, this._syncWaitTimeoutMs());
   }
 
   async generateAndMerge(
@@ -1218,7 +1259,7 @@ export class TTSService {
     }
   }
 
-  private _waitForJob(id: string, intervalMs = 200, timeoutMs = 60_000): Promise<string> {
+  private _waitForJob(id: string, intervalMs: number, timeoutMs: number): Promise<string> {
     return new Promise((resolve, reject) => {
       const start = Date.now();
       const tick = setInterval(() => {

--- a/services/tts/src/__tests__/TTSService.test.ts
+++ b/services/tts/src/__tests__/TTSService.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the synchronous `generate()` wait timeout (issue #1136).
+ *
+ * Previously `_waitForJob` hardcoded a 60,000ms timeout, independent of the
+ * configurable retry policy (maxRetries x maxDelayMs per attempt). Under
+ * sustained provider degradation, the synchronous endpoint could reject with
+ * a timeout error while `_process(job)` kept running in the background and
+ * eventually completed, with no way for the original caller to know.
+ *
+ * These tests verify:
+ *  - The wait timeout is derived from the configured retry budget (via
+ *    `deriveSyncWaitTimeoutMs`), not a fixed constant.
+ *  - A job that outlives a short, explicitly configured sync wait timeout is
+ *    still retrievable via `getJobAsync` once it eventually completes.
+ */
+
+import { TTSService, VOICES, deriveSyncWaitTimeoutMs, RetryConfig } from "../TTSService";
+
+const VOICE = VOICES["el-rachel-en"];
+const AUDIO_BYTES = Buffer.from("fake-mp3-bytes");
+
+function audioResponse() {
+  return {
+    ok: true,
+    arrayBuffer: async () =>
+      AUDIO_BYTES.buffer.slice(AUDIO_BYTES.byteOffset, AUDIO_BYTES.byteOffset + AUDIO_BYTES.byteLength),
+  };
+}
+
+/** Simulates a provider that eventually succeeds, but only after `delayMs`. */
+function mockDelayedSuccess(delayMs: number) {
+  (global as any).fetch = jest.fn().mockImplementation(
+    () => new Promise((resolve) => setTimeout(() => resolve(audioResponse()), delayMs))
+  );
+}
+
+describe("TTSService — synchronous wait timeout derived from retry budget (issue #1136)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (global as any).fetch = undefined;
+  });
+
+  describe("deriveSyncWaitTimeoutMs", () => {
+    it("scales with maxRetries, maxDelayMs, provider timeout, and provider count", () => {
+      const retry: RetryConfig = { maxRetries: 2, maxDelayMs: 5_000 };
+      // attemptsPerProvider = maxRetries + 1 = 3
+      // perProviderBudgetMs = 3 * (5000 + 1000) = 18000
+      // 1 provider -> 18000, 2 providers -> 36000
+      expect(deriveSyncWaitTimeoutMs(retry, 1, 1_000)).toBe(18_000);
+      expect(deriveSyncWaitTimeoutMs(retry, 2, 1_000)).toBe(36_000);
+    });
+
+    it("is not hardcoded to 60,000ms — a small retry budget yields a small timeout", () => {
+      const retry: RetryConfig = { maxRetries: 0, maxDelayMs: 100 };
+      expect(deriveSyncWaitTimeoutMs(retry, 1, 50)).toBeLessThan(60_000);
+    });
+  });
+
+  it("derives the service's synchronous wait timeout from the configured retry budget by default", () => {
+    const svc = new TTSService({
+      provider: "elevenlabs",
+      elevenlabs: { apiKey: "test-key" },
+      outputDir: "/tmp/tts-timeout-test",
+      retry: { maxRetries: 1, maxDelayMs: 5_000 },
+      circuitBreaker: { timeoutMs: 2_000 },
+    });
+
+    // 1 provider, attemptsPerProvider = 2, perProviderBudgetMs = 2 * (5000 + 2000) = 14000
+    expect((svc as any)._syncWaitTimeoutMs()).toBe(14_000);
+  });
+
+  it("honors an explicit syncWaitTimeoutMs override instead of deriving one", () => {
+    const svc = new TTSService({
+      provider: "elevenlabs",
+      elevenlabs: { apiKey: "test-key" },
+      outputDir: "/tmp/tts-timeout-test",
+      retry: { maxRetries: 5, maxDelayMs: 60_000 },
+      syncWaitTimeoutMs: 250,
+    });
+
+    expect((svc as any)._syncWaitTimeoutMs()).toBe(250);
+  });
+
+  it("keeps a job queryable via getJobAsync after the synchronous caller times out", async () => {
+    // The provider takes 400ms to respond (simulating sustained degradation),
+    // but the synchronous wait is configured far shorter than that — and far
+    // shorter than the long retry budget background processing is allowed to
+    // use. The HTTP caller should see a timeout, but the job must keep
+    // processing and remain retrievable once it finishes.
+    mockDelayedSuccess(400);
+
+    const svc = new TTSService({
+      provider: "elevenlabs",
+      elevenlabs: { apiKey: "test-key" },
+      outputDir: "/tmp/tts-timeout-test",
+      retry: { maxRetries: 3, maxDelayMs: 60_000 }, // long configured retry budget
+      syncWaitTimeoutMs: 100, // independently short synchronous wait
+    });
+
+    let timeoutMessage = "";
+    try {
+      await svc.generate("hello world", VOICE, "elevenlabs");
+      throw new Error("expected generate() to time out");
+    } catch (err) {
+      timeoutMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    const match = timeoutMessage.match(/^Job (.+) timed out after 100ms$/);
+    expect(match).not.toBeNull();
+    const jobId = match![1];
+
+    // The synchronous caller already gave up, but background processing is
+    // still running — poll until it completes, then confirm it's queryable.
+    const start = Date.now();
+    let job = await svc.getJobAsync(jobId);
+    while (job && job.status !== "done" && job.status !== "error" && Date.now() - start < 5_000) {
+      await new Promise((r) => setTimeout(r, 25));
+      job = await svc.getJobAsync(jobId);
+    }
+
+    expect(job).toBeDefined();
+    expect(job!.status).toBe("done");
+    expect(job!.outputPath).toBeTruthy();
+  });
+});

--- a/services/tts/src/__tests__/server-audio-download.test.ts
+++ b/services/tts/src/__tests__/server-audio-download.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for GET /tts/job/:id/audio (issue #1130).
+ *
+ * Job responses return `outputPath`, a filesystem path local to the
+ * container, but until now there was no HTTP route to actually retrieve the
+ * synthesized audio. These tests exercise the new download endpoint end to
+ * end: enqueue → wait for completion → download.
+ */
+
+process.env.ELEVENLABS_API_KEY = "test-audio-download-key";
+process.env.TTS_OUTPUT_DIR = "/tmp/tts-audio-download-test";
+delete process.env.TTS_API_KEY;
+
+import request from "supertest";
+import app from "../server";
+
+const AUDIO_BYTES = Buffer.from("fake-mp3-bytes");
+
+function mockSuccessfulSynthesis() {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: async () => AUDIO_BYTES.buffer.slice(
+      AUDIO_BYTES.byteOffset,
+      AUDIO_BYTES.byteOffset + AUDIO_BYTES.byteLength
+    ),
+  });
+}
+
+async function waitForJobDone(jobId: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    const res = await request(app).get(`/tts/job/${jobId}`);
+    if (res.body.status === "done" || res.body.status === "error") return;
+    if (Date.now() - start > timeoutMs) throw new Error("Job did not complete in time");
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe("GET /tts/job/:id/audio", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("streams the generated audio for a completed job", async () => {
+    mockSuccessfulSynthesis();
+
+    const enqueueRes = await request(app)
+      .post("/tts/enqueue")
+      .send({ text: "hello world", voiceId: "el-rachel-en" });
+    expect(enqueueRes.status).toBe(200);
+    const jobId = enqueueRes.body.jobId as string;
+
+    await waitForJobDone(jobId);
+
+    const jobRes = await request(app).get(`/tts/job/${jobId}`);
+    expect(jobRes.body.status).toBe("done");
+
+    const audioRes = await request(app).get(`/tts/job/${jobId}/audio`);
+    expect(audioRes.status).toBe(200);
+    expect(audioRes.headers["content-type"]).toMatch(/audio\/mpeg/);
+    expect(Buffer.compare(audioRes.body as Buffer, AUDIO_BYTES)).toBe(0);
+  });
+
+  it("returns 404 for a non-existent job", async () => {
+    const res = await request(app).get("/tts/job/does-not-exist/audio");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when the job has not finished processing", async () => {
+    // Never resolves — job stays "processing" for the duration of this test.
+    (global as any).fetch = jest.fn().mockImplementation(() => new Promise(() => {}));
+
+    const enqueueRes = await request(app)
+      .post("/tts/enqueue")
+      .send({ text: "still working", voiceId: "el-rachel-en" });
+    const jobId = enqueueRes.body.jobId as string;
+
+    const audioRes = await request(app).get(`/tts/job/${jobId}/audio`);
+    expect(audioRes.status).toBe(409);
+  });
+});
+
+describe("GET /tts/job/:id/audio ownership enforcement", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("enforces the same per-owner scoping as GET /tts/job/:id", async () => {
+    // Re-import server with API-key auth configured so two distinct
+    // credentials produce two distinct owners.
+    jest.resetModules();
+    process.env.TTS_API_KEY = "key-a,key-b";
+    process.env.ELEVENLABS_API_KEY = "test-audio-download-key";
+    mockSuccessfulSynthesis();
+
+    const authedApp = (await import("../server")).default;
+
+    const enqueueRes = await request(authedApp)
+      .post("/tts/enqueue")
+      .set("Authorization", "Bearer key-a")
+      .send({ text: "owner scoped", voiceId: "el-rachel-en" });
+    expect(enqueueRes.status).toBe(200);
+    const jobId = enqueueRes.body.jobId as string;
+
+    // Poll as the owning credential until done.
+    const start = Date.now();
+    for (;;) {
+      const jobRes = await request(authedApp)
+        .get(`/tts/job/${jobId}`)
+        .set("Authorization", "Bearer key-a");
+      if (jobRes.body.status === "done" || jobRes.body.status === "error") break;
+      if (Date.now() - start > 5000) throw new Error("Job did not complete in time");
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // A different credential must not be able to download this job's audio.
+    const otherRes = await request(authedApp)
+      .get(`/tts/job/${jobId}/audio`)
+      .set("Authorization", "Bearer key-b");
+    expect(otherRes.status).toBe(404);
+
+    // The owning credential can.
+    const ownerRes = await request(authedApp)
+      .get(`/tts/job/${jobId}/audio`)
+      .set("Authorization", "Bearer key-a");
+    expect(ownerRes.status).toBe(200);
+
+    delete process.env.TTS_API_KEY;
+  });
+});

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -12,10 +12,12 @@
  * TTS endpoints:
  * - POST /tts/enqueue — Enqueue a TTS job
  * - GET /tts/job/:id — Get job status
+ * - GET /tts/job/:id/audio — Download the generated audio for a completed job
  * - GET /tts/jobs — List all jobs
  * - POST /tts/generate — Synchronous generation
  */
 
+import { createReadStream } from "fs";
 import express, { Express, Request, Response, NextFunction } from "express";
 import rateLimit from "express-rate-limit";
 import { TTSService, TTSConfig, VOICES, AuthError } from "./TTSService";
@@ -301,6 +303,55 @@ app.get("/tts/job/:id", async (req: Request, res: Response) => {
       return res.status(404).json({ error: "Job not found" });
     }
     res.json(job);
+  } catch (error: any) {
+    const statusCode = error.statusCode || 500;
+    res.status(statusCode).json({ error: error.message });
+  }
+});
+
+/**
+ * GET /tts/job/:id/audio
+ * Download the generated audio for a completed job (issue #1130).
+ *
+ * The job endpoint above returns `outputPath`, a filesystem path local to
+ * this container — there was previously no way for an external caller to
+ * actually retrieve that file over HTTP. Enforces the same ownership check
+ * as GET /tts/job/:id: a credential can only download audio for jobs it
+ * created.
+ *
+ * Headers:
+ * - Authorization: Bearer <api-key> (required if auth configured)
+ *
+ * Response: audio/mpeg stream (200), or JSON error (404 not found /
+ * not owned by caller, 409 job not yet complete).
+ */
+app.get("/tts/job/:id/audio", async (req: Request, res: Response) => {
+  try {
+    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const credential = extractCredential(req);
+    const job = await service.getJobAsync(id, credential);
+    if (!job) {
+      // Same response whether the job doesn't exist or belongs to another
+      // tenant, matching GET /tts/job/:id's ownership check.
+      return res.status(404).json({ error: "Job not found" });
+    }
+    if (job.status !== "done" || !job.outputPath) {
+      return res.status(409).json({ error: `Job is not complete (status: ${job.status})` });
+    }
+
+    res.setHeader("Content-Type", "audio/mpeg");
+    res.setHeader("Content-Disposition", `attachment; filename="${id}.mp3"`);
+
+    const stream = createReadStream(job.outputPath);
+    stream.on("error", (err) => {
+      console.error(`[server] Failed to stream audio for job ${id}: ${err.message}`);
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Failed to read audio file" });
+      } else {
+        res.destroy();
+      }
+    });
+    stream.pipe(res);
   } catch (error: any) {
     const statusCode = error.statusCode || 500;
     res.status(statusCode).json({ error: error.message });

--- a/services/tts/src/tracing.ts
+++ b/services/tts/src/tracing.ts
@@ -4,7 +4,7 @@
 
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 
@@ -18,14 +18,14 @@ export function initTracing() {
   });
 
   const sdk = new NodeSDK({
-    resource: new Resource({
+    resource: resourceFromAttributes({
       [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
       [SemanticResourceAttributes.SERVICE_VERSION]: "1.0.0",
     }),
     traceExporter,
     instrumentations: [
       new HttpInstrumentation({
-        ignoreIncomingPaths: ["/health"],
+        ignoreIncomingRequestHook: (req) => req.url === "/health",
       }),
     ],
   });


### PR DESCRIPTION
Closes #1148 
Closes #1149 
Closes #1150 
Closes #1151 


Summary of what was implemented:

— Added GET /tts/job/:id/audio to stream the synthesized file, with the same per-credential ownership check as GET /tts/job/:id and a 409 while still processing. Also fixed tracing.ts, which was failing tsc for every test importing server.ts due to an OpenTelemetry API change (Resource class → resourceFromAttributes, ignoreIncomingPaths → ignoreIncomingRequestHook) — this was blocking all TTS test runs, unrelated to the issue itself but necessary to unblock verification.
— Added deriveSyncWaitTimeoutMs() so the synchronous generate() wait timeout scales with the configured retry budget instead of a hardcoded 60s, plus a syncWaitTimeoutMs override. Added tests proving a job that outlives a short sync timeout stays retrievable via getJobAsync.
— Fixed public-client.ts/admin-client.ts hardcoded paths (/api/statistics, /api/markets/featured, /api/blockchain/*, /api/markets/{id}/resolve) to the /api/v1/ prefix that schema.d.ts actually defines — this is what was keeping Statistics.tsx stuck on "N/A". Added a contract test that reads real path keys out of schema.d.ts and checks every client call against them.
— Linked public-client.ts/admin-client.ts types to schema.d.ts via satisfies Record<string, keyof paths> path constants and components['schemas'][...] response types, so a future path/shape drift fails the TypeScript build instead of shipping silently.
