### PR TITLE
Fix/tts google client reuse cache bytes errhandler trustproxy

### DIFF
--- a/services/tts/src/TTSService.ts
+++ b/services/tts/src/TTSService.ts
@@ -147,6 +147,14 @@ export interface CacheConfig {
   ttlMs: number;
   /** Max number of entries; oldest evicted when exceeded */
   maxEntries: number;
+  /**
+   * Max total bytes across all cached buffers; oldest entries are evicted
+   * (in addition to entry-count eviction) until the new entry fits. Since
+   * MAX_INPUT_LENGTH allows up to 5000 characters per request, synthesized
+   * buffers can be several MB each — without this, entry-count alone permits
+   * unbounded heap growth. Omit to disable byte-based eviction.
+   */
+  maxBytes?: number;
 }
 
 interface CacheEntry {
@@ -160,11 +168,13 @@ export interface CacheMetrics {
   misses: number;
   evictions: number;
   size: number;
+  /** Total bytes across all currently cached buffers */
+  bytes: number;
 }
 
 export class AudioCache {
   private store = new Map<string, CacheEntry>();
-  private metrics: CacheMetrics = { hits: 0, misses: 0, evictions: 0, size: 0 };
+  private metrics: CacheMetrics = { hits: 0, misses: 0, evictions: 0, size: 0, bytes: 0 };
 
   constructor(private config: CacheConfig) {}
 
@@ -179,6 +189,7 @@ export class AudioCache {
     if (Date.now() - entry.createdAt > this.config.ttlMs) {
       this.store.delete(key);
       this.metrics.size--;
+      this.metrics.bytes -= entry.buffer.length;
       this.metrics.misses++;
       return undefined;
     }
@@ -188,17 +199,33 @@ export class AudioCache {
   }
 
   set(key: string, buffer: Buffer): void {
-    if (this.store.size >= this.config.maxEntries) {
-      // Evict the oldest entry
-      const oldest = this.store.keys().next().value;
-      if (oldest !== undefined) {
-        this.store.delete(oldest);
-        this.metrics.evictions++;
-        this.metrics.size--;
+    const maxBytes = this.config.maxBytes;
+    // A buffer that alone exceeds the byte budget can never be cached without
+    // violating it, no matter what else gets evicted — so don't cache it.
+    if (maxBytes !== undefined && buffer.length > maxBytes) return;
+
+    while (this.store.size >= this.config.maxEntries) {
+      this._evictOldest();
+    }
+    if (maxBytes !== undefined) {
+      while (this.store.size > 0 && this.metrics.bytes + buffer.length > maxBytes) {
+        this._evictOldest();
       }
     }
+
     this.store.set(key, { buffer, createdAt: Date.now(), hits: 0 });
     this.metrics.size++;
+    this.metrics.bytes += buffer.length;
+  }
+
+  private _evictOldest(): void {
+    const oldest = this.store.keys().next().value;
+    if (oldest === undefined) return;
+    const entry = this.store.get(oldest)!;
+    this.store.delete(oldest);
+    this.metrics.evictions++;
+    this.metrics.size--;
+    this.metrics.bytes -= entry.buffer.length;
   }
 
   getMetrics(): Readonly<CacheMetrics> {

--- a/services/tts/src/TTSService.ts
+++ b/services/tts/src/TTSService.ts
@@ -637,6 +637,35 @@ async function generateElevenLabs(
   });
 }
 
+interface GoogleTTSClient {
+  synthesizeSpeech: (
+    req: object,
+    options?: object
+  ) => Promise<[{ audioContent: Buffer | string }]>;
+}
+
+/**
+ * One TextToSpeechClient per distinct `google` config object, lazily created
+ * and cached for the lifetime of that config. Constructing the client sets up
+ * its credentials/auth (a gRPC channel, token fetch, etc.), so re-creating it
+ * on every synthesis call adds that setup cost to every request instead of
+ * once per process.
+ */
+const googleClientCache = new WeakMap<object, GoogleTTSClient>();
+
+function getGoogleClient(config: NonNullable<TTSConfig["google"]>): GoogleTTSClient {
+  let client = googleClientCache.get(config);
+  if (!client) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { TextToSpeechClient } = require("@google-cloud/text-to-speech") as {
+      TextToSpeechClient: new (opts: object) => GoogleTTSClient;
+    };
+    client = new TextToSpeechClient(config);
+    googleClientCache.set(config, client);
+  }
+  return client;
+}
+
 async function generateGoogle(
   text: string,
   voice: TTSVoice,
@@ -650,17 +679,7 @@ async function generateGoogle(
       span.setAttribute("tts.voice.id", voice.voiceId);
       span.setAttribute("tts.text.length", text.length);
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { TextToSpeechClient } = require("@google-cloud/text-to-speech") as {
-        TextToSpeechClient: new (opts: object) => {
-          synthesizeSpeech: (
-            req: object,
-            options?: object
-          ) => Promise<[{ audioContent: Buffer | string }]>;
-        };
-      };
-
-      const client = new TextToSpeechClient(config);
+      const client = getGoogleClient(config);
 
       let response: { audioContent: Buffer | string };
       try {

--- a/services/tts/src/__tests__/audio-cache-byte-budget.test.ts
+++ b/services/tts/src/__tests__/audio-cache-byte-budget.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for perf/audio-cache-is-unbounded-by-memory-size-only-by.
+ *
+ * AudioCache.set() previously evicted only when store.size >= maxEntries,
+ * with no cap on total bytes cached. Since MAX_INPUT_LENGTH allows up to
+ * 5000 characters per request, synthesized MP3 buffers can be several MB
+ * each — so the default config could retain gigabytes of audio in process
+ * heap with no memory-based eviction. These tests assert a configurable
+ * `maxBytes` budget bounds total cached bytes and evicts the oldest entries
+ * to make room.
+ */
+
+import { AudioCache } from "../TTSService";
+
+describe("AudioCache — byte budget (perf/audio-cache-is-unbounded-by-memory-size-only-by)", () => {
+  it("tracks total bytes across cached buffers in metrics", () => {
+    const cache = new AudioCache({ ttlMs: 10_000, maxEntries: 10 });
+    cache.set("k1", Buffer.alloc(100));
+    cache.set("k2", Buffer.alloc(250));
+    expect(cache.getMetrics().bytes).toBe(350);
+  });
+
+  it("evicts the oldest entries once the byte budget is exceeded, even with entries well under maxEntries", () => {
+    const oneMb = 1024 * 1024;
+    const cache = new AudioCache({ ttlMs: 10_000, maxEntries: 1000, maxBytes: oneMb * 2 });
+
+    cache.set("k1", Buffer.alloc(oneMb)); // 1MB total
+    cache.set("k2", Buffer.alloc(oneMb)); // 2MB total — at budget
+    expect(cache.get("k1")).toBeDefined();
+
+    cache.set("k3", Buffer.alloc(oneMb)); // pushes to 3MB — must evict k1 to fit
+
+    expect(cache.get("k1")).toBeUndefined(); // evicted to stay within budget
+    expect(cache.get("k2")).toBeDefined();
+    expect(cache.get("k3")).toBeDefined();
+    expect(cache.getMetrics().bytes).toBeLessThanOrEqual(oneMb * 2);
+  });
+
+  it("keeps memory usage bounded when filled with many large buffers", () => {
+    const oneMb = 1024 * 1024;
+    const budget = oneMb * 5;
+    const cache = new AudioCache({ ttlMs: 60_000, maxEntries: 10_000, maxBytes: budget });
+
+    // Fill with far more than the budget would allow if only maxEntries applied.
+    for (let i = 0; i < 20; i++) {
+      cache.set(`k${i}`, Buffer.alloc(oneMb));
+    }
+
+    const metrics = cache.getMetrics();
+    expect(metrics.bytes).toBeLessThanOrEqual(budget);
+    expect(metrics.evictions).toBeGreaterThan(0);
+    // Only the most recent entries (within budget) should remain retrievable.
+    expect(cache.get("k19")).toBeDefined();
+    expect(cache.get("k0")).toBeUndefined();
+  });
+
+  it("does not cache a single buffer that alone exceeds the byte budget", () => {
+    const cache = new AudioCache({ ttlMs: 10_000, maxEntries: 10, maxBytes: 1000 });
+    cache.set("too-big", Buffer.alloc(2000));
+    expect(cache.get("too-big")).toBeUndefined();
+    expect(cache.getMetrics().bytes).toBe(0);
+  });
+
+  it("decrements tracked bytes when an entry expires via TTL", async () => {
+    const cache = new AudioCache({ ttlMs: 20, maxEntries: 10, maxBytes: 10_000 });
+    cache.set("k1", Buffer.alloc(500));
+    expect(cache.getMetrics().bytes).toBe(500);
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(cache.get("k1")).toBeUndefined();
+    expect(cache.getMetrics().bytes).toBe(0);
+  });
+
+  it("is backward compatible: without maxBytes configured, only entry-count eviction applies", () => {
+    const cache = new AudioCache({ ttlMs: 10_000, maxEntries: 2 });
+    cache.set("k1", Buffer.alloc(1024 * 1024 * 10)); // 10MB — no byte budget configured
+    cache.set("k2", Buffer.alloc(1024 * 1024 * 10));
+    cache.set("k3", Buffer.alloc(1024 * 1024 * 10)); // evicts k1 by count only
+
+    expect(cache.get("k1")).toBeUndefined();
+    expect(cache.get("k2")).toBeDefined();
+    expect(cache.get("k3")).toBeDefined();
+  });
+});

--- a/services/tts/src/__tests__/error-handler-status-code.test.ts
+++ b/services/tts/src/__tests__/error-handler-status-code.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for fix/global-error-handler-always-returns-http-500-dis.
+ *
+ * The final Express error-handling middleware used to unconditionally
+ * respond 500, ignoring err.status/err.statusCode entirely — so a malformed
+ * JSON request body (a SyntaxError thrown inside express.json(), uncaught by
+ * any route-level try/catch) was reported to the client as a 500 rather than
+ * a 400.
+ */
+
+import request from "supertest";
+import app, { globalErrorHandler } from "../server";
+import { Response } from "express";
+
+function mockResponse(): Response {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe("globalErrorHandler (unit)", () => {
+  it("defaults to 500 with a generic message when the error carries no statusCode/status", () => {
+    const res = mockResponse();
+    globalErrorHandler(new Error("some internal detail"), {} as any, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
+
+  it("respects err.statusCode when present", () => {
+    const res = mockResponse();
+    const err: any = new Error("missing field foo");
+    err.statusCode = 400;
+    globalErrorHandler(err, {} as any, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "missing field foo" });
+  });
+
+  it("respects err.status when statusCode is absent (e.g. body-parser SyntaxError shape)", () => {
+    const res = mockResponse();
+    const err: any = new SyntaxError("Unexpected token o in JSON at position 1");
+    err.status = 400;
+    globalErrorHandler(err, {} as any, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: err.message });
+  });
+
+  it("keeps a generic message for 5xx even when explicitly set", () => {
+    const res = mockResponse();
+    const err: any = new Error("upstream connection reset");
+    err.statusCode = 503;
+    globalErrorHandler(err, {} as any, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
+});
+
+describe("malformed JSON request body (integration)", () => {
+  it("POST /tts/enqueue with malformed JSON returns 400, not 500", async () => {
+    const res = await request(app)
+      .post("/tts/enqueue")
+      .set("Content-Type", "application/json")
+      .send("{ this is not valid json");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("POST /tts/generate with malformed JSON returns 400, not 500", async () => {
+    const res = await request(app)
+      .post("/tts/generate")
+      .set("Content-Type", "application/json")
+      .send("{ also not valid json");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+});

--- a/services/tts/src/__tests__/google-tts-client-reuse.test.ts
+++ b/services/tts/src/__tests__/google-tts-client-reuse.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for perf/google-tts-client-is-re-instantiated-on-every-sy.
+ *
+ * generateGoogle() used to call `new TextToSpeechClient(config)` inside the
+ * function body, so a brand-new client — including its credential/auth setup
+ * — was constructed for every single TTS request instead of being created
+ * once and reused. These tests assert the client constructor is invoked at
+ * most once per distinct `google` config, regardless of how many synthesis
+ * calls are made against it.
+ */
+
+import path from "path";
+import os from "os";
+import fs from "fs/promises";
+import { TTSService, VOICES } from "../TTSService";
+
+const mockSynthesizeSpeech = jest.fn();
+const mockClientCtor = jest.fn().mockImplementation(() => ({
+  synthesizeSpeech: mockSynthesizeSpeech,
+}));
+
+jest.mock("@google-cloud/text-to-speech", () => ({
+  TextToSpeechClient: mockClientCtor,
+}));
+
+const VOICE = VOICES["gcp-en-us-f"];
+const FAKE_MP3 = Buffer.from([0x49, 0x44, 0x33, 0xff, 0xfb, 0x90, 0x00]);
+
+async function tmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "tts-google-client-reuse-"));
+}
+
+describe("Google TTS client reuse (perf/google-tts-client-is-re-instantiated-on-every-sy)", () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = await tmpDir();
+    mockClientCtor.mockClear();
+    mockSynthesizeSpeech.mockReset();
+    mockSynthesizeSpeech.mockResolvedValue([
+      { audioContent: FAKE_MP3.toString("base64") },
+    ]);
+  });
+
+  it("constructs the TextToSpeechClient at most once across multiple synthesis calls", async () => {
+    const svc = new TTSService({ provider: "google", google: {}, outputDir });
+
+    await svc.generate("first request", VOICE, "google");
+    await svc.generate("second request", VOICE, "google");
+    await svc.generate("third request", VOICE, "google");
+
+    expect(mockSynthesizeSpeech).toHaveBeenCalledTimes(3);
+    expect(mockClientCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the same client instance for cache-bypassed repeat calls", async () => {
+    const svc = new TTSService({ provider: "google", google: {}, outputDir });
+
+    await svc.generate("hello", VOICE, "google", undefined, undefined, true);
+    await svc.generate("hello", VOICE, "google", undefined, undefined, true);
+
+    expect(mockClientCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("constructs a separate client per distinct google config (e.g. different credentials)", async () => {
+    const svcA = new TTSService({
+      provider: "google",
+      google: { keyFilename: "a-credentials.json" },
+      outputDir,
+    });
+    const svcB = new TTSService({
+      provider: "google",
+      google: { keyFilename: "b-credentials.json" },
+      outputDir,
+    });
+
+    await svcA.generate("hello", VOICE, "google");
+    await svcB.generate("hello", VOICE, "google");
+    await svcA.generate("hello again", VOICE, "google");
+
+    expect(mockClientCtor).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/tts/src/__tests__/trust-proxy.test.ts
+++ b/services/tts/src/__tests__/trust-proxy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for fix/no-trust-proxy-configuration-makes-req-ip-based.
+ *
+ * req.ip is used both as the Express-level rate-limit key and as the
+ * rateLimitKey passed into TTSService. Without app.set("trust proxy", ...),
+ * Express derives req.ip from the raw socket address — deployed behind any
+ * reverse proxy/load balancer, every request then appears to originate from
+ * the proxy's address, collapsing all distinct clients into a single
+ * rate-limit bucket. These tests assert TRUST_PROXY is honored so req.ip
+ * reflects X-Forwarded-For under a configured proxy topology.
+ *
+ * Each test re-requires ../server after setting TRUST_PROXY, since the
+ * setting is applied once at module load time via app.set(...).
+ */
+
+describe("trust proxy configuration", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.resetModules();
+  });
+
+  it("defaults to trusting 1 hop, so req.ip reflects X-Forwarded-For behind a single load balancer", async () => {
+    jest.resetModules();
+    delete process.env.TRUST_PROXY;
+
+    const request = require("supertest");
+    const app = require("../server").default;
+    app.get("/__whoami", (req: any, res: any) => res.json({ ip: req.ip }));
+
+    const res = await request(app)
+      .get("/__whoami")
+      .set("X-Forwarded-For", "203.0.113.7");
+
+    expect(res.body.ip).toBe("203.0.113.7");
+  });
+
+  it("ignores X-Forwarded-For when TRUST_PROXY=false (no proxy in front)", async () => {
+    jest.resetModules();
+    process.env.TRUST_PROXY = "false";
+
+    const request = require("supertest");
+    const app = require("../server").default;
+    app.get("/__whoami", (req: any, res: any) => res.json({ ip: req.ip }));
+
+    const res = await request(app)
+      .get("/__whoami")
+      .set("X-Forwarded-For", "203.0.113.7");
+
+    expect(res.body.ip).not.toBe("203.0.113.7");
+  });
+
+  it("distinguishes different clients behind a configured reverse proxy via X-Forwarded-For", async () => {
+    jest.resetModules();
+    process.env.TRUST_PROXY = "1";
+
+    const request = require("supertest");
+    const app = require("../server").default;
+    app.get("/__whoami", (req: any, res: any) => res.json({ ip: req.ip }));
+
+    const resA = await request(app).get("/__whoami").set("X-Forwarded-For", "198.51.100.1");
+    const resB = await request(app).get("/__whoami").set("X-Forwarded-For", "198.51.100.2");
+
+    expect(resA.body.ip).toBe("198.51.100.1");
+    expect(resB.body.ip).toBe("198.51.100.2");
+    expect(resA.body.ip).not.toBe(resB.body.ip);
+  });
+
+  it("honors an explicit numeric hop count greater than 1", async () => {
+    jest.resetModules();
+    process.env.TRUST_PROXY = "2";
+
+    const request = require("supertest");
+    const app = require("../server").default;
+    app.get("/__whoami", (req: any, res: any) => res.json({ ip: req.ip }));
+
+    // Two hops: X-Forwarded-For "client, proxy1" — with trust proxy = 2,
+    // Express counts back 2 hops from the socket peer, landing on "client".
+    const res = await request(app)
+      .get("/__whoami")
+      .set("X-Forwarded-For", "203.0.113.9, 10.0.0.1");
+
+    expect(res.body.ip).toBe("203.0.113.9");
+  });
+});

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -106,6 +106,26 @@ const healthChecker = new HealthChecker(config, service);
 const app: Express = express();
 const port = process.env.PORT || 3000;
 
+// Without an explicit trust proxy setting, Express derives req.ip from the
+// raw socket address. Deployed behind any reverse proxy/load balancer, every
+// request then appears to originate from the proxy's address, collapsing all
+// distinct clients into a single rate-limit bucket (req.ip is used both as
+// the Express-level rate-limit key below and as the TTSService rate-limit
+// key in the route handlers). TRUST_PROXY configures how many hops (or which
+// trusted subnets) sit between the client and this process so Express parses
+// X-Forwarded-For and populates req.ip with the real client address.
+// Defaults to 1 hop — a single load balancer, the common deployment topology
+// — override via the env var to match a different topology (e.g. "false" for
+// a direct/no-proxy deployment, a higher hop count, or a trusted-subnet
+// keyword Express recognizes, such as "loopback").
+const trustProxyEnv = process.env.TRUST_PROXY ?? "1";
+const trustProxySetting: number | boolean | string =
+  trustProxyEnv === "true" ? true
+  : trustProxyEnv === "false" ? false
+  : /^-?\d+$/.test(trustProxyEnv) ? Number(trustProxyEnv)
+  : trustProxyEnv;
+app.set("trust proxy", trustProxySetting);
+
 // Security headers — applied to every response (JSON error bodies included).
 // Mirrors services/api/src/security.rs's security_headers_middleware.
 app.use((req: Request, res: Response, next: NextFunction) => {

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -74,6 +74,10 @@ const config: TTSConfig = {
   cache: {
     ttlMs: parseInt(process.env.TTS_CACHE_TTL_MS || "86400000", 10),
     maxEntries: parseInt(process.env.TTS_CACHE_MAX_ENTRIES || "1000", 10),
+    // Bounds total cached audio bytes, not just entry count — MAX_INPUT_LENGTH
+    // allows several-MB buffers per entry, so maxEntries alone permits
+    // gigabytes of heap growth. Default: 256 MiB.
+    maxBytes: parseInt(process.env.TTS_CACHE_MAX_BYTES || String(256 * 1024 * 1024), 10),
   },
   retry: {
     maxRetries: parseInt(process.env.TTS_MAX_RETRIES || "3", 10),

--- a/services/tts/src/server.ts
+++ b/services/tts/src/server.ts
@@ -483,10 +483,25 @@ app.get("/tts/voices", (req: Request, res: Response) => {
 // Error handling
 // ---------------------------------------------------------------------------
 
-app.use((err: any, req: Request, res: Response, next: any) => {
+/**
+ * Final error-handling middleware. Respects `err.statusCode`/`err.status`
+ * when present — e.g. a SyntaxError thrown inside express.json() on a
+ * malformed JSON body carries `status`/`statusCode` 400 — and defaults to 500
+ * only when neither is set. 5xx keeps a generic message to avoid leaking
+ * internals; 4xx messages describe a client mistake and are safe to surface,
+ * matching how the route-level catch blocks already handle their errors.
+ */
+export function globalErrorHandler(err: any, req: Request, res: Response, next: NextFunction): void {
   console.error("Unhandled error:", err);
-  res.status(500).json({ error: "Internal server error" });
-});
+  const statusCode =
+    typeof err?.statusCode === "number" ? err.statusCode
+    : typeof err?.status === "number" ? err.status
+    : 500;
+  const message = statusCode >= 500 ? "Internal server error" : (err?.message || "Bad request");
+  res.status(statusCode).json({ error: message });
+}
+
+app.use(globalErrorHandler);
 
 // ---------------------------------------------------------------------------
 // Server startup


### PR DESCRIPTION
Closes #1144 
Closes #1145 
Closes #1146 
Closes #1147 

Summary:

1.  Google TTS client reuse (TTSService.ts): generateGoogle() was constructing a new TextToSpeechClient (with its own credential/auth setup) on every request. Added a WeakMap-cached lazy singleton per distinct google config, so the client is built once and reused. Test: google-tts-client-reuse.test.ts (mocks the SDK constructor, asserts it's called once across multiple generate() calls).
2. AudioCache byte budget (TTSService.ts, server.ts): AudioCache only evicted by entry count, allowing unbounded heap growth from multi-MB buffers. Added a maxBytes config option with FIFO eviction until new entries fit, plus a bytes metric; wired a 256 MiB default via TTS_CACHE_MAX_BYTES. Test: audio-cache-byte-budget.test.ts (byte tracking, eviction under budget pressure, oversized-buffer rejection, TTL/backward-compat behavior).
3. Error handler status codes (server.ts): The final error middleware always returned 500, ignoring err.statusCode/err.status (so malformed JSON bodies returned 500 instead of 400). Exported globalErrorHandler, which now respects those fields and only defaults to 500 when absent. Test: error-handler-status-code.test.ts (unit tests on the handler + integration test posting malformed JSON).
4. Trust proxy configuration (server.ts): No trust proxy setting meant req.ip (used for rate-limit keys) collapsed to the proxy's address behind any load balancer. Added a TRUST_PROXY env var (default: 1 hop) supporting numeric hop counts, booleans, or Express's subnet keywords. Test: trust-proxy.test.ts (default hop behavior, disabled case, multi-client differentiation, 2-hop chains).