### PR TITLE
Fix/statistics csp newsletter security hardening

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -16,20 +16,24 @@ global.IntersectionObserver = class IntersectionObserver {
   unobserve() {}
 }
 
-// Mock matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-})
+// Mock matchMedia (only relevant under the default jsdom environment — some
+// test files opt into `@jest-environment node`, e.g. to exercise edge
+// middleware with real Request/Response globals, where `window` doesn't exist)
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}
 
 // Suppress console errors in tests (optional)
 const originalError = console.error

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -72,10 +72,11 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
-          {
-            key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'strict-dynamic'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests",
-          },
+          // Content-Security-Policy is intentionally NOT set here. It is
+          // computed per-request in src/proxy.ts, which needs a fresh nonce
+          // and the runtime API origin for connect-src — values this static
+          // config cannot supply. Defining it in both places would mean two
+          // divergent policies write the same header for the same routes.
         ],
       },
     ];

--- a/frontend/src/__tests__/proxy.test.ts
+++ b/frontend/src/__tests__/proxy.test.ts
@@ -1,68 +1,93 @@
-jest.mock('next/server', () => ({
-  NextResponse: {
-    next: jest.fn(() => ({
-      headers: new Map(),
-    })),
-  },
-  NextRequest: jest.fn(),
-}));
-
+/**
+ * @jest-environment node
+ *
+ * Integration coverage for the CSP actually served to the browser.
+ *
+ * next.config.js's headers() and this proxy used to define two different,
+ * divergent Content-Security-Policy values for the same routes (the static
+ * one in next.config.js even used 'strict-dynamic' with no nonce/hash, which
+ * per spec blocks nearly all script execution). next.config.js no longer
+ * sets CSP at all (see security-headers.test.ts) — proxy.ts is now the only
+ * place that computes it.
+ *
+ * Earlier versions of this file fully mocked `next/server`, so it only
+ * verified the string-building logic in isolation and never exercised what
+ * a real request/response round-trip through `proxy()` actually produces.
+ * These tests use the real NextRequest/NextResponse classes and call the
+ * real `proxy` function — the same function Next's edge runtime invokes for
+ * every matched request — and inspect the header that would actually reach
+ * the browser.
+ */
+import { NextRequest } from 'next/server';
 import { proxy } from '../proxy';
 
-describe('Proxy CSP', () => {
-  const originalCrypto = global.crypto;
+function runProxy(path = '/') {
+  const request = new NextRequest(new URL(path, 'http://localhost:3000'));
+  return { request, response: proxy(request) };
+}
 
-  beforeAll(() => {
-    (global as any).crypto = {
-      randomUUID: jest.fn(() => 'test-nonce-uuid'),
-    };
+describe('proxy Content-Security-Policy', () => {
+  it('serves exactly one Content-Security-Policy header on the real response', () => {
+    const { response } = runProxy('/');
+    expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
   });
 
-  afterAll(() => {
-    (global as any).crypto = originalCrypto;
+  it('uses a per-request nonce plus strict-dynamic, not a bare strict-dynamic with no nonce/hash', () => {
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
+
+    const scriptSrcMatch = csp.match(/script-src\s+([^;]+)/);
+    expect(scriptSrcMatch).toBeTruthy();
+    const scriptSrc = scriptSrcMatch![1];
+
+    expect(scriptSrc).toContain("'strict-dynamic'");
+    expect(scriptSrc).toMatch(/'nonce-[A-Za-z0-9+/=]+'/);
   });
 
-  function makeRequest(headers: Record<string, string> = {}) {
-    return {
-      headers: new Headers(headers),
-    };
-  }
+  it('generates a fresh nonce per request rather than a static/reused value', () => {
+    const nonceOf = (csp: string) => csp.match(/'nonce-([^']+)'/)?.[1];
+
+    const nonceA = nonceOf(runProxy('/').response.headers.get('Content-Security-Policy')!);
+    const nonceB = nonceOf(runProxy('/').response.headers.get('Content-Security-Policy')!);
+
+    expect(nonceA).toBeTruthy();
+    expect(nonceB).toBeTruthy();
+    expect(nonceA).not.toBe(nonceB);
+  });
+
+  it('forwards the same nonce to the request headers so RootLayout can apply it to the inline dark-mode init script', () => {
+    const { response } = runProxy('/');
+
+    const cspNonce = response.headers
+      .get('Content-Security-Policy')!
+      .match(/'nonce-([^']+)'/)?.[1];
+    // NextResponse.next({ request: { headers } }) encodes the overridden
+    // request headers onto the response itself, under this key, so the
+    // downstream request (and RootLayout's headers().get('x-nonce')) sees them.
+    const forwardedNonce = response.headers.get('x-middleware-request-x-nonce');
+
+    expect(forwardedNonce).toBeTruthy();
+    expect(forwardedNonce).toBe(cspNonce);
+  });
+
+  it('still sets the other core directives previously only defined in next.config.js', () => {
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
+
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+  });
 
   it('should not include unsafe-inline in style-src', () => {
-    const headers = new Map<string, string>();
-    const mockNextResponse = {
-      headers: {
-        set: (key: string, value: string) => headers.set(key, value),
-        get: (key: string) => headers.get(key),
-      },
-    };
-
-    jest.requireMock('next/server').NextResponse.next.mockReturnValue(mockNextResponse as any);
-
-    const request = makeRequest();
-    proxy(request as any);
-
-    const csp = headers.get('Content-Security-Policy') ?? '';
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
     const styleSrcMatch = csp.match(/style-src\s+([^;]+)/);
     expect(styleSrcMatch).toBeDefined();
     expect(styleSrcMatch?.[1]).not.toContain('unsafe-inline');
   });
 
   it('should include style-src self in CSP', () => {
-    const headers = new Map<string, string>();
-    const mockNextResponse = {
-      headers: {
-        set: (key: string, value: string) => headers.set(key, value),
-        get: (key: string) => headers.get(key),
-      },
-    };
-
-    jest.requireMock('next/server').NextResponse.next.mockReturnValue(mockNextResponse as any);
-
-    const request = makeRequest();
-    proxy(request as any);
-
-    const csp = headers.get('Content-Security-Policy') ?? '';
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
     expect(csp).toContain("style-src 'self'");
   });
 });

--- a/frontend/src/__tests__/proxy.test.ts
+++ b/frontend/src/__tests__/proxy.test.ts
@@ -91,3 +91,48 @@ describe('proxy Content-Security-Policy', () => {
     expect(csp).toContain("style-src 'self'");
   });
 });
+
+describe('proxy connect-src / img-src allow-list', () => {
+  // jest.config.js defaults NEXT_PUBLIC_API_URL to this for the test env.
+  const apiOrigin = 'http://localhost:3001';
+
+  function directive(csp: string, name: string): string {
+    return csp.match(new RegExp(`${name}\\s+([^;]+)`))?.[1] ?? '';
+  }
+
+  it('restricts connect-src to self and the configured API origin, not a bare https: wildcard', () => {
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
+    const connectSrc = directive(csp, 'connect-src');
+
+    expect(connectSrc).toContain("'self'");
+    expect(connectSrc).toContain(apiOrigin);
+    // A bare `https:` scheme-source would permit fetch()/XHR to *any* HTTPS
+    // origin (e.g. an attacker-controlled exfiltration endpoint), which is
+    // exactly what an explicit allow-list is meant to rule out.
+    expect(connectSrc.split(/\s+/)).not.toContain('https:');
+  });
+
+  it('restricts img-src to self, data:, and the configured API origin, not a bare https: wildcard', () => {
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
+    const imgSrc = directive(csp, 'img-src');
+
+    expect(imgSrc).toContain("'self'");
+    expect(imgSrc).toContain('data:');
+    expect(imgSrc).toContain(apiOrigin);
+    expect(imgSrc.split(/\s+/)).not.toContain('https:');
+  });
+
+  it('would block a fetch to an arbitrary third-party HTTPS origin under this policy', () => {
+    const csp = runProxy('/').response.headers.get('Content-Security-Policy')!;
+    const connectSrc = directive(csp, 'connect-src').split(/\s+/);
+    const thirdParty = 'https://evil.example.com';
+
+    // No source-list entry other than 'self'/apiOrigin would match an
+    // arbitrary third-party origin, so a real browser's CSP enforcement
+    // would block a fetch() to it (manually verifiable in a browser devtools
+    // console against a page served with this header).
+    expect(connectSrc).not.toContain('https:');
+    expect(connectSrc).not.toContain(thirdParty);
+    expect(connectSrc.some((src) => thirdParty.startsWith(src))).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/security-headers.test.ts
+++ b/frontend/src/__tests__/security-headers.test.ts
@@ -36,22 +36,14 @@ describe('Security Headers', () => {
     expect(header.value).toContain('camera=()');
   });
 
-it('should have Content-Security-Policy header configured', () => {
-     const header = headers.find((h: any) => h.key === 'Content-Security-Policy');
-     expect(header).toBeDefined();
-     expect(header.value).toContain("default-src 'self'");
-     expect(header.value).toContain("script-src 'self'");
-     expect(header.value).toContain("style-src 'self'");
-     expect(header.value).toContain("frame-ancestors 'none'");
-   });
-
-   it('should not have unsafe-inline in style-src', () => {
-     const header = headers.find((h: any) => h.key === 'Content-Security-Policy');
-     expect(header).toBeDefined();
-     const styleSrcMatch = header.value.match(/style-src\s+([^;]+)/);
-     expect(styleSrcMatch).toBeDefined();
-     expect(styleSrcMatch[1]).not.toContain('unsafe-inline');
-   });
+  // Content-Security-Policy is deliberately NOT asserted here: it is computed
+  // per-request in src/proxy.ts (nonce + runtime API origin), not by
+  // next.config.js's static headers(). See src/__tests__/proxy.test.ts for
+  // the CSP that actually reaches the browser.
+  it('should not define a static Content-Security-Policy here (owned by proxy.ts)', () => {
+    const header = headers.find((h: any) => h.key === 'Content-Security-Policy');
+    expect(header).toBeUndefined();
+  });
 
   it('should have all required security headers', () => {
     const requiredHeaders = [
@@ -59,7 +51,6 @@ it('should have Content-Security-Policy header configured', () => {
       'X-Frame-Options',
       'Referrer-Policy',
       'Permissions-Policy',
-      'Content-Security-Policy',
     ];
 
     const headerKeys = headers.map((h: any) => h.key);

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -58,12 +58,6 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
-    if (e.key === 'Enter') {
-      e.currentTarget.requestSubmit();
-    }
-  };
-
   const features = [
     { icon: '/icons/decentralized.svg', title: t('features.decentralized.title'), description: t('features.decentralized.description') },
     { icon: '/icons/secure.svg', title: t('features.secure.title'), description: t('features.secure.description') },
@@ -166,9 +160,8 @@ export const LandingPage: React.FC<LandingPageProps> = ({ className }) => {
           </p>
           
           {/* CTA Form */}
-          <form 
+          <form
             onSubmit={handleSubmit}
-            onKeyDown={handleKeyDown}
             aria-labelledby="signup-heading"
             aria-busy={isLoading}
             noValidate

--- a/frontend/src/components/Statistics.css
+++ b/frontend/src/components/Statistics.css
@@ -120,7 +120,7 @@
   height: 2rem;
 }
 
-.stat-skeleton--users {
+.stat-skeleton--active-markets {
   width: 5rem;
   height: 2rem;
 }

--- a/frontend/src/components/Statistics.tsx
+++ b/frontend/src/components/Statistics.tsx
@@ -5,10 +5,12 @@ import { LoadingSpinner } from './LoadingSpinner';
 import { Skeleton } from './Skeleton';
 import './Statistics.css';
 
+// Field names match the backend's Statistics struct (services/api/src/db.rs),
+// which serializes as snake_case like every other typed response in this client.
 interface StatisticsData {
-  totalMarkets?: number;
-  totalVolume?: number;
-  activeUsers?: number;
+  total_markets?: number;
+  total_volume?: number;
+  active_markets?: number;
   [key: string]: unknown;
 }
 
@@ -22,19 +24,19 @@ export const Statistics: React.FC = () => {
   const displayValues = React.useMemo(
     () => ({
       totalMarkets:
-        typeof data?.totalMarkets === 'number'
-          ? data.totalMarkets.toLocaleString()
+        typeof data?.total_markets === 'number'
+          ? data.total_markets.toLocaleString()
           : 'N/A',
       totalVolume:
-        typeof data?.totalVolume === 'number'
-          ? `$${data.totalVolume.toLocaleString()}`
+        typeof data?.total_volume === 'number'
+          ? `$${data.total_volume.toLocaleString()}`
           : '$N/A',
-      activeUsers:
-        typeof data?.activeUsers === 'number'
-          ? data.activeUsers.toLocaleString()
+      activeMarkets:
+        typeof data?.active_markets === 'number'
+          ? data.active_markets.toLocaleString()
           : 'N/A',
     }),
-    [data?.activeUsers, data?.totalMarkets, data?.totalVolume],
+    [data?.active_markets, data?.total_markets, data?.total_volume],
   );
 
   const handleRetry = () => {
@@ -80,12 +82,12 @@ export const Statistics: React.FC = () => {
           )}
         </div>
         <div className="stat-item">
-          <h3>Active Users</h3>
+          <h3>Active Markets</h3>
           {loading ? (
-            <Skeleton className="stat-skeleton stat-skeleton--users" aria-label="Loading active users" />
+            <Skeleton className="stat-skeleton stat-skeleton--active-markets" aria-label="Loading active markets" />
           ) : (
             <p className="stat-value" aria-live="polite">
-              {displayValues.activeUsers}
+              {displayValues.activeMarkets}
             </p>
           )}
         </div>

--- a/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.accessibility.test.tsx
@@ -16,7 +16,7 @@ describe('LandingPage Accessibility Tests', () => {
     // the per-test fetch mock intended for the newsletter form.
     jest
       .spyOn(api, 'getStatistics')
-      .mockResolvedValue({ totalMarkets: 128, totalVolume: 45000, activeUsers: 512 });
+      .mockResolvedValue({ total_markets: 128, total_volume: 45000, active_markets: 512 });
   });
 
   afterEach(() => {

--- a/frontend/src/components/__tests__/LandingPage.dataDriven.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.dataDriven.test.tsx
@@ -7,7 +7,7 @@ describe('LandingPage data-driven sections', () => {
   beforeEach(() => {
     jest
       .spyOn(api, 'getStatistics')
-      .mockResolvedValue({ totalMarkets: 128, totalVolume: 45000, activeUsers: 512 });
+      .mockResolvedValue({ total_markets: 128, total_volume: 45000, active_markets: 512 });
   });
 
   afterEach(() => {

--- a/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.keyboard.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LandingPage from '../LandingPage';
 import { api } from '../../lib/api/public-client';
 
 const originalFetch = global.fetch;
 
-describe('LandingPage handleKeyDown', () => {
+describe('LandingPage Enter-to-submit', () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -14,7 +14,7 @@ describe('LandingPage handleKeyDown', () => {
     });
     jest
       .spyOn(api, 'getStatistics')
-      .mockResolvedValue({ totalMarkets: 1, totalVolume: 1, activeUsers: 1 });
+      .mockResolvedValue({ total_markets: 1, total_volume: 1, active_markets: 1 });
   });
 
   afterEach(() => {
@@ -22,39 +22,33 @@ describe('LandingPage handleKeyDown', () => {
     jest.restoreAllMocks();
   });
 
-  it('submits the form when Enter is pressed on the form with a valid email', async () => {
+  // Regression test for a double-submit bug: an explicit onKeyDown handler
+  // called requestSubmit() on Enter without calling preventDefault(), so in
+  // a real browser the native implicit-submit-on-Enter behavior for a
+  // single-input form fired *as well*, submitting twice. fireEvent.keyDown
+  // does not exercise that native browser behavior (jsdom only triggers
+  // implicit submission from a real keypress sequence), so this uses
+  // userEvent to type into the field and press Enter as a genuine keypress.
+  it('submits the newsletter form exactly once when Enter is pressed in the email field', async () => {
     render(<LandingPage />);
     const emailInput = screen.getByLabelText(/email address/i);
-    await userEvent.type(emailInput, 'test@example.com');
 
-    const form = emailInput.closest('form')!;
-    fireEvent.keyDown(form, { key: 'Enter', code: 'Enter' });
+    await userEvent.type(emailInput, 'test@example.com{Enter}');
 
-    expect(
-      await screen.findByRole('button', { name: /subscribed/i }),
-    ).toBeInTheDocument();
+    await screen.findByRole('button', { name: /subscribed/i });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers validation when Enter is pressed on the form with empty email', () => {
+  it('triggers validation when Enter is pressed with an empty email, without calling the API', async () => {
     render(<LandingPage />);
-    const form = screen.getByLabelText(/email address/i).closest('form')!;
+    const emailInput = screen.getByLabelText(/email address/i);
+    emailInput.focus();
 
-    fireEvent.keyDown(form, { key: 'Enter', code: 'Enter' });
+    await userEvent.keyboard('{Enter}');
 
     expect(screen.getByRole('alert')).toHaveTextContent(/email is required/i);
-  });
-
-  it('does not trigger submission for non-Enter keys', async () => {
-    render(<LandingPage />);
-    const emailInput = screen.getByLabelText(/email address/i);
-    await userEvent.type(emailInput, 'test@example.com');
-
-    const form = emailInput.closest('form')!;
-    fireEvent.keyDown(form, { key: 'a', code: 'KeyA' });
-
-    expect(
-      screen.queryByRole('button', { name: /subscribed/i }),
-    ).not.toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it('keeps keyboard focus on the submit button through loading and success, instead of silently dropping it', async () => {
@@ -75,5 +69,6 @@ describe('LandingPage handleKeyDown', () => {
 
     await screen.findByRole('button', { name: /subscribed/i });
     expect(submitButton).toHaveFocus();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/__tests__/LandingPage.live-region.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.live-region.test.tsx
@@ -15,7 +15,7 @@ describe('LandingPage success-message live-region', () => {
     });
     jest
       .spyOn(api, 'getStatistics')
-      .mockResolvedValue({ totalMarkets: 1, totalVolume: 1, activeUsers: 1 });
+      .mockResolvedValue({ total_markets: 1, total_volume: 1, active_markets: 1 });
   });
 
   afterEach(() => {

--- a/frontend/src/components/__tests__/Statistics.test.tsx
+++ b/frontend/src/components/__tests__/Statistics.test.tsx
@@ -27,10 +27,14 @@ describe('Statistics', () => {
   });
 
   it('displays data when loaded successfully', async () => {
+    // Shape returned by the real /api/v1/statistics backend response
+    // (services/api/src/db.rs Statistics struct — snake_case, with an
+    // extra field the UI doesn't display, to prove unknown fields are ignored).
     const mockData = {
-      totalMarkets: 150,
-      totalVolume: 2500000,
-      activeUsers: 50000,
+      total_markets: 150,
+      total_volume: 2500000,
+      active_markets: 50000,
+      resolved_markets: 12,
     };
     mockApi.getStatistics.mockResolvedValue(mockData);
 
@@ -64,7 +68,7 @@ describe('Statistics', () => {
   it('retries on button click', async () => {
     mockApi.getStatistics
       .mockRejectedValueOnce(new Error('Network error'))
-      .mockResolvedValueOnce({ totalMarkets: 100 });
+      .mockResolvedValueOnce({ total_markets: 100 });
 
     render(<Statistics />);
 
@@ -169,7 +173,7 @@ describe('Statistics wrapped in ErrorBoundary', () => {
     // Normal statistics content should not be present
     expect(screen.queryByText('Total Markets')).not.toBeInTheDocument();
     expect(screen.queryByText('Total Volume')).not.toBeInTheDocument();
-    expect(screen.queryByText('Active Users')).not.toBeInTheDocument();
+    expect(screen.queryByText('Active Markets')).not.toBeInTheDocument();
 
     // Fallback should be visible instead
     expect(screen.getByRole('alert')).toBeInTheDocument();

--- a/frontend/src/components/__tests__/accessibility.test.tsx
+++ b/frontend/src/components/__tests__/accessibility.test.tsx
@@ -12,7 +12,7 @@ describe('Component Accessibility Tests', () => {
     // Keep the Statistics mount fetch deterministic and off the network.
     jest
       .spyOn(api, 'getStatistics')
-      .mockResolvedValue({ totalMarkets: 128, totalVolume: 45000, activeUsers: 512 });
+      .mockResolvedValue({ total_markets: 128, total_volume: 45000, active_markets: 512 });
   });
 
   afterEach(() => {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -13,13 +13,17 @@ function apiOrigin(): string {
 
 export function proxy(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
-  const connectSrc = ["'self'", 'https:', apiOrigin()].filter(Boolean).join(' ');
+  // Explicit allow-list only: 'self' plus the configured API origin. A bare
+  // https: scheme-source would let an injected script fetch()/load images
+  // from *any* HTTPS host, defeating the point of computing apiOrigin() at all.
+  const connectSrc = ["'self'", apiOrigin()].filter(Boolean).join(' ');
+  const imgSrc = ["'self'", 'data:', apiOrigin()].filter(Boolean).join(' ');
 
   const cspHeader = [
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
     "style-src 'self'",
-    "img-src 'self' data: https:",
+    `img-src ${imgSrc}`,
     "font-src 'self' data:",
     `connect-src ${connectSrc}`,
     "frame-ancestors 'none'",

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -25,6 +25,7 @@ export function proxy(request: NextRequest) {
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",
+    "object-src 'none'",
     "upgrade-insecure-requests",
   ].join('; ');
 


### PR DESCRIPTION
Closes #1152 
Closes #1153 
Closes #1154 
Closes #1155

Summary of what was implemented:

— Statistics.tsx expected camelCase (totalMarkets, etc.) but the backend's Statistics struct serializes snake_case (total_markets, total_volume, active_markets) — confirmed by reading services/api/src/db.rs. There's no active_users field at all, so "Active Users" was replaced with "Active Markets" (backed by active_markets), making all three stats real instead of permanent N/A.
— Removed the duplicate, divergent CSP from next.config.js (which used strict-dynamic with no nonce, effectively blocking scripts) so proxy.ts's per-request nonce-based CSP is the sole source of truth. Replaced the old fully-mocked proxy.test.ts with a real integration test that calls the actual proxy() function with real NextRequest/NextResponse objects and inspects the header that's actually served.
— Removed the redundant onKeyDown/requestSubmit() handler in LandingPage.tsx that fired alongside native Enter-to-submit, causing the newsletter subscribe API to be called twice per Enter keypress. Rewrote the keyboard test to use a real userEvent keypress sequence (not fireEvent.keyDown, which doesn't trigger jsdom's native implicit submission) and assert the API is called exactly once.
— Replaced the https: wildcard in connect-src/img-src with an explicit allow-list ('self' + the configured API origin), closing the data-exfiltration gap where any injected script could fetch() to an arbitrary HTTPS host.